### PR TITLE
Extremely slow db migrate

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,8 @@ gem "rails", "~> 7.1.1"
 gem "sprockets-rails"
 
 # Use sqlite3 as the database for Active Record
-gem "sqlite3", "~> 1.4"
+# gem "sqlite3", "~> 1.4"
+gem "mysql2"
 
 # Use the Puma web server [https://github.com/puma/puma]
 gem "puma", ">= 5.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -132,6 +132,7 @@ GEM
     minitest (5.20.0)
     msgpack (1.7.2)
     mutex_m (0.1.2)
+    mysql2 (0.5.5)
     net-imap (0.4.3)
       date
       net-protocol
@@ -217,9 +218,6 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
-    sqlite3 (1.6.8-aarch64-linux)
-    sqlite3 (1.6.8-arm64-darwin)
-    sqlite3 (1.6.8-x86_64-linux)
     stackprof (0.2.25)
     stimulus-rails (1.3.0)
       railties (>= 6.0.0)
@@ -265,13 +263,13 @@ DEPENDENCIES
   importmap-rails
   jbuilder
   memory_profiler
+  mysql2
   puma (>= 5.0)
   rack-mini-profiler
   rails (~> 7.1.1)
   redis (>= 4.0.1)
   selenium-webdriver
   sprockets-rails
-  sqlite3 (~> 1.4)
   stackprof
   stimulus-rails
   tailwindcss-rails (~> 2.0)

--- a/config/application.rb
+++ b/config/application.rb
@@ -23,5 +23,6 @@ module Slowpoke
     #
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
+    config.active_record.schema_format = :sql
   end
 end

--- a/config/database.yml
+++ b/config/database.yml
@@ -5,21 +5,18 @@
 #   gem "sqlite3"
 #
 default: &default
-  adapter: sqlite3
+  username: root
+  adapter: mysql2
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   timeout: 5000
 
 development:
   <<: *default
-  database: storage/development.sqlite3
+  database: slowpoke_development
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: storage/test.sqlite3
-
-production:
-  <<: *default
-  database: storage/production.sqlite3
+  database: slowpoke_test

--- a/db/migrate/20231207153315_slow.rb
+++ b/db/migrate/20231207153315_slow.rb
@@ -1,0 +1,18288 @@
+class Slow < ActiveRecord::Migration[7.1]
+  def change
+    create_table "naturists", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "listerelloses", null: false
+      t.text "gretchens", null: false
+      t.integer "neoplasia", null: false
+      t.integer "effusiometers", null: false
+      t.integer "reliers", null: false
+      t.integer "maytenus", null: false
+      t.integer "scalenous", null: false
+      t.datetime "lags", precision: nil, null: false
+      t.datetime "pancreatoids", precision: nil, null: false
+    end
+
+    create_table "recordatives", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "aphthics", null: false
+      t.bigint "pseudoblepsia"
+      t.string "sibredes", null: false
+      t.string "catallacticallies"
+      t.datetime "foreconsiders", precision: nil, null: false
+      t.datetime "cyclograms", precision: nil, null: false
+      t.string "argyropelecus", null: false
+      t.bigint "whilks"
+      t.string "pinniferous"
+      t.string "leftwards"
+      t.string "recusatives"
+    end
+
+    create_table "droits", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "trichotomists", null: false
+      t.datetime "interplicals", precision: nil, null: false
+      t.datetime "deuteromyosinoses", precision: nil
+      t.datetime "funoris", precision: nil
+    end
+
+    create_table "nongerminations", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "unlaws", null: false
+      t.string "unconjoineds", null: false
+      t.text "mosasauris"
+      t.datetime "jacobaeas", precision: nil
+      t.datetime "hemicatalepsies", precision: nil
+    end
+
+    create_table "masteds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "orthodoxalities", null: false
+      t.datetime "tarairis", precision: nil, null: false
+      t.datetime "yachtswomen", precision: nil
+      t.datetime "malabars", precision: nil
+    end
+
+    create_table "dentatocrenates", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "bewingeds", limit: 36, null: false
+      t.string "samsonesses", limit: 36, null: false
+      t.datetime "relasters", precision: nil
+      t.datetime "threaders", precision: nil
+      t.datetime "pneumatologists", precision: nil
+      t.datetime "mesodisilicics", precision: nil
+    end
+
+    create_table "metachromases", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "playerdoms", limit: 36, null: false
+      t.bigint "melolonthides", null: false
+      t.boolean "chrysotiles", default: false, null: false
+      t.datetime "sauropods", precision: nil
+      t.datetime "unibivalents", precision: nil
+      t.boolean "upwrings", default: false, null: false
+      t.date "internarials"
+      t.date "cockleboats"
+    end
+
+    create_table "scutulates", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "causeways", limit: 36, null: false
+      t.datetime "osteomalacials", precision: nil
+      t.datetime "trihemiobolions", precision: nil
+      t.string "pennaceous"
+      t.string "apneumatics"
+      t.string "twinelikes"
+      t.string "enslavednesses"
+      t.string "podites"
+      t.bigint "upstrokes", null: false
+      t.text "perstringements"
+    end
+
+    create_table "repropitiates", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "smuggishlies", limit: 36, null: false
+      t.string "retiariaes", limit: 36, null: false
+      t.boolean "wildeds", default: true, null: false
+      t.boolean "festinations", default: false, null: false
+      t.string "quackishlies"
+      t.string "wisecrackeries"
+      t.string "nahuans"
+      t.string "semitonals"
+      t.string "phalangiforms"
+      t.boolean "strabismometries", default: false, null: false
+      t.datetime "bahiaites", precision: nil
+      t.datetime "unclericalnesses", precision: nil
+      t.boolean "zygobranches", default: true, null: false
+      t.string "sleepings"
+      t.integer "cotta", default: 0, null: false
+      t.boolean "melodeons"
+      t.text "hyperapophyseals"
+      t.text "unbettereds"
+    end
+
+    create_table "unhusks", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "oliversmiths", limit: 36, null: false
+      t.string "shortages", limit: 36, null: false
+      t.datetime "untransparents", precision: nil
+      t.datetime "convokers", precision: nil
+    end
+
+    create_table "downingia", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.datetime "taenials", precision: nil, null: false
+      t.datetime "vanelesses", precision: nil, null: false
+      t.string "quadrienniumutiles", limit: 36, null: false
+      t.string "sells", null: false
+      t.boolean "oxygas", default: true, null: false
+    end
+
+    create_table "fulahs", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.datetime "parchers", precision: nil, null: false
+      t.datetime "galvanoplastics", precision: nil, null: false
+      t.string "unhoundlikes", limit: 36, null: false
+      t.string "negritizes", limit: 36, null: false
+      t.string "subadjacents", limit: 36, null: false
+      t.text "uncongealables", null: false
+      t.string "magellanics", null: false
+      t.string "canches", null: false
+      t.string "installs", null: false
+      t.text "karos"
+      t.text "rhinosporidia"
+    end
+
+    create_table "jacktans", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.datetime "benzophenazines", precision: nil, null: false
+      t.datetime "tutins", precision: nil, null: false
+      t.string "jauntilies", limit: 36, null: false
+      t.string "preopinions", null: false
+      t.string "prankeds", null: false
+      t.integer "allelotropisms", null: false
+      t.datetime "instinctuals", precision: nil, null: false
+      t.string "jazzinesses", limit: 36, null: false
+    end
+
+    create_table "hydrosulphurous", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.datetime "telergicallies", precision: nil, null: false
+      t.datetime "tesses", precision: nil, null: false
+      t.string "advisers", limit: 36, null: false
+      t.string "twiddlers", null: false
+      t.string "lovingnesses", limit: 36, null: false
+    end
+
+    create_table "resources", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "pseudocysts", limit: 36, null: false
+      t.bigint "preconveyals", null: false
+      t.bigint "plumpnesses", null: false
+      t.datetime "mossis", precision: nil
+      t.datetime "stereornithes", precision: nil
+    end
+
+    create_table "melocotons", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "unpertinentlies", null: false
+      t.bigint "physcomitria", null: false
+      t.datetime "sternoclaviculars", precision: nil
+      t.datetime "awafts", precision: nil
+    end
+
+    create_table "redoubles", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "crankilies", null: false
+      t.bigint "congenericals"
+      t.datetime "kadmis", precision: nil
+      t.datetime "inopportunes", precision: nil
+      t.string "bookbindings"
+    end
+
+    create_table "preceremonials", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "cleistogamicallies", null: false
+      t.string "dinotheres", null: false
+      t.string "dianthaceaes", null: false
+      t.text "thalamiflorals"
+      t.string "nonascertainings", null: false
+      t.boolean "stomatolalia", null: false
+      t.string "heteroscopes", null: false
+      t.datetime "uphelyas", precision: nil
+      t.datetime "abnormallies", precision: nil
+      t.datetime "degenerates", precision: nil
+      t.bigint "tipplers", null: false
+      t.datetime "bepatcheds", precision: nil, null: false
+      t.datetime "ammoniacums", precision: nil, null: false
+      t.string "trikeria", limit: 36, null: false
+      t.string "participables", limit: 36
+      t.string "preimportations", limit: 36
+      t.text "cadencies"
+    end
+
+    create_table "areometricals", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "spirochetoses", limit: 36, null: false
+      t.bigint "squatinas", null: false
+      t.string "triclinia", limit: 36, null: false
+      t.datetime "romaics", precision: nil, null: false
+      t.datetime "pitchometers", precision: nil, null: false
+    end
+
+    create_table "prolixities", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "underdigs"
+      t.string "tollkeepers"
+      t.integer "cambists"
+      t.string "levs", limit: 300, default: "--- []\n"
+      t.string "magnetostrictions"
+      t.string "phareodus"
+      t.boolean "rationalisms", default: false
+      t.boolean "unconstrueds", default: false
+      t.datetime "overanxieties", precision: nil, null: false
+      t.datetime "ungraphics", precision: nil, null: false
+      t.string "kilograms"
+      t.boolean "accessibilities", default: false
+      t.datetime "overdrowseds", precision: nil
+      t.string "hypervasculars"
+      t.string "forkwises"
+      t.string "commons"
+      t.string "cornfields"
+      t.string "bolimbas"
+      t.string "ichnolithologies"
+      t.string "demilancers"
+      t.string "overtones"
+      t.string "laggers"
+      t.string "alternants"
+      t.string "ferinelies"
+      t.string "vagabondia"
+      t.string "hemiolia"
+      t.string "lycanthropizes"
+      t.string "reliquians"
+      t.boolean "zarabandas"
+      t.bigint "cladodonts"
+      t.boolean "sanjakates"
+      t.bigint "indentations"
+      t.string "befrills"
+      t.string "weightedlies"
+      t.boolean "mesiolinguals"
+      t.string "bedtickings"
+      t.string "palpus", limit: 1024
+      t.datetime "robalitos", precision: nil
+      t.string "cinchers"
+      t.boolean "upwrenches"
+      t.boolean "breedings", default: false
+      t.string "mizzlers"
+      t.text "pyridinia"
+      t.boolean "extrastates"
+      t.text "monohydrogens"
+      t.string "filicals", limit: 36, null: false
+      t.string "wanderers"
+      t.string "amandins"
+    end
+
+    create_table "embeggars", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "dowlas", limit: 36, null: false, collation: "ascii_general_ci"
+      t.bigint "alliaceaes", null: false
+      t.integer "micturitions", null: false
+      t.string "palpis", limit: 36, collation: "ascii_general_ci"
+      t.string "joltinglies", limit: 36, collation: "ascii_general_ci"
+      t.datetime "dextraurals", precision: nil
+      t.datetime "operatizes", precision: nil
+    end
+
+    create_table "exhilarants", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "jussives", null: false
+      t.string "anisamides", null: false
+      t.integer "seringals", null: false
+      t.integer "techniques", null: false
+      t.datetime "amphicribrals", precision: nil
+      t.datetime "coreligionists", precision: nil
+    end
+
+    create_table "subtacksmen", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "pronubas", null: false
+      t.datetime "oleraceous", precision: nil
+      t.datetime "rhamnites", precision: nil
+    end
+
+    create_table "swaddlebills", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "unworkmanlies", limit: 36, null: false, collation: "ascii_general_ci"
+      t.bigint "pentenes", null: false
+      t.bigint "postcolumellars"
+      t.string "lhota", null: false
+      t.string "isoldes", default: "processing", null: false
+      t.string "discursions", null: false
+      t.datetime "admedians", precision: nil, null: false
+      t.datetime "acts", precision: nil, null: false
+    end
+
+    create_table "ypsiloids", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "phantomists", limit: 36, null: false
+      t.datetime "evocativelies", precision: nil, null: false
+      t.datetime "katastates", precision: nil, null: false
+      t.bigint "summits", null: false
+      t.string "foraminiferas", null: false
+      t.string "captiousnesses", null: false
+      t.string "unpicks"
+      t.string "stades", null: false
+    end
+
+    create_table "domiciliates", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "requotations"
+      t.string "preobliges"
+      t.string "aircraftmen"
+      t.string "supersentimentals"
+      t.text "beechwoods"
+      t.string "contemptuouslies"
+      t.text "cosherers"
+      t.datetime "dermatonosus", precision: nil, null: false
+      t.datetime "phigalians", precision: nil, null: false
+      t.string "clatches"
+      t.bigint "papyrotypes", null: false
+    end
+
+    create_table "enchains", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "gulflikes", limit: 36, null: false
+      t.bigint "shirlcocks"
+      t.bigint "mensurals"
+      t.datetime "supervisionaries", precision: nil
+      t.datetime "sabals", precision: nil
+    end
+
+    create_table "enteromyiases", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "globals", limit: 36, null: false
+      t.bigint "katabellas", null: false
+      t.bigint "trainmen", null: false
+      t.string "podilegous"
+      t.string "bedchambers"
+      t.string "sturks"
+      t.string "barramundis"
+      t.datetime "frications", precision: nil, null: false
+      t.datetime "lugs", precision: nil, null: false
+      t.boolean "lyoneses", default: false
+    end
+
+    create_table "monobasicities", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "haughtonites", limit: 36, null: false
+      t.bigint "hollies", null: false
+      t.date "millerisms", null: false
+      t.boolean "anthogenetics", null: false
+      t.datetime "arundinaceous", precision: nil, null: false
+      t.datetime "undesirablies", precision: nil, null: false
+    end
+
+    create_table "revenants", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "overcontracts", limit: 36, null: false
+      t.bigint "wongas", null: false
+      t.bigint "tortulous"
+      t.datetime "tamils", precision: nil, null: false
+      t.datetime "wouldnts", precision: nil, null: false
+      t.string "cellateds", null: false
+      t.datetime "graphiologists", precision: nil
+      t.datetime "thermomagnetics", precision: nil
+    end
+
+    create_table "vereks", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "dactyliothecas", limit: 36, null: false
+      t.bigint "criticisms", null: false
+      t.bigint "lipeurus", null: false
+      t.bigint "hyphomycetes", null: false
+      t.boolean "greetings", default: false
+      t.datetime "lipodystrophies", precision: nil
+      t.datetime "sandies", precision: nil
+    end
+
+    create_table "viscerotropics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "concursus", null: false
+      t.bigint "slipperinesses", null: false
+      t.datetime "invocatives", precision: nil
+      t.datetime "biloxis", precision: nil
+    end
+
+    create_table "antinaturals", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "sheepheads", null: false
+      t.string "crestfallennesses", null: false
+      t.datetime "mizzentopmen", precision: nil, null: false
+      t.datetime "benzophenols", precision: nil, null: false
+      t.string "pseudoantiques"
+      t.string "trivia"
+    end
+
+    create_table "abradants", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "cuprums", limit: 36, null: false
+      t.bigint "portios", null: false
+      t.boolean "restoppers", default: true, null: false
+      t.datetime "thunderlesses", precision: nil
+      t.datetime "deductivelies", precision: nil
+    end
+
+    create_table "ursoids", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "indeterminablenesses", limit: 36, null: false
+      t.bigint "allowers", null: false
+      t.string "bullworts"
+      t.datetime "hateables", precision: nil
+      t.datetime "physiques", precision: nil
+      t.bigint "pycnodontis", null: false
+      t.boolean "bulimies", default: true, null: false
+    end
+
+    create_table "scalplesses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "duelistics", limit: 36, null: false
+      t.datetime "bacitracins", precision: nil, null: false
+      t.datetime "molimen", precision: nil, null: false
+      t.bigint "cecomorphics", null: false
+      t.bigint "uncognizables", null: false
+      t.date "toadlets", null: false
+      t.date "foreruns"
+    end
+
+    create_table "anthropozoics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "pteridospermous"
+      t.string "levynites"
+      t.string "wailinglies"
+      t.boolean "reticellas", default: false
+      t.datetime "printablenesses", precision: nil
+      t.datetime "unaddeds", precision: nil
+      t.boolean "electionaries", default: false
+      t.boolean "gambiers", default: true
+      t.string "koltunnas"
+      t.integer "tsubos"
+      t.integer "calcineds", default: 0, null: false
+      t.boolean "protomagnesia", default: false
+      t.string "puninesses"
+      t.integer "ams", limit: 1
+      t.date "atticizes"
+      t.string "untorrids"
+      t.string "antithefts"
+      t.boolean "meriahs", default: false, null: false
+      t.string "docmacs", limit: 36, null: false
+      t.string "cajolers"
+      t.bigint "arengs"
+      t.boolean "witenagemots", default: false, null: false
+      t.boolean "ascus", default: false, null: false
+      t.string "interdentals"
+      t.boolean "indigestibles", default: false, null: false
+      t.string "disgustfulnesses", default: "client_billed_rev_share", null: false
+    end
+
+    create_table "squamules", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "rullers"
+      t.bigint "nebulizations"
+      t.string "cashierments"
+      t.bigint "heterandrous"
+      t.string "cyanhydrates"
+      t.text "hebdomarians"
+      t.boolean "climas", default: false
+      t.string "scouches"
+      t.datetime "alcyonia", precision: nil
+      t.datetime "barometrographies", precision: nil
+      t.datetime "erectors", precision: nil
+      t.bigint "propiolics"
+      t.text "pseudobrachia"
+      t.text "anisics", size: :long
+      t.integer "platyrrhinis"
+    end
+
+    create_table "adlais", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "osteophytes", null: false
+      t.string "syntypics"
+      t.datetime "thyroidals", precision: nil
+      t.datetime "smuggishes", precision: nil
+    end
+
+    create_table "zolaesques", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "flaxtails", null: false
+      t.string "muggilies", null: false
+      t.bigint "pyromania"
+      t.string "apoquinines"
+      t.text "chummers"
+      t.datetime "anthropomorphologies", precision: nil, null: false
+      t.datetime "agues", precision: nil, null: false
+      t.string "protoactinia"
+      t.bigint "cannoneers"
+      t.boolean "boolyas", default: false
+    end
+
+    create_table "besides", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "hoppies", null: false
+      t.string "retrotarsals", limit: 36, null: false
+      t.bigint "perithyreoiditis", null: false
+      t.string "statutorilies", null: false
+      t.bigint "germinals", null: false
+      t.datetime "antithetics", null: false
+    end
+
+    create_table "bangalays", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "devourments", null: false
+      t.string "bitesheeps", null: false
+      t.string "pleds"
+      t.text "nontidals"
+      t.string "infusibilities", null: false
+      t.bigint "outbuys", null: false
+      t.string "pressworks"
+      t.datetime "unpossessings", null: false
+    end
+
+    create_table "gynics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.datetime "flexiles", precision: nil
+      t.datetime "merists", precision: nil
+      t.bigint "pyrheliometers"
+      t.string "theriotrophicals"
+      t.string "acontius", limit: 36, null: false
+    end
+
+    create_table "unforecasteds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "interplights", null: false
+      t.string "podostemonaceaes", null: false
+    end
+
+    create_table "shallus", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "multimotors", null: false
+      t.date "pannikins"
+      t.integer "unashamednesses"
+      t.datetime "uncenters", precision: nil, null: false
+      t.datetime "plumoses", precision: nil, null: false
+    end
+
+    create_table "unfunnies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "street_1"
+      t.string "street_2"
+      t.string "dikereeves"
+      t.string "accidentals"
+      t.string "columbins"
+      t.string "cuspules"
+      t.datetime "synoptics", precision: nil, null: false
+      t.datetime "stalkies", precision: nil, null: false
+      t.string "plateries"
+      t.bigint "bulbocapnins"
+      t.string "tangies"
+      t.string "nicotinamides"
+      t.string "edelweisses"
+      t.string "rhipidistians"
+      t.string "progressionists"
+      t.string "endothermous"
+      t.string "nonornamentals"
+      t.string "sponsorials"
+      t.string "blockpates"
+      t.string "insteams"
+      t.string "superaccurates"
+      t.string "nauts"
+      t.string "jonathans"
+      t.string "spanings"
+      t.boolean "tullibees", default: false
+      t.string "tercines", limit: 36, null: false
+      t.string "manomins"
+    end
+
+    create_table "sundaynesses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.decimal "shoppers", precision: 16, scale: 2, default: "0.0"
+      t.string "prickwoods"
+      t.bigint "tonsurates", null: false
+      t.bigint "poundmen", null: false
+      t.datetime "unstatutables", precision: nil
+      t.string "overpaineds", null: false
+      t.datetime "phalangides", precision: nil
+      t.datetime "annoyments", precision: nil
+    end
+
+    create_table "archpuritans", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "astatizes"
+      t.bigint "slipovers"
+      t.string "eosides"
+      t.decimal "silverfins", precision: 8, scale: 2
+      t.decimal "undercups", precision: 16, scale: 2
+      t.string "outsuffers"
+      t.date "traplights"
+      t.date "pyeloscopies"
+      t.bigint "interarticulars"
+      t.datetime "loopholes", precision: nil
+      t.datetime "ultraparallels", precision: nil
+    end
+
+    create_table "reuchlinians", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "pimientos"
+      t.string "sacculateds"
+      t.string "smooriches"
+      t.text "rupestrines"
+      t.datetime "unstimulatings", precision: nil
+      t.datetime "alburnous"
+      t.string "silicotics", default: "panda", null: false
+      t.boolean "centos", default: true, null: false
+    end
+
+    create_table "abbotnullius", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "semifluids", null: false
+      t.bigint "aptyalisms", null: false
+      t.datetime "misprofessors", precision: nil
+      t.datetime "predelinquentlies"
+    end
+
+    create_table "unhopinglies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "strands"
+      t.bigint "massilies"
+    end
+
+    create_table "dipterous", charset: "utf8mb3", force: :cascade do |t|
+      t.bigint "gesnings"
+      t.bigint "wordlikes"
+      t.datetime "blackberries", precision: nil
+      t.datetime "glarilies", precision: nil
+      t.bigint "flutters"
+    end
+
+    create_table "autosymbolicallies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "panoramas", null: false
+      t.bigint "saturates", null: false
+      t.datetime "infinitesimalities", precision: nil
+      t.datetime "predistributes", precision: nil
+    end
+
+    create_table "recontracts", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "eightieths", null: false
+      t.datetime "redbreasts", precision: nil, null: false
+      t.datetime "marmorateds", precision: nil, null: false
+      t.string "jurylesses"
+      t.string "unpriestlies", default: "panda", null: false
+    end
+
+    create_table "glavers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "ungossipings"
+      t.string "daimiates"
+      t.bigint "herships"
+      t.string "reinherits"
+      t.text "beechnuts"
+      t.datetime "xanthopicrites", precision: nil, null: false
+      t.datetime "gloves", precision: nil, null: false
+      t.string "toothcombs"
+      t.datetime "ack0_received_at", precision: nil
+      t.datetime "ack1_received_at", precision: nil
+      t.datetime "ack2_received_at", precision: nil
+      t.datetime "oophoralgia", precision: nil
+      t.bigint "tripewomen"
+      t.bigint "desilverizations"
+      t.string "antiphonallies"
+    end
+
+    create_table "chiloplasties", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "conjurors"
+      t.string "iodinophilous"
+      t.integer "bacillariophyta"
+      t.datetime "otoscopes", precision: nil
+      t.datetime "continuants", precision: nil
+    end
+
+    create_table "recontends", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "recipient_1", null: false
+      t.string "recipient_2"
+      t.string "street_1", null: false
+      t.string "street_2"
+      t.string "giggledoms", null: false
+      t.string "bjornes", null: false
+      t.string "cordeaus", null: false
+      t.string "unabidings"
+      t.datetime "departmentalizes", precision: nil
+      t.datetime "alcoholmetrics", precision: nil
+    end
+
+    create_table "nightwards", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "galvanisms", null: false
+      t.string "lutations", null: false
+      t.string "woodwardships", null: false
+      t.date "crepons", null: false
+      t.bigint "problockades", null: false
+    end
+
+    create_table "spermics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "annelids"
+      t.string "stubrunners"
+      t.date "skylooks"
+      t.string "ratlines"
+      t.boolean "unatmospherics", default: false
+      t.string "kingmakings"
+      t.string "outhectors"
+      t.integer "nonirritables"
+      t.datetime "hypaethrons", precision: nil
+      t.bigint "spheroidicallies"
+      t.bigint "curculionists"
+      t.datetime "xenia", precision: nil
+      t.datetime "pisciculturists", precision: nil
+    end
+
+    create_table "subsulfides", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "priestesses", null: false
+      t.bigint "extracardials", null: false
+      t.datetime "hillockies", precision: nil, null: false
+      t.datetime "uranostaphyloplasties", precision: nil, null: false
+    end
+
+    create_table "artocarpous", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "hypomerons"
+      t.bigint "endocoelars"
+    end
+
+    create_table "prices", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "massivenesses", null: false
+      t.integer "desoxycorticosterones"
+      t.integer "vacciniaceous"
+      t.date "horometries"
+      t.string "hadentomoideas"
+      t.string "sphericalnesses"
+      t.string "fenugreeks"
+      t.integer "expectances"
+      t.decimal "multimarbles", precision: 16, scale: 2
+      t.decimal "comicotragedies", precision: 16, scale: 2
+      t.datetime "alodialities", precision: nil
+      t.datetime "lontars", precision: nil
+      t.integer "proctoriallies", default: 0
+      t.string "refunctions"
+      t.integer "irresponsiblies", default: 0
+      t.boolean "preambleds", default: false
+      t.integer "counterhammerings"
+      t.text "pyretics"
+      t.string "intuitionlesses"
+      t.bigint "repetitives"
+      t.bigint "unrespireds"
+      t.string "melituria"
+      t.bigint "dollarleafs"
+      t.bigint "phlogistics"
+      t.date "yogins"
+      t.decimal "sylvites", precision: 16, scale: 2
+    end
+
+    create_table "reobservations", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.datetime "ridgeplates", precision: nil, null: false
+      t.datetime "slobberers", precision: nil, null: false
+    end
+
+    create_table "stachyuraceaes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "infamous", null: false
+      t.bigint "yuhs"
+      t.string "breadnuts", null: false
+      t.string "bacteriaceous", null: false
+      t.string "ingloriouslies", null: false
+      t.string "gynecomastisms", null: false
+      t.datetime "mudguards", precision: nil, null: false
+      t.datetime "skinkles", precision: nil, null: false
+      t.string "focimetries"
+      t.string "hypotrophics"
+    end
+
+    create_table "odinists", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "repletivelies", null: false
+      t.string "riddlers", null: false
+      t.string "lymphocytotics", limit: 36, null: false
+      t.datetime "springes", precision: nil, null: false
+      t.datetime "apepsinia", precision: nil, null: false
+    end
+
+    create_table "precontracts", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "cucumaria", null: false
+      t.bigint "presacrificials"
+      t.string "minnows", null: false
+      t.string "involvers", null: false
+      t.text "canaanitics", null: false
+      t.datetime "gonotypes", precision: nil, null: false
+      t.datetime "rheeboks", precision: nil, null: false
+      t.string "unbaileds"
+      t.string "pruners"
+      t.string "pelleteds"
+    end
+
+    create_table "favorings", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "recommences"
+      t.bigint "bioecologicallies"
+      t.string "runaways"
+      t.datetime "synoviparous", precision: nil
+      t.datetime "tendosynovitis", precision: nil
+    end
+
+    create_table "anitrogenous", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "phidians"
+      t.bigint "ballstocks"
+      t.datetime "acatharsia", precision: nil, null: false
+      t.datetime "roughhewns", precision: nil, null: false
+      t.string "compacteds"
+      t.string "wasats"
+      t.string "macroanalyticals"
+    end
+
+    create_table "reifies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "rubiators"
+      t.integer "laevotartarics"
+      t.datetime "mojos", precision: nil
+      t.datetime "cenobia", precision: nil
+      t.string "dezincations"
+    end
+
+    create_table "gaugerships", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.boolean "shammockings"
+      t.string "unfastidiouslies"
+      t.datetime "backstretches", precision: nil
+      t.datetime "melodrams", precision: nil
+      t.string "fugallies"
+      t.string "enwombs"
+      t.date "encoronets"
+      t.string "trickishlies"
+      t.integer "astaticallies"
+      t.integer "serventes"
+      t.string "indwellers"
+      t.string "unsnaggeds"
+      t.integer "anodes"
+      t.datetime "telautograms", precision: nil
+      t.bigint "penttails"
+      t.bigint "arduinites"
+      t.date "pharyngoesophageals"
+      t.date "undramaticallies"
+      t.bigint "fervescences"
+      t.date "anisodactylas"
+      t.boolean "uncomparablies", default: false
+      t.boolean "preleases", default: false
+      t.decimal "extrinsicallies", precision: 16, scale: 6
+      t.text "dynamicallies"
+      t.text "semifinalists"
+      t.datetime "oxyterpenes", precision: nil
+      t.boolean "saloons"
+      t.bigint "quindecemvirs"
+      t.boolean "squilgeers"
+      t.string "uncriticizings"
+      t.string "coctiles"
+      t.string "rugates"
+      t.string "manduas"
+      t.string "devaluations"
+    end
+
+    create_table "knawels", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "booms"
+      t.bigint "coleslaws"
+      t.datetime "tetraonids", precision: nil
+      t.datetime "cowherds", precision: nil
+    end
+
+    create_table "thereouts", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "larrigans"
+      t.string "consults"
+      t.string "haughtnesses"
+      t.string "whitetails"
+      t.bigint "ladyfingers"
+      t.string "lighthouses"
+      t.datetime "misexpressions", precision: nil
+      t.datetime "quakerizes", precision: nil
+    end
+
+    create_table "ovariorrhexis", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "mesiobuccals"
+      t.bigint "nonconductions"
+      t.string "sarcosomas"
+      t.datetime "tercelets", precision: nil
+      t.datetime "fs", precision: nil
+    end
+
+    create_table "aeacides", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "piaculums"
+      t.string "speers"
+      t.date "yens"
+      t.date "emphatics"
+      t.decimal "acalycals", precision: 16, scale: 2
+      t.integer "osteocartilaginous"
+      t.text "limoniads"
+      t.datetime "eventognathis", precision: nil, null: false
+      t.datetime "pupildoms", precision: nil, null: false
+      t.date "dogeships"
+      t.text "pecksniffians"
+      t.boolean "iconoplasts", default: false
+      t.bigint "glonoins"
+      t.string "plebes"
+      t.date "unoppugneds"
+      t.decimal "linitis", precision: 16, scale: 2, default: "0.0"
+      t.date "microhenries"
+      t.date "mottes"
+      t.boolean "aimaks", default: false
+      t.bigint "garbages"
+      t.bigint "antioptimists"
+      t.string "fluctuosities"
+      t.text "kaddishes"
+      t.string "discoideas"
+      t.string "gemmates"
+      t.bigint "propublications"
+      t.string "shoestrings"
+      t.boolean "hoppets", default: false, null: false
+    end
+
+    create_table "degausses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "trentines", null: false
+      t.bigint "reinserts", null: false
+      t.datetime "polydemics", precision: nil, null: false
+      t.datetime "germanhoods", precision: nil, null: false
+    end
+
+    create_table "waiters", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "radiatenesses", null: false
+      t.bigint "lucklesses", null: false
+      t.datetime "prepunishes", precision: nil
+      t.datetime "petroliferous", precision: nil
+    end
+
+    create_table "commonishes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "aerates", null: false
+      t.bigint "stonesmiches", null: false
+      t.date "hippotomists", null: false
+      t.integer "oxystearics", null: false
+      t.string "condescendingnesses"
+      t.string "craniosacrals"
+      t.datetime "rhetorizes", precision: nil
+      t.datetime "imbaseds", precision: nil
+    end
+
+    create_table "epurations", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "thereons"
+      t.bigint "daftnesses"
+      t.datetime "neurals", precision: nil, null: false
+      t.datetime "ohia", precision: nil, null: false
+      t.boolean "mosslesses", default: false
+      t.string "hexadactylisms"
+      t.string "farmerlikes"
+      t.string "belliferous"
+    end
+
+    create_table "artemis", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "interoperculums", limit: 36, null: false
+      t.bigint "antitropals", null: false
+      t.string "karatas", null: false
+      t.string "headlightings", null: false
+      t.datetime "unknitteds", precision: nil
+      t.datetime "consultings", precision: nil
+    end
+
+    create_table "firebrands", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "unimbibings"
+      t.string "suturallies"
+      t.string "forcefulnesses"
+      t.string "bromocyanidations"
+      t.string "phyllomania"
+      t.string "afloats"
+      t.bigint "philodramatists"
+      t.bigint "halses"
+      t.string "unkilleds"
+      t.string "fantigues"
+    end
+
+    create_table "sidesplittings", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "tapamakers", limit: 36, null: false
+      t.string "ophicephaloids", null: false
+      t.text "polarizes", null: false
+      t.datetime "crazedlies", precision: nil
+      t.datetime "electrizations", precision: nil
+      t.string "spoonilies", default: "United States", null: false
+    end
+
+    create_table "antipyics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "kalemas", limit: 36, null: false
+      t.bigint "plowwrights", null: false
+      t.string "perfectations", null: false
+      t.string "summerers"
+      t.datetime "prostatorrhoeas", precision: nil, null: false
+      t.datetime "hominians", precision: nil, null: false
+    end
+
+    create_table "penkeepers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "weighings", null: false
+      t.string "mecons", null: false
+      t.datetime "dichotomistics", precision: nil
+      t.datetime "regulus", precision: nil
+      t.datetime "chinks", precision: nil
+    end
+
+    create_table "lebistes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "extensiles", limit: 36, null: false
+      t.string "smellfuls", null: false
+      t.bigint "postotics", null: false
+      t.datetime "spelunkers", precision: nil
+      t.datetime "euphonous", precision: nil
+      t.string "hemiplegia"
+    end
+
+    create_table "trigrammatisms", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "numerants", null: false
+      t.boolean "vomitings", default: false
+      t.datetime "langueds", precision: nil, null: false
+      t.datetime "vinlands", precision: nil, null: false
+    end
+
+    create_table "subsoils", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "unrebuffables", null: false
+      t.bigint "tactfuls", null: false
+      t.integer "bananists", null: false
+      t.text "enroots"
+      t.datetime "probeables", precision: nil
+      t.datetime "xenogamous", precision: nil
+      t.string "contentfuls", default: "open"
+    end
+
+    create_table "analgeses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "braceds", limit: 36, null: false
+      t.bigint "irregularisms", null: false
+      t.string "tailforemosts", null: false
+      t.bigint "stalkinesses", null: false
+      t.string "morchellas", null: false
+      t.datetime "retrotympanics", precision: nil
+      t.datetime "ludgates", precision: nil
+    end
+
+    create_table "jitneymen", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "ges", limit: 36, null: false
+      t.bigint "interlaminates", null: false
+      t.bigint "anaphylaxis", null: false
+      t.string "costanoans", null: false
+      t.datetime "ootocoids", precision: nil
+      t.datetime "overintellectuals", precision: nil
+    end
+
+    create_table "callings", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "nonrefractions", limit: 36, null: false
+      t.bigint "plenilunars"
+      t.datetime "hurrahs", precision: nil, null: false
+      t.bigint "dorsopleurals", null: false
+      t.bigint "betreads", null: false
+      t.bigint "briskets", null: false
+      t.bigint "ancorals"
+      t.datetime "proparoxytones", precision: nil
+      t.datetime "probativelies", precision: nil
+      t.bigint "semiwilds"
+    end
+
+    create_table "heterocarpisms", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "hunhs", limit: 36, null: false
+      t.datetime "landfasts", precision: nil
+      t.datetime "universalizes", precision: nil
+      t.bigint "dilatators", null: false
+      t.bigint "phanics", null: false
+      t.bigint "wildfires", null: false
+      t.bigint "automobilisms"
+      t.integer "atropaceous", null: false
+      t.string "hysteromyomectomies"
+      t.string "shaveries"
+      t.text "overstudiouslies"
+      t.boolean "alternances", default: false, null: false
+      t.bigint "counteraccusations"
+    end
+
+    create_table "lipothymies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "oversells", limit: 36, null: false
+      t.datetime "undislodgeables", precision: nil
+      t.datetime "smutchies", precision: nil
+      t.string "friezies", null: false
+      t.string "hermeticals", null: false
+      t.string "divisibilities", null: false
+      t.string "debrominates"
+    end
+
+    create_table "unfraughts", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "lovebirds"
+      t.bigint "precystics"
+      t.string "linins", default: "pending", null: false
+      t.datetime "pediculophobia", precision: nil
+      t.string "unenviouslies", null: false
+      t.bigint "repatriations"
+      t.string "foulers"
+      t.text "transformisms"
+      t.datetime "nondisqualifyings", precision: nil
+      t.datetime "encases", precision: nil
+      t.boolean "villagehoods", default: false
+      t.boolean "dipsomaniacals", default: false
+    end
+
+    create_table "seminaphthalidines", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "steersmen", null: false
+      t.string "defalcators", null: false
+      t.text "protorthopteras", null: false
+      t.bigint "lapons", null: false
+      t.bigint "unmortiseds"
+      t.datetime "bewreaths", precision: nil
+      t.datetime "chowders", precision: nil
+    end
+
+    create_table "unrecoineds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "sniveleds", limit: 36, null: false
+      t.string "ragamuffinisms", null: false
+      t.string "vindemiatrixes"
+      t.string "unbetterables"
+      t.integer "chronometers"
+      t.datetime "intuitivelies", precision: nil
+      t.datetime "climatures", precision: nil, null: false
+      t.datetime "woodchucks", precision: nil, null: false
+      t.string "anerotics"
+      t.string "nymphets"
+      t.integer "plasmotomies"
+      t.datetime "stinges", precision: nil
+    end
+
+    create_table "acajous", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "townlesses", limit: 36, null: false
+      t.bigint "uninterruptings", null: false
+      t.boolean "untyrannics", default: true, null: false
+      t.datetime "subduinglies", precision: nil
+      t.datetime "papposes", precision: nil
+    end
+
+    create_table "worrilesses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "contretemps", limit: 36, null: false
+      t.bigint "columbaes", null: false
+      t.string "digressories", null: false
+      t.bigint "brandons", null: false
+      t.datetime "polyhydroxies", precision: nil
+      t.datetime "uta", precision: nil
+      t.datetime "drests", precision: nil, null: false
+    end
+
+    create_table "presurrounds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "arrestives", limit: 36, null: false
+      t.bigint "debussyanizes", null: false
+      t.datetime "spiraeaceaes", precision: nil
+      t.datetime "perceptuallies", precision: nil
+      t.text "squamoids"
+      t.text "unwatereds"
+      t.boolean "predispositionals"
+      t.boolean "vineyardists"
+      t.boolean "bodiceds"
+      t.boolean "nonterms"
+      t.boolean "obconicals"
+      t.string "scolexes"
+      t.string "mosasauroids"
+      t.string "urnisms"
+      t.text "athletehoods"
+      t.text "solds"
+      t.bigint "insulances"
+      t.text "shives"
+      t.text "pretensions"
+      t.boolean "dioptrics"
+    end
+
+    create_table "arthrodynia", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "landolphia", limit: 36, null: false
+      t.bigint "xanthochrois", null: false
+      t.datetime "yaguazas", precision: nil
+      t.datetime "semichromes", precision: nil
+      t.boolean "unspoilablenesses", default: false
+      t.datetime "unbuttonments", precision: nil
+      t.datetime "stromateidaes", precision: nil
+      t.string "cabilliaus"
+      t.string "unlucks"
+    end
+
+    create_table "protoplasms", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "chlorophyllous", limit: 36, null: false
+      t.bigint "terfezs", null: false
+      t.bigint "enhusks", null: false
+      t.bigint "leucitites", null: false
+      t.datetime "patellidans", precision: nil
+      t.datetime "orthobrachycephalics", precision: nil
+      t.string "appositivelies"
+    end
+
+    create_table "sailplanes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "mountainsides", limit: 36, null: false
+      t.string "dooms", limit: 36, null: false
+      t.datetime "guardianlesses", precision: nil
+      t.datetime "brightworks", precision: nil
+    end
+
+    create_table "poligars", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "rickmatics", limit: 36, null: false, collation: "ascii_general_ci"
+      t.date "curitis"
+      t.date "auxoblasts"
+      t.string "depots", null: false
+      t.string "endosporous", null: false
+      t.datetime "denselies", precision: nil
+      t.datetime "mawkies", precision: nil
+    end
+
+    create_table "aduncs", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "clumses", null: false
+      t.bigint "phonophotoscopics", null: false
+      t.bigint "prolyls", null: false
+      t.datetime "encroachments", precision: nil
+      t.datetime "exorcists", precision: nil
+      t.bigint "angelicalnesses"
+      t.bigint "celestials"
+      t.datetime "nonpersecutions", precision: nil
+    end
+
+    create_table "mushlas", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "harvestmen", limit: 36, null: false
+      t.bigint "lymphangiectases", null: false
+      t.bigint "erechtheums", null: false
+      t.bigint "capeds", null: false
+      t.bigint "unspelts"
+      t.datetime "interpages", precision: nil
+      t.datetime "outcourts", precision: nil, null: false
+      t.datetime "ricinus", precision: nil, null: false
+    end
+
+    create_table "guardlikes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "waremen"
+      t.string "murines"
+      t.boolean "opes"
+      t.string "telephus"
+      t.datetime "uncurbedlies", precision: nil
+      t.datetime "thurifers", precision: nil
+      t.datetime "unresistedlies", precision: nil
+      t.boolean "fanfares"
+      t.boolean "epigrams"
+      t.boolean "henneries"
+      t.boolean "intermixtures"
+      t.boolean "lamiinaes"
+      t.boolean "interchangers"
+      t.boolean "palladia"
+      t.string "italicanists"
+      t.integer "barythymia"
+      t.boolean "keelhales"
+      t.string "unsnatcheds"
+      t.integer "sacatons"
+      t.string "erysipeloids"
+      t.integer "unapplyings"
+      t.string "penuriousnesses"
+      t.text "pseudoracemics"
+      t.string "loligos"
+      t.datetime "helvetia", precision: nil
+      t.datetime "gorgons", precision: nil
+      t.boolean "lasers"
+    end
+
+    create_table "antejentaculars", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "elatedlies", limit: 36, null: false
+      t.string "antiruns", null: false
+      t.string "fossilizations"
+      t.string "gunls", null: false
+      t.integer "hoosierizes", null: false
+      t.string "sambos"
+      t.string "silphids"
+      t.integer "assiduities"
+      t.datetime "ballata", precision: nil
+      t.datetime "oblongitudes", precision: nil
+      t.datetime "homolosines", precision: nil
+      t.text "presuperfluouslies"
+    end
+
+    create_table "unmoralists", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "septonasals"
+      t.string "universities"
+      t.bigint "lindas"
+      t.string "treckschuyts"
+      t.string "clitellines"
+      t.bigint "hortatives"
+      t.bigint "leskeaceaes"
+      t.datetime "arsinoitheria", precision: nil
+      t.datetime "quinquagesimals", precision: nil
+    end
+
+    create_table "koilas", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "aglyphodonta"
+      t.bigint "fluemen"
+      t.datetime "bromochlorophenols", precision: nil
+      t.datetime "ophiuroideans", precision: nil
+      t.decimal "redivives", precision: 16, scale: 2, default: "0.0"
+      t.decimal "sarcoses", precision: 16, scale: 2, default: "0.0"
+      t.decimal "diphygenics", precision: 16, scale: 2, default: "0.0"
+      t.decimal "suburbeds", precision: 16, scale: 2, default: "0.0"
+      t.decimal "unbluffeds", precision: 16, scale: 2, default: "0.0"
+      t.decimal "alizaris", precision: 16, scale: 2, default: "0.0"
+      t.decimal "apogamouslies", precision: 16, scale: 2, default: "0.0"
+    end
+
+    create_table "hosters", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "noncrystallizables"
+      t.string "ansarians"
+      t.decimal "froggeds", precision: 16, scale: 2
+      t.datetime "responsiblenesses", precision: nil
+      t.datetime "metagnostics", precision: nil
+      t.bigint "interventionals"
+    end
+
+    create_table "disinfectants", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "pharmakos"
+      t.date "cylindrocylindrics"
+      t.decimal "unshadoweds", precision: 16, scale: 2, default: "0.0"
+      t.decimal "papists", precision: 16, scale: 2, default: "0.0"
+      t.decimal "cartridges", precision: 16, scale: 2, default: "0.0"
+      t.decimal "eggplants", precision: 16, scale: 2, default: "0.0"
+      t.decimal "twangs", precision: 16, scale: 2, default: "0.0"
+      t.decimal "microphthalmus", precision: 16, scale: 2, default: "0.0"
+      t.date "unkingers"
+      t.string "preanticipates"
+      t.bigint "interseminals"
+      t.text "baas"
+      t.datetime "arthrosporous", precision: nil
+      t.datetime "sluggardings", precision: nil
+      t.string "ousts"
+      t.text "palladianisms"
+      t.string "aluminates"
+      t.string "awashes"
+      t.string "bulkheadeds"
+      t.date "mustermasters"
+      t.datetime "grits", precision: nil
+      t.decimal "dancings", precision: 16, scale: 2, default: "0.0"
+      t.string "geissorhizas"
+    end
+
+    create_table "transparencies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "polybranchia", null: false
+      t.bigint "dianilides", null: false
+      t.bigint "spiritlands"
+      t.datetime "hexodes", precision: nil
+      t.datetime "rhinolophines", precision: nil
+    end
+
+    create_table "shaps", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "relinquishes", null: false
+      t.bigint "stamins", null: false
+      t.string "pickers", null: false
+      t.datetime "unweddeds", precision: nil
+      t.datetime "conducivenesses", precision: nil
+      t.datetime "idolatresses", precision: nil
+      t.datetime "unresistances", precision: nil
+    end
+
+    create_table "esquilines", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "nonpaids"
+      t.datetime "superstrains", precision: nil
+      t.datetime "sevenbarks", precision: nil
+    end
+
+    create_table "grovelers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "catholiclies", limit: 36, null: false
+      t.bigint "dromedarists", null: false
+      t.string "pekingeses", null: false
+      t.datetime "heliotropers", precision: nil, null: false
+      t.datetime "turnixes", precision: nil, null: false
+    end
+
+    create_table "omniregencies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "unconvincibles", limit: 36, null: false
+      t.string "bluebelleds", null: false
+      t.string "befavours", null: false
+      t.string "unhearables", null: false
+      t.bigint "contrasuggestibles", null: false
+      t.datetime "melanopathies", precision: nil, null: false
+      t.datetime "pseudoclericals", precision: nil, null: false
+    end
+
+    create_table "autoecious", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "waterworns", limit: 36, null: false
+      t.string "dancers", null: false
+      t.string "piraticals"
+      t.bigint "meaningfullies", null: false
+      t.datetime "achromatizations", precision: nil, null: false
+      t.datetime "entrails", precision: nil, null: false
+    end
+
+    create_table "uirinas", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "regainments", limit: 36, null: false
+      t.string "hobbisms", null: false
+      t.bigint "guggles", null: false
+      t.string "biochemicallies", null: false
+      t.datetime "unobtrusivenesses", precision: nil, null: false
+      t.datetime "misprisals", precision: nil, null: false
+    end
+
+    create_table "psorophthalmics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "outgrows", limit: 36, null: false
+      t.string "demoralizers"
+      t.string "neozas"
+      t.string "hyosternums"
+      t.decimal "osteofibrous", precision: 24, scale: 2
+      t.datetime "unmireds", precision: nil
+      t.boolean "epiphloedics"
+      t.bigint "cymraegs"
+      t.string "glaikets", default: "People::CompanyMember", null: false
+      t.bigint "downweighs"
+      t.datetime "transfusionists", precision: nil, null: false
+      t.datetime "undershapens", precision: nil, null: false
+    end
+
+    create_table "ferociousnesses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "wheelinglies"
+      t.datetime "thievings", precision: nil
+      t.string "oologizes"
+      t.boolean "omenta", default: false, null: false
+      t.datetime "physiogenetics", precision: nil
+      t.datetime "unethicalnesses", precision: nil
+      t.string "rensselaerites"
+      t.string "overfactious"
+      t.string "underbitteds"
+    end
+
+    create_table "arachnoiditis", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "algiomusculars", null: false
+      t.bigint "unadults"
+      t.boolean "unamis"
+      t.datetime "spraylikes", precision: nil
+      t.datetime "unterrifyings", precision: nil
+      t.datetime "paratypics", precision: nil
+      t.integer "alticas"
+      t.boolean "bridgepots"
+      t.string "unfarroweds"
+    end
+
+    create_table "classables", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "premedicals", limit: 36, null: false, collation: "ascii_general_ci"
+      t.bigint "quadrifarious"
+      t.bigint "himas", null: false
+      t.bigint "nopaleas", null: false
+      t.text "christenings", null: false
+      t.date "soporoses", null: false
+      t.date "bushlets", null: false
+      t.boolean "bolters", default: false, null: false
+      t.boolean "anticholagogues", default: false, null: false
+      t.string "kahikateas", null: false
+      t.string "openheartednesses"
+      t.datetime "rolleyways", precision: nil
+      t.datetime "filionymics", precision: nil
+      t.datetime "areolets", precision: nil
+      t.datetime "ureidos", precision: nil
+      t.datetime "aarons", precision: nil
+      t.text "zestfullies"
+      t.string "modals"
+      t.string "heartikins"
+    end
+
+    create_table "invocables", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "volans", limit: 36, null: false, collation: "ascii_general_ci"
+      t.bigint "leadproofs"
+      t.bigint "horsemongers", null: false
+      t.bigint "distributables", null: false
+      t.string "elkwoods", null: false
+      t.datetime "imaginablenesses", precision: nil
+      t.datetime "gumptious", precision: nil
+      t.datetime "microtherms", precision: nil
+      t.datetime "extraclassrooms", precision: nil
+      t.datetime "noninductivelies", precision: nil
+      t.text "bioecologists"
+    end
+
+    create_table "stauraxonia", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "suscitations", limit: 36, null: false
+      t.bigint "shaggednesses", null: false
+      t.bigint "maternallies", null: false
+      t.boolean "mastoideosquamous", default: false, null: false
+      t.text "queriers", null: false
+      t.datetime "thyrogenics", precision: nil, null: false
+      t.datetime "supracensorious", precision: nil, null: false
+    end
+
+    create_table "tympanichords", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "collarbones", limit: 36, null: false
+      t.bigint "sordariaceaes", null: false
+      t.bigint "intussusceptions", null: false
+      t.datetime "sishes", precision: nil, null: false
+      t.datetime "diploids", precision: nil, null: false
+    end
+
+    create_table "arteriectasia", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "inculpatives", limit: 36, null: false
+      t.bigint "didsts", null: false
+      t.bigint "feverishes", null: false
+      t.bigint "missileproofs", null: false
+      t.date "turkdoms", null: false
+      t.date "siccaneous"
+      t.string "spanworms", null: false
+      t.datetime "sadhs", precision: nil, null: false
+      t.datetime "croftings", precision: nil, null: false
+      t.string "fratricellis", default: "unprocessed", null: false
+    end
+
+    create_table "elementalisms", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "outlanders", limit: 36, null: false
+      t.text "humanizers", size: :long
+      t.integer "arbalesters"
+      t.datetime "zoolitics", precision: nil
+      t.datetime "lepidoids", precision: nil
+    end
+
+    create_table "xenophobians", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "convulsedlies", limit: 36, null: false
+      t.string "unglossies", null: false
+      t.text "opsonizations", null: false
+      t.string "singeds", limit: 36, null: false
+      t.datetime "youwards", precision: nil
+      t.datetime "chaptalizes", precision: nil
+    end
+
+    create_table "devilmen", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "bashawships", null: false
+      t.bigint "seepies", null: false
+      t.string "bavarians", null: false
+      t.string "antiannexationists", null: false
+      t.string "proamendments", limit: 500, default: "[]", null: false
+      t.datetime "vetivenols", precision: nil, null: false
+      t.datetime "thankworthies", precision: nil, null: false
+      t.string "polts", null: false
+    end
+
+    create_table "societologies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "unempts"
+      t.string "postulatories"
+      t.string "tics"
+      t.string "marrers", null: false
+      t.string "bachels"
+      t.datetime "bicorporals", precision: nil
+      t.datetime "sanforizeds", precision: nil
+      t.datetime "salsifies", precision: nil, null: false
+      t.datetime "sanks", precision: nil, null: false
+      t.date "hois"
+      t.string "amphiarthrodials"
+      t.datetime "concertos", precision: nil
+      t.string "squaloideis"
+      t.string "challahs"
+      t.string "unspeakablenesses"
+      t.datetime "uncloudednesses", precision: nil
+      t.string "inventibilities"
+      t.bigint "noneducationals"
+      t.bigint "wordles", null: false
+    end
+
+    create_table "collieshangies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "monogynoecials", limit: 36, null: false, collation: "ascii_general_ci"
+      t.string "cirsoids", limit: 36, null: false, collation: "ascii_general_ci"
+      t.text "heiaus", null: false
+      t.text "individuals"
+      t.datetime "presumablies", precision: nil, null: false
+      t.datetime "polytrochous", precision: nil, null: false
+    end
+
+    create_table "tudels", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "pediculicidals", limit: 36, null: false
+      t.bigint "episodials", null: false
+      t.string "blechnoids"
+      t.text "chapterals"
+      t.text "roilies"
+      t.string "euskeras"
+      t.datetime "festinatelies", precision: nil, null: false
+      t.datetime "stepfathers", precision: nil, null: false
+    end
+
+    create_table "wormweeds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "beachmasters"
+      t.decimal "jinniyehs", precision: 16, scale: 2, default: "0.0", null: false
+      t.date "batatillas"
+      t.text "moonfaceds"
+      t.datetime "potterers", precision: nil
+      t.datetime "leaders", precision: nil
+      t.date "ungestings"
+      t.string "viremics"
+      t.bigint "quicksilveries"
+      t.bigint "miolithics"
+      t.string "intermundanes"
+      t.boolean "mentorisms", default: false
+      t.string "counterfesseds"
+      t.string "unaccessionals"
+      t.bigint "unpalisadoeds"
+      t.string "spoorers"
+      t.bigint "burettes"
+      t.string "prebiddings", default: "pending", null: false
+    end
+
+    create_table "dictyogens", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "mechanizations", null: false
+      t.date "laryngoscopies", null: false
+      t.bigint "pretannages"
+      t.datetime "ergamines", precision: nil
+      t.datetime "hypoantimonates", precision: nil
+      t.string "ascaricides"
+    end
+
+    create_table "tututnis", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "scutigeridaes", null: false
+      t.bigint "compellablies", null: false
+      t.decimal "suggestionables", precision: 16, scale: 2, default: "0.0", null: false
+      t.datetime "periphrases", precision: nil
+      t.datetime "cutiterebras", precision: nil
+    end
+
+    create_table "unsuppliables", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "hyenas", null: false
+      t.decimal "pensums", precision: 16, scale: 2
+      t.integer "rebegs"
+      t.string "collegataries"
+      t.string "connaches"
+      t.datetime "genioplasties", precision: nil, null: false
+      t.datetime "trikirs", precision: nil, null: false
+      t.decimal "headcloths", precision: 16, scale: 2
+      t.date "hyperprosexia"
+      t.boolean "antipathics", default: false
+      t.decimal "britannicallies", precision: 16, scale: 2
+      t.text "decretories"
+      t.integer "nourishers"
+      t.bigint "bearables"
+    end
+
+    create_table "prestabilisms", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "chiropractors"
+      t.string "semitaes"
+      t.bigint "inerratics"
+      t.string "poltinniks"
+      t.datetime "odontognathous", precision: nil
+      t.datetime "coanimates", precision: nil
+    end
+
+    create_table "mesothetics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.datetime "puntlatshes", precision: nil, null: false
+      t.datetime "frats", precision: nil, null: false
+      t.bigint "protochlorides", null: false
+      t.date "infanglements"
+      t.decimal "uncreditablies", precision: 16, scale: 2
+      t.string "precisionizes"
+      t.boolean "calcifugals"
+      t.string "nippilies"
+      t.text "insinuatinglies"
+      t.boolean "programmatists"
+      t.datetime "louisines", precision: nil
+    end
+
+    create_table "konomihus", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "malacanthidaes"
+      t.string "echelonments"
+      t.bigint "deckes"
+      t.string "fluocerites"
+      t.datetime "uppishlies", precision: nil
+      t.datetime "gonococcus", precision: nil
+    end
+
+    create_table "overbids", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "stepdames"
+      t.decimal "t1", precision: 16, scale: 2
+      t.decimal "t2", precision: 16, scale: 2
+      t.integer "shorings", default: 0
+      t.datetime "nonspirits", precision: nil, null: false
+      t.datetime "anatinaes", precision: nil, null: false
+      t.string "superfeminines"
+      t.boolean "vesicularia", default: false
+      t.datetime "betsileos", precision: nil
+      t.boolean "discreations", default: false
+      t.bigint "exodontists"
+      t.bigint "importunes"
+      t.string "gallifications", null: false
+      t.integer "lowerers"
+      t.bigint "chokeberries"
+      t.bigint "zafrees"
+      t.bigint "cayuses"
+      t.bigint "gongoresques"
+      t.boolean "rationalities", default: false, null: false
+    end
+
+    create_table "pachytenes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "unhumanlies", null: false
+      t.bigint "hydroselenurets", null: false
+      t.bigint "cannies"
+      t.boolean "cheechakos"
+      t.datetime "piastres", precision: nil
+      t.datetime "shiftfuls", precision: nil
+      t.bigint "inspiritinglies"
+      t.string "zoophilics"
+    end
+
+    create_table "baleis", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "matkas", null: false
+      t.boolean "diazonia", default: false
+      t.string "decrees", null: false
+      t.string "nonhydrolyzables", null: false
+      t.string "perdures", null: false
+      t.datetime "antidotisms", precision: nil, null: false
+      t.datetime "introspects", precision: nil, null: false
+      t.string "piperazins", limit: 36
+      t.string "blaflums"
+      t.boolean "tempesticals", default: false
+      t.bigint "annellata"
+    end
+
+    create_table "fives", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "opisthoglyphics", null: false
+      t.bigint "connexives", null: false
+      t.string "lidflowers", null: false
+      t.datetime "parisonics", precision: nil, null: false
+      t.datetime "paradoxics", precision: nil
+      t.datetime "essentializes", precision: nil
+      t.boolean "laputicallies", default: false, null: false
+      t.boolean "norwards"
+    end
+
+    create_table "pleonastics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.date "barkeys"
+      t.datetime "ultracentenarians", precision: nil, null: false
+      t.datetime "grammontines", precision: nil, null: false
+    end
+
+    create_table "monotremata", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "tutballs", limit: 36, null: false
+      t.bigint "aceraceous", null: false
+      t.bigint "breys", null: false
+      t.datetime "symbolisticals", precision: nil, null: false
+      t.datetime "coadores", precision: nil, null: false
+    end
+
+    create_table "aheys", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "truncates"
+      t.date "embracingnesses"
+      t.text "dentosurgicals"
+      t.string "posita"
+      t.string "formaldehydes"
+      t.integer "holconotis", default: 0
+      t.integer "leefangs"
+      t.string "monobromizeds"
+      t.integer "subterraneousnesses"
+      t.datetime "townswomen", precision: nil
+      t.datetime "staffs", precision: nil
+      t.bigint "untaunteds"
+      t.bigint "limpets"
+      t.string "detoxicates"
+      t.string "fulminatings"
+      t.bigint "paramours"
+      t.boolean "scaffies", default: false
+    end
+
+    create_table "lightscots", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.decimal "fivepennies", precision: 16, scale: 2, null: false
+      t.string "chloroacetics", null: false
+      t.string "weeders"
+      t.string "coidentities"
+      t.string "unnomadics"
+      t.boolean "overfreights"
+      t.boolean "wallabies"
+      t.bigint "hyperosmics", null: false
+      t.text "mediatorships"
+      t.integer "formenics"
+      t.datetime "loamlesses", precision: nil, null: false
+      t.datetime "unsuborneds", precision: nil, null: false
+      t.string "preponderations"
+    end
+
+    create_table "pleasurings", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "vixenishlies"
+      t.string "toastmistresses"
+      t.string "paradisiacals"
+      t.datetime "jackstones", precision: nil
+      t.datetime "conciliations", precision: nil
+      t.bigint "anthropopathicallies"
+      t.datetime "squails", precision: nil
+    end
+
+    create_table "doughlikes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.integer "polymyariis"
+      t.string "gasconisms"
+      t.string "street_1"
+      t.string "street_2"
+      t.string "polybunies"
+      t.string "reticulovenoses"
+      t.string "polyphonicals"
+      t.string "cheirologies"
+      t.date "toskishes"
+      t.datetime "fulgentlies", precision: nil
+      t.datetime "calkins", precision: nil
+    end
+
+    create_table "archministers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "oedogoniaceous", limit: 36, null: false
+      t.bigint "semesters", null: false
+      t.bigint "scaremongers", null: false
+      t.string "eminentlies", null: false
+      t.decimal "mountants", precision: 8, scale: 2
+      t.decimal "hepatauxes", precision: 16, scale: 2
+      t.string "unconstituteds", null: false
+      t.datetime "outservants", precision: nil
+      t.datetime "trystings", precision: nil
+    end
+
+    create_table "thermoneuroses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "messings", limit: 36, null: false
+      t.bigint "cognizances", null: false
+      t.string "mesocoracoids", null: false
+      t.datetime "debts", precision: nil
+      t.datetime "snavels", precision: nil
+      t.datetime "milliares", precision: nil
+    end
+
+    create_table "parts", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "wordilies", limit: 36, null: false
+      t.bigint "paraxylenes", null: false
+      t.bigint "fezzans", null: false
+      t.datetime "peromedusaes", precision: nil
+      t.datetime "xinas", precision: nil
+      t.datetime "lynchers", precision: nil
+      t.datetime "mesonyxes", precision: nil
+    end
+
+    create_table "tinlets", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "markebs", limit: 36, null: false
+      t.string "takars", null: false
+      t.datetime "harperesses", precision: nil
+      t.datetime "jotties", precision: nil
+    end
+
+    create_table "novalia", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "costicartilages", limit: 36, null: false
+      t.string "unburlesqueds", null: false
+      t.string "abruptlies", null: false
+      t.datetime "orthogrades", precision: nil
+      t.datetime "oxers", precision: nil
+    end
+
+    create_table "hastatis", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "writeables", null: false
+      t.datetime "practicabilities", precision: nil
+      t.datetime "broons", precision: nil
+      t.datetime "semicircularlies", precision: nil
+    end
+
+    create_table "homospories", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "leistens", null: false
+      t.datetime "prickles", precision: nil, null: false
+      t.datetime "roentgenoscopics", precision: nil, null: false
+      t.datetime "synentognaths", precision: nil
+      t.text "synonymousnesses"
+      t.datetime "subradius", precision: nil
+      t.datetime "brotanies", precision: nil
+    end
+
+    create_table "outcurses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "hadrosaurs", null: false
+      t.datetime "garlics", precision: nil, null: false
+      t.datetime "batoideis", precision: nil
+      t.string "rowlets"
+      t.datetime "vasotomies", precision: nil
+      t.datetime "argillous", precision: nil
+    end
+
+    create_table "extraparietals", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "mensks", null: false
+      t.integer "hyperphoria"
+      t.datetime "resiliences", precision: nil
+      t.datetime "myologies", precision: nil
+      t.datetime "globulicidals", precision: nil
+      t.string "gelatinoids"
+      t.string "interminables"
+      t.string "dionymals"
+      t.bigint "tachardia"
+      t.integer "terrorists"
+      t.string "nosetiologies"
+      t.string "sacrums"
+      t.string "undistantlies"
+      t.boolean "penetrologies", default: false
+      t.datetime "talckies", precision: nil
+    end
+
+    create_table "stretchermen", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "supplicatives"
+      t.datetime "phosphites", precision: nil
+      t.datetime "nomadians", precision: nil
+      t.string "aggregatenesses", null: false
+      t.string "wiseacrednesses", null: false
+      t.datetime "anarchals", precision: nil
+    end
+
+    create_table "phenomenallies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "phyllosomes", limit: 36, null: false
+      t.bigint "superstimulations", null: false
+      t.integer "unhoods", null: false
+      t.integer "airfreighters", null: false
+      t.integer "deplasters", null: false
+      t.datetime "bromoethylenes", precision: nil
+      t.datetime "downinesses", precision: nil
+    end
+
+    create_table "perceivablies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "tiffins", null: false
+      t.integer "pabouches", null: false
+      t.datetime "thirstinglies", precision: nil
+      t.datetime "postholders", precision: nil
+    end
+
+    create_table "overflutters", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.datetime "reuplifts", precision: nil
+      t.datetime "clutterers", precision: nil
+      t.datetime "pastorages", precision: nil
+      t.string "diazoates"
+      t.string "extrasolars"
+    end
+
+    create_table "rebundles", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "hellenophiles", limit: 36, null: false
+      t.string "paraquinones", null: false
+      t.integer "earthfasts", null: false
+      t.integer "amblotics", null: false
+      t.datetime "meggies", precision: nil
+      t.datetime "vaginolabials", precision: nil
+    end
+
+    create_table "impressionistics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "rabies", null: false
+      t.string "pitchworks", null: false
+      t.string "scalenohedrons", null: false
+      t.datetime "janizarians", precision: nil
+      t.datetime "capillarities", precision: nil
+      t.boolean "snaggies", default: true, null: false
+      t.boolean "hammermen", default: false, null: false
+      t.boolean "neohexanes", default: false, null: false
+      t.boolean "earlinesses", default: false, null: false
+      t.boolean "tricksinesses", default: false, null: false
+      t.datetime "fishgarths", precision: nil
+      t.datetime "capacitativlies", precision: nil
+      t.string "dependablies", limit: 36, null: false
+    end
+
+    create_table "iras", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "egosyntonics", null: false
+      t.string "musklikes", null: false
+      t.string "egotheisms"
+      t.string "manslaughterers"
+      t.string "quinquenerveds"
+      t.datetime "electrofusions", precision: nil
+      t.datetime "eustaces", precision: nil
+      t.string "floriculturals", limit: 36, null: false
+    end
+
+    create_table "overawes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "materialisticals", limit: 36, null: false
+      t.string "strawyards", null: false
+      t.string "dournesses", null: false
+      t.string "shudderinglies", null: false
+      t.string "eleutheropetalous", null: false
+      t.datetime "coronions", precision: nil
+      t.datetime "obduratelies", precision: nil
+    end
+
+    create_table "affiliables", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.text "archcheaters"
+      t.text "retrenches"
+      t.text "pinchables"
+      t.text "archons"
+      t.datetime "lifesomenesses", precision: nil
+      t.datetime "flitchens", precision: nil
+    end
+
+    create_table "mechanicointellectuals", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "laminoses", null: false
+      t.string "akhrots", null: false
+      t.boolean "wefts", default: false, null: false
+      t.datetime "radiophonies", precision: nil
+      t.datetime "daimonions", precision: nil
+      t.integer "canaliferous"
+      t.integer "ornithophilies"
+      t.datetime "erythrines", precision: nil
+      t.datetime "subjectdoms", precision: nil
+      t.string "labelers"
+      t.string "scenarizes", limit: 36, null: false
+    end
+
+    create_table "viniferas", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "tyrannosaurs", limit: 36, null: false
+      t.string "thionurates", null: false
+      t.string "ermanriches", null: false
+      t.string "sprylies", null: false
+      t.datetime "revelabilities", precision: nil
+      t.datetime "taipans", precision: nil
+    end
+
+    create_table "protovillains", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "greenwings"
+      t.string "coths"
+      t.datetime "stainlesses", precision: nil, null: false
+      t.datetime "nameables", precision: nil, null: false
+      t.boolean "lancemen", default: false, null: false
+      t.bigint "subordinatinglies"
+      t.string "sticklikes"
+      t.string "undifferents"
+      t.string "optates"
+      t.date "negationists"
+      t.string "materializees"
+      t.boolean "sawmons"
+      t.string "cantharidaes"
+      t.string "chatelains"
+      t.boolean "agrypnia", default: false
+      t.boolean "arterioplania", default: false
+    end
+
+    create_table "appellants", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "urotoxia", limit: 36, null: false
+      t.bigint "hypanthia", null: false
+      t.bigint "azorians", null: false
+      t.datetime "lusians", precision: nil, null: false
+      t.datetime "mattoids", precision: nil, null: false
+    end
+
+    create_table "dreads", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "demologies", limit: 36, null: false
+      t.bigint "nidamentals", null: false
+      t.date "lents", null: false
+      t.datetime "perisarcs", precision: nil, null: false
+      t.datetime "formablies", precision: nil, null: false
+    end
+
+    create_table "commelinaceous", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "strags", limit: 36, null: false
+      t.bigint "violabilities", null: false
+      t.bigint "diatomaceoids", null: false
+      t.datetime "glubs", precision: nil, null: false
+      t.datetime "cheloniidaes", precision: nil, null: false
+    end
+
+    create_table "fluoroses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "barrers", null: false
+      t.string "arthrodynics", limit: 36, null: false
+      t.bigint "theopneustics", null: false
+      t.decimal "clippables", precision: 16, scale: 2
+      t.decimal "inframontanes", precision: 16, scale: 2
+      t.date "phellodermals"
+      t.datetime "syllabatims", precision: nil, null: false
+      t.datetime "shylocks", precision: nil, null: false
+      t.string "rhizomatous"
+      t.string "unarrays"
+      t.decimal "impressionalists", precision: 16, scale: 2
+      t.decimal "inscripts", precision: 16, scale: 2
+      t.decimal "superclasses", precision: 16, scale: 2
+      t.decimal "hipponosologies", precision: 16, scale: 2
+    end
+
+    create_table "undernurses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "boils", null: false
+      t.string "hoplonemertines", limit: 36, null: false
+      t.bigint "cebells", null: false
+      t.date "nonrepressions", null: false
+      t.decimal "interconvertibilities", precision: 16, scale: 2, null: false
+      t.decimal "enders", precision: 16, scale: 2, null: false
+      t.string "rondeaus", null: false
+      t.datetime "carbanilides", precision: nil, null: false
+      t.datetime "mucusins", precision: nil, null: false
+    end
+
+    create_table "cellulipetals", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "unbeseeminglies", null: false
+      t.bigint "turbidnesses", null: false
+      t.datetime "radiochemistries", precision: nil, null: false
+      t.datetime "gastropneumatics", precision: nil, null: false
+    end
+
+    create_table "tillodontidaes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "molossidaes", limit: 36, null: false
+      t.bigint "paragraphs", null: false
+      t.string "nicols", limit: 36, null: false
+      t.decimal "narwhalians", precision: 16, scale: 2
+      t.decimal "spinetails", precision: 16, scale: 2
+      t.datetime "variolizations", precision: nil, null: false
+      t.datetime "sustainers", precision: nil, null: false
+      t.decimal "psychopannychistics", precision: 16, scale: 2
+      t.decimal "upstamps", precision: 16, scale: 2
+      t.decimal "boatwomen", precision: 16, scale: 2
+      t.decimal "substanches", precision: 16, scale: 2
+      t.date "prothetics"
+      t.string "jejunoduodenals", limit: 36
+      t.boolean "glassinesses", default: false
+    end
+
+    create_table "matchings", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "unregretfulnesses", limit: 36, null: false
+      t.string "makes", limit: 36, null: false
+      t.datetime "quandaries", precision: nil, null: false
+      t.datetime "quininas", precision: nil, null: false
+      t.string "deuteroscopies"
+      t.boolean "overlives"
+      t.bigint "shakes"
+    end
+
+    create_table "zarathustrisms", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "guiltilies", null: false
+      t.string "disquiparancies"
+      t.datetime "ovenfuls", precision: nil, null: false
+      t.datetime "suffragitis", precision: nil, null: false
+      t.string "indivinables"
+    end
+
+    create_table "tregergs", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "provables", limit: 36, null: false
+      t.string "quakinesses", limit: 36, null: false
+      t.string "zonitids", limit: 36, null: false
+      t.decimal "northeasterns", precision: 16, scale: 2, null: false
+      t.datetime "hates", precision: nil, null: false
+      t.datetime "gauds", precision: nil, null: false
+      t.boolean "undisparities", default: false, null: false
+      t.datetime "featherers", precision: nil
+      t.string "poleburns", limit: 36
+    end
+
+    create_table "ipomoeas", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "cambricleafs"
+      t.string "browbounds"
+      t.datetime "unemotioneds", precision: nil, null: false
+      t.datetime "settlings", precision: nil, null: false
+      t.boolean "mucics", default: true
+      t.integer "hanches"
+      t.boolean "handwears", default: false
+      t.string "ungeldeds"
+      t.integer "megadonts"
+      t.bigint "bracinglies"
+      t.bigint "pietes"
+      t.text "inomyositis"
+      t.string "noncontentions", limit: 36, null: false
+    end
+
+    create_table "syres", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "superbnesses"
+      t.string "sobers"
+      t.string "robustious"
+      t.datetime "sacrococcygeus", precision: nil
+      t.datetime "rakits", precision: nil
+    end
+
+    create_table "pergamenians", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "laurinoxylons"
+      t.bigint "sawns"
+      t.string "exognathites"
+      t.date "hymenolepis"
+      t.datetime "exorcisements", precision: nil
+      t.datetime "pawns", precision: nil
+      t.bigint "fetchinglies"
+    end
+
+    create_table "warrantises", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "ambrosia", null: false
+      t.datetime "overraces", precision: nil, null: false
+      t.datetime "conglobulates", precision: nil, null: false
+      t.integer "acromiosternals", limit: 1, default: 0, null: false
+      t.bigint "parasyphilitics"
+      t.text "guyandots"
+    end
+
+    create_table "iridials", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "sainfoins", null: false
+      t.integer "underthings", null: false
+      t.text "spinachlikes", null: false
+      t.bigint "racialities"
+      t.integer "spinozists"
+      t.text "numerablies"
+      t.bigint "bismuthines"
+      t.datetime "zebralikes", precision: nil
+      t.datetime "stomachfullies", precision: nil, null: false
+      t.datetime "silicoaluminates", precision: nil, null: false
+    end
+
+    create_table "mintakas", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "trichomas", null: false
+      t.string "footgangers"
+      t.string "toddicks"
+      t.float "cacoxenites"
+      t.float "vilas"
+      t.datetime "unreturnablies", precision: nil
+      t.integer "stylohyoideans", default: 0
+      t.datetime "managerships", precision: nil
+      t.datetime "preapplications", precision: nil
+    end
+
+    create_table "unnoiseds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "concavers", null: false
+      t.integer "doubloons", null: false
+      t.text "microcombustions", null: false
+      t.bigint "gadoideas"
+      t.integer "mauveines"
+      t.text "outlays"
+      t.bigint "ussingites"
+      t.datetime "suberifications", precision: nil
+      t.datetime "thynnids", precision: nil, null: false
+      t.datetime "borizes", precision: nil, null: false
+    end
+
+    create_table "balbutiates", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "leads", limit: 36, null: false
+      t.string "unmilteds"
+      t.string "minsitives"
+      t.boolean "eugenicals", default: true, null: false
+      t.bigint "reradiations", null: false
+      t.datetime "unsettlings", precision: nil
+      t.datetime "carbomethoxies", precision: nil
+    end
+
+    create_table "scaphopodous", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "overlightsomes", limit: 36, null: false
+      t.string "tussurs"
+      t.string "chirianas"
+      t.boolean "primordials", default: true, null: false
+      t.integer "packers", null: false
+      t.bigint "sulpharsenics", null: false
+      t.datetime "asceticisms", precision: nil
+      t.datetime "ms", precision: nil
+    end
+
+    create_table "vestments", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "slubberinglies", limit: 36, null: false
+      t.integer "whatsomevers", null: false
+      t.integer "imprescriptiblies", null: false
+      t.bigint "eudeves", null: false
+      t.bigint "leucocytes"
+      t.boolean "protervities", default: true, null: false
+      t.boolean "unswatheds", default: true, null: false
+      t.text "praiselesses"
+      t.datetime "cocashweeds", precision: nil
+      t.datetime "educives", precision: nil
+      t.string "flageolets"
+      t.bigint "unacclimations"
+      t.string "roughdrafts", default: "check_date", null: false
+      t.boolean "arvicolas", default: false, null: false
+      t.boolean "imperscriptibles", default: false, null: false
+    end
+
+    create_table "parallelogrammatics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "sublettables", limit: 36, null: false
+      t.integer "consultaries", null: false
+      t.bigint "lappings"
+      t.string "stampedinglies"
+      t.bigint "termen", null: false
+      t.datetime "foreigneerings", precision: nil
+      t.datetime "wappingers", precision: nil
+    end
+
+    create_table "transpleurals", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "maegbotes", limit: 36, null: false
+      t.bigint "profeminisms", null: false
+      t.bigint "oxaluramides", null: false
+      t.bigint "sargus", null: false
+      t.date "snatchilies", null: false
+      t.datetime "redemptives", precision: nil
+      t.datetime "sinians", precision: nil
+    end
+
+    create_table "heikums", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "chiastoneurals", limit: 36, null: false
+      t.string "chais", limit: 36, null: false
+      t.integer "sawsetters", null: false
+      t.datetime "pitcairnia", precision: nil
+      t.datetime "urodelous", precision: nil
+      t.bigint "orthoarsenites"
+      t.boolean "deacetylates", null: false
+      t.boolean "prepositionallies", default: false, null: false
+      t.bigint "rutters", null: false
+      t.bigint "scrutatories", null: false
+      t.boolean "halfpennies", default: false, null: false
+    end
+
+    create_table "ambilians", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "superprosperous"
+      t.string "campers"
+      t.string "seaghans"
+      t.string "zoolatries", limit: 36, null: false
+      t.datetime "baldribs", precision: nil
+      t.datetime "nonfenestrateds", precision: nil
+      t.boolean "archtraitors", default: true, null: false
+      t.boolean "braidisms"
+    end
+
+    create_table "lamelloses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "semiperipheries", limit: 36, null: false
+      t.datetime "orpheonists", precision: nil, null: false
+      t.string "novatives", null: false
+      t.string "jogs", null: false
+      t.string "mogadors", null: false
+      t.bigint "biniodides", null: false
+      t.datetime "knaves", precision: nil
+      t.datetime "fractionals", precision: nil
+    end
+
+    create_table "hexadics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "copremia"
+      t.bigint "imitatrixes"
+      t.string "superabominables"
+      t.decimal "polyacoustics", precision: 16, scale: 2, null: false
+      t.string "splashinglies"
+      t.string "neifs"
+      t.date "exceptivelies"
+      t.string "conusors"
+      t.bigint "lomenta", null: false
+      t.string "anthocerotes"
+      t.string "pompilus", limit: 36, null: false
+      t.datetime "unrebuffablies", precision: nil
+      t.datetime "nonvisitings", precision: nil
+      t.string "firelocks"
+      t.integer "homeoplastics", limit: 1
+      t.string "coprides"
+    end
+
+    create_table "dysanalytes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "unsparses", limit: 36, null: false
+      t.date "grittles"
+      t.string "unempties"
+      t.string "aves"
+      t.string "furunculoses"
+      t.string "balistes"
+      t.string "prosopalgia"
+      t.bigint "ulcerations", null: false
+      t.bigint "selenates", null: false
+      t.datetime "overgenerallies", precision: nil
+      t.datetime "gonals", precision: nil
+    end
+
+    create_table "persecutresses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.integer "uncurseds", null: false
+      t.string "granuloses", limit: 36, null: false
+      t.datetime "slantingways", precision: nil
+      t.datetime "phyllomorphoses", precision: nil
+    end
+
+    create_table "viscachas", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.integer "uncrisps", null: false
+      t.integer "barbacous", null: false
+      t.datetime "sphenomaxillaries", precision: nil
+      t.datetime "isopiestics", precision: nil
+    end
+
+    create_table "mesepithelia", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "varnishments", null: false
+      t.text "shorters"
+      t.datetime "cycloses", precision: nil, null: false
+      t.datetime "subpermanents", precision: nil, null: false
+    end
+
+    create_table "anemometrographics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "medullations", null: false
+      t.decimal "masculinists", precision: 16, scale: 15, default: "0.0"
+      t.decimal "textarians", precision: 16, scale: 15, default: "0.0"
+      t.text "thymelaeales"
+      t.text "unlanterneds"
+      t.datetime "kulahs", precision: nil, null: false
+      t.datetime "debouchments", precision: nil, null: false
+    end
+
+    create_table "brigalows", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "peakilies", null: false
+      t.bigint "mymarids", null: false
+      t.datetime "spintexts", precision: nil
+      t.datetime "geminates", precision: nil
+    end
+
+    create_table "expeditates", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "ileus", limit: 36, null: false
+      t.string "triggereds", limit: 36, null: false
+      t.datetime "picos", precision: nil, null: false
+      t.datetime "cervisia", precision: nil, null: false
+    end
+
+    create_table "undazzles", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "squames", limit: 36, null: false
+      t.string "actinolites", null: false
+      t.string "curvilinearities", null: false
+      t.string "claudia"
+      t.string "anhemolytics"
+      t.boolean "comamies"
+      t.string "chondrosepta"
+      t.text "unimmortals"
+      t.datetime "untwitcheds", precision: nil, null: false
+      t.datetime "receiverships", precision: nil, null: false
+    end
+
+    create_table "iris", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "phanerocephalous", null: false
+      t.bigint "perceptivenesses", null: false
+      t.datetime "pleuralgia", precision: nil
+      t.datetime "ecardinals", precision: nil
+    end
+
+    create_table "albuginitis", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "interfenestrals", null: false
+      t.string "polypodas", null: false
+      t.string "superdeities", null: false
+      t.string "edriophthalmas", null: false
+      t.string "predestines", null: false
+      t.string "photometrists", null: false
+      t.string "bruscus", null: false
+      t.string "entrainments", limit: 36, null: false
+      t.datetime "balangays", precision: nil
+      t.datetime "clamworms", precision: nil
+    end
+
+    create_table "progenities", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "frecklishes", limit: 36, null: false
+      t.datetime "slushes", precision: nil
+      t.datetime "scrums", precision: nil
+      t.bigint "promiscuouslies", null: false
+      t.bigint "selfishlies", null: false
+    end
+
+    create_table "virtuosities", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "unlearneds", null: false
+      t.string "proreservationists", limit: 36, null: false
+      t.datetime "pilikais", precision: nil
+      t.datetime "stickweeds", precision: nil
+      t.bigint "oscars", null: false
+    end
+
+    create_table "gagees", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "nebulations", null: false
+      t.string "kiwanis", null: false
+      t.string "blackwashes", null: false
+      t.string "nonsensibles"
+      t.string "pieplants"
+      t.string "undotteds", null: false
+      t.string "procurements", limit: 36, null: false
+      t.datetime "saccharocolloids", precision: nil
+      t.datetime "paschas", precision: nil
+    end
+
+    create_table "halvelings", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "lurkinglies", limit: 36, null: false
+      t.string "servients", limit: 256, null: false
+      t.string "iguanodontidaes", limit: 512, null: false
+      t.integer "biloculinas", null: false
+      t.integer "sonnetwises", default: 0
+      t.integer "tettigoniidaes", default: 0
+      t.datetime "toshes", precision: nil
+      t.datetime "polyphagies", precision: nil
+      t.datetime "placentitis", precision: nil
+      t.datetime "forgeries", precision: nil
+      t.string "alamedas", limit: 256
+      t.string "unhoardeds", limit: 36
+    end
+
+    create_table "rhodes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "postliminaries", null: false
+      t.string "megachiles", null: false
+      t.string "transplendentlies", null: false
+      t.string "furiosos"
+      t.datetime "numerations", precision: nil
+      t.datetime "homeopathicallies", precision: nil
+      t.string "vougeots", limit: 36
+    end
+
+    create_table "pentaploidics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "idiographs", limit: 36, null: false
+      t.datetime "bromobenzenes", precision: nil
+      t.datetime "widespreadnesses", precision: nil
+      t.bigint "biogeneses", null: false
+      t.bigint "dermolyses", null: false
+    end
+
+    create_table "fussocks", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "pelecypodas", limit: 36, null: false
+      t.string "catamarans", limit: 256, null: false
+      t.string "polyodontoids", limit: 512
+      t.string "mammonistics", limit: 256, null: false
+      t.datetime "thoftfellows", precision: nil
+      t.datetime "thiocarbamics", precision: nil
+      t.string "aquiculturists", limit: 50
+      t.boolean "immaterializes", default: false
+    end
+
+    create_table "spinners", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "coadnates", limit: 36, null: false
+      t.integer "toylikes", null: false
+      t.datetime "subessentials", precision: nil
+      t.datetime "sheristadars", precision: nil
+      t.bigint "quibblinglies"
+    end
+
+    create_table "nontrigonometricals", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "corsites", limit: 36, null: false
+      t.bigint "crackers", null: false
+      t.boolean "rhodanates"
+      t.datetime "cholelithotomies", precision: nil
+      t.datetime "foremisgivings", precision: nil
+      t.bigint "tarragons"
+      t.bigint "panades"
+      t.datetime "uncassocks", precision: nil
+      t.float "mushaas", default: 0.0, null: false
+      t.float "gnomonia", default: 0.0, null: false
+    end
+
+    create_table "publicizes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "nyctipithecus", limit: 256, null: false
+      t.string "reallotments", limit: 256
+      t.string "guildries", limit: 256
+      t.string "nonaspirates", limit: 256, null: false
+      t.string "cheeklesses", limit: 36, null: false
+      t.datetime "unforetolds", precision: nil
+      t.datetime "snapberries", precision: nil
+      t.string "confitures", limit: 512
+    end
+
+    create_table "superwagers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "scobiforms", null: false
+      t.string "eurobins", null: false
+      t.string "triovulates", null: false
+      t.string "bibliopegistics", null: false
+      t.boolean "unwelcomelies", default: false, null: false
+      t.datetime "housemistresses", precision: nil
+      t.datetime "brochans", precision: nil
+      t.string "hurrieds", limit: 36, null: false
+      t.integer "begalls"
+    end
+
+    create_table "stylogonidia", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "eophytics", limit: 36, null: false
+      t.string "philologastries", limit: 36, null: false
+      t.string "prescribers", limit: 36, null: false
+      t.datetime "dragoons", precision: nil, null: false
+      t.datetime "royalisms", precision: nil, null: false
+    end
+
+    create_table "plasterlikes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "tremellas", null: false
+      t.bigint "scissurellids", null: false
+      t.string "neurotonics", limit: 36, null: false
+      t.datetime "interjealousies", precision: nil
+      t.datetime "guejarites", precision: nil
+      t.string "nervisms", limit: 36
+    end
+
+    create_table "pterygia", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "fatuitous", limit: 36, null: false
+      t.bigint "ornithoids", null: false
+      t.bigint "unelboweds"
+      t.string "whups", null: false
+      t.string "narratresses", null: false
+      t.string "omphalopagus", null: false
+      t.string "bankruptisms"
+      t.string "tonemes"
+      t.string "crannocks"
+      t.datetime "sclavs", precision: nil, null: false
+      t.datetime "gasterothecals", precision: nil, null: false
+    end
+
+    create_table "coseisms", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "cornelius", null: false
+      t.bigint "ovaliforms", null: false
+      t.string "longsomelies", limit: 36, null: false
+      t.datetime "underhandedlies", precision: nil
+      t.datetime "grapes", precision: nil
+    end
+
+    create_table "theatrophiles", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "quadruplets"
+      t.bigint "succinites", null: false
+      t.string "daubings"
+      t.string "singultous", null: false
+      t.datetime "grippies", precision: nil
+      t.datetime "propaedeutics", precision: nil
+      t.string "continuedlies", limit: 36, null: false
+    end
+
+    create_table "contextureds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "levants", null: false
+      t.string "handistrokes", null: false
+      t.string "stegocephalia", limit: 36, null: false
+      t.datetime "monocycles", precision: nil
+      t.datetime "carobas", precision: nil
+    end
+
+    create_table "unbrowneds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "agrobiologists", null: false
+      t.string "venedotians", null: false
+      t.string "purries"
+      t.string "punctations"
+      t.string "antismokings"
+      t.string "omoplatoscopies"
+      t.string "nasillates"
+      t.string "pyocyanases"
+      t.datetime "bibliographicals", precision: nil, null: false
+      t.datetime "bertrums", precision: nil
+      t.integer "encrinoideas", default: 0, null: false
+      t.datetime "merops", precision: nil
+      t.datetime "sultanisms", precision: nil
+      t.string "etiolins"
+      t.string "petitionees"
+      t.string "anywises", limit: 36, null: false
+      t.string "hemipterans"
+      t.string "stintedlies", limit: 36
+      t.string "blees", default: "BusinessCenter::Recommendation", null: false
+      t.string "autoinoculations"
+      t.boolean "waygangs"
+    end
+
+    create_table "harrs", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "zygantrums", limit: 36, null: false
+      t.string "scintles", limit: 36, null: false
+      t.datetime "messianicallies"
+      t.datetime "shrees"
+      t.datetime "trioxazines", null: false
+      t.datetime "droppers"
+      t.datetime "severities", precision: nil, null: false
+      t.datetime "hydroideans", precision: nil, null: false
+      t.string "kangaroos", limit: 36
+    end
+
+    create_table "canonics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "hyperinsulinizes"
+      t.bigint "applenuts"
+      t.datetime "censoriouslies", precision: nil
+      t.datetime "siphonophorans", precision: nil
+    end
+
+    create_table "cougnars", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "unshamables"
+      t.text "dirtilies"
+      t.datetime "promisables", precision: nil
+      t.datetime "sociologicallies", precision: nil
+    end
+
+    create_table "sesamoiditis", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "scabiosas", limit: 36, null: false
+      t.string "apterygials", null: false
+      t.datetime "strinkles"
+      t.datetime "pileworms"
+      t.datetime "circuiters", null: false
+      t.datetime "trialogues"
+      t.datetime "mountings", precision: nil, null: false
+      t.datetime "oleoses", precision: nil, null: false
+      t.string "faradocontractilities", limit: 36
+    end
+
+    create_table "tamables", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "udders"
+      t.bigint "accessarinesses"
+      t.string "isobathics"
+      t.string "hylegiacals"
+      t.integer "sunburnednesses"
+      t.string "consonantics"
+      t.integer "kecklings"
+      t.string "address_line_1"
+      t.integer "address_line_1_distance"
+      t.string "address_line_2"
+      t.integer "address_line_2_distance"
+      t.string "golees"
+      t.integer "holdups"
+      t.string "baggagemen"
+      t.integer "slatteds"
+      t.string "shufflewings"
+      t.integer "interpunctions"
+      t.string "stoodens"
+      t.integer "monarchists"
+      t.float "laparoenterotomies"
+      t.integer "millies"
+      t.datetime "securitans", precision: nil
+      t.datetime "photochromographies", precision: nil
+      t.boolean "nucleoplasmatics"
+      t.boolean "repermits"
+      t.boolean "address_line_1_success"
+      t.boolean "address_line_2_success"
+      t.boolean "laggins"
+      t.boolean "balsas"
+      t.boolean "geronomites"
+      t.boolean "altheas"
+      t.boolean "youngnesses"
+      t.boolean "damaginglies"
+      t.boolean "eleemosynaries"
+      t.boolean "indicators"
+      t.boolean "serapeas"
+      t.boolean "goniatites"
+      t.boolean "urbifies"
+      t.boolean "preaxiallies"
+      t.boolean "interresponsibilities"
+      t.boolean "sponsalia"
+      t.boolean "usuries"
+    end
+
+    create_table "hydrosulphites", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "shrubwoods", null: false
+      t.bigint "oarlocks", null: false
+      t.datetime "dashees", precision: nil, null: false
+      t.datetime "huddlers", precision: nil, null: false
+      t.date "sargos", null: false
+      t.date "ninnyishes", null: false
+      t.date "parchies", null: false
+      t.date "provocativenesses", null: false
+    end
+
+    create_table "myomantics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.datetime "atheologicallies", precision: nil, null: false
+      t.datetime "romances", precision: nil, null: false
+      t.bigint "slavisms", null: false
+      t.string "wastebaskets", null: false
+    end
+
+    create_table "roundworms", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "arterials"
+      t.bigint "suprahumen"
+      t.boolean "underboughts", default: false
+      t.datetime "sleets", precision: nil
+      t.integer "polystomellas", default: 0
+      t.datetime "phosphosilicates", precision: nil
+      t.datetime "nonvertebrals", precision: nil
+    end
+
+    create_table "selenes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "academials"
+      t.string "liparoceles"
+      t.datetime "curtails", precision: nil
+      t.datetime "tantalizingnesses", precision: nil
+      t.boolean "yorkshiremen", default: false, null: false
+      t.datetime "nonintegrities", precision: nil
+      t.string "unworshipings"
+      t.string "lanateds"
+      t.string "cerebralisms"
+    end
+
+    create_table "simsons", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "cheerinesses", null: false
+      t.bigint "statisticallies"
+      t.string "impitiablies", null: false
+      t.string "diplocaulescents"
+      t.string "saltworks", null: false
+      t.string "amphiblastics"
+      t.datetime "unexercisables", precision: nil, null: false
+      t.datetime "streamlets", precision: nil, null: false
+      t.bigint "hippocausts"
+      t.datetime "librarians", precision: nil
+      t.boolean "pinoleums", null: false
+      t.boolean "deuteromorphics", null: false
+      t.string "enthusiasticals", limit: 36, null: false
+      t.string "duplifies"
+      t.bigint "generales", null: false
+      t.string "dysphagics"
+      t.string "sphenograms"
+    end
+
+    create_table "amurcas", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "ascigerous", null: false
+      t.bigint "rangemen", null: false
+      t.date "trollers", null: false
+      t.string "horsehoofs", null: false
+      t.datetime "chondropterygious", precision: nil, null: false
+      t.datetime "laymanships", precision: nil, null: false
+      t.bigint "amueixas"
+    end
+
+    create_table "windrowers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "birefringents", null: false
+      t.datetime "interlocates", precision: nil, null: false
+      t.bigint "amongsts", null: false
+      t.datetime "trophophores", precision: nil
+      t.datetime "stercoranisms", precision: nil
+      t.bigint "orlops", default: 0, null: false
+    end
+
+    create_table "orseilles", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "ekrons", null: false
+      t.boolean "margarodids", default: false, null: false
+      t.string "palaeoniscums", null: false
+      t.text "endarchies"
+      t.datetime "ungenuinenesses", precision: nil, null: false
+      t.datetime "imputativelies", precision: nil, null: false
+    end
+
+    create_table "salsillas", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "glandes", limit: 36, null: false
+      t.string "discussibles", limit: 36, null: false
+      t.string "uncodeds", limit: 36, null: false
+      t.datetime "terrages", precision: nil, null: false
+      t.datetime "changers", precision: nil, null: false
+      t.datetime "bandakas", precision: nil
+      t.text "theatries", null: false
+    end
+
+    create_table "interweavings", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "moucharabies", limit: 36, null: false
+      t.string "programmatics", limit: 36, null: false
+      t.datetime "polliniferous", precision: nil, null: false
+      t.datetime "endotheliocytes", precision: nil, null: false
+      t.string "postsphenoidals", null: false
+      t.string "parlandos", null: false
+      t.string "cotos", null: false
+      t.boolean "definiens", null: false
+      t.boolean "zooxanthellas", null: false
+    end
+
+    create_table "paramounts", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "nonvacuous", null: false
+      t.string "embronzes", null: false
+      t.bigint "rotges", null: false
+      t.bigint "dexiotropics", null: false
+      t.string "reconstitutes", null: false
+      t.datetime "osteodynia", precision: nil
+      t.datetime "scirtopodas", precision: nil
+      t.text "sawmillers"
+    end
+
+    create_table "hyperchlorhydria", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.date "foredenounces", null: false
+      t.date "mustelidaes", null: false
+      t.string "semiresolutes", null: false
+      t.string "oecodomics", null: false
+      t.bigint "logographicals", null: false
+      t.string "creatines", null: false
+      t.datetime "grouchinglies", precision: nil
+      t.datetime "xanthochroids", precision: nil
+      t.datetime "hyposynergia", precision: nil
+      t.datetime "eatings", precision: nil
+      t.string "awaits"
+      t.text "steamilies"
+      t.string "gals", limit: 36
+    end
+
+    create_table "men", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "gascoignies", null: false
+      t.string "homotaxiallies", null: false
+      t.string "charcas"
+      t.datetime "wrastlers", precision: nil, null: false
+      t.datetime "ratskellers", precision: nil, null: false
+      t.boolean "implants", default: false
+      t.text "suppressivelies", size: :medium
+      t.string "limmocks"
+      t.string "subbasals"
+      t.string "gyracanthus", limit: 36, null: false
+    end
+
+    create_table "scummers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.date "superuniverses"
+      t.boolean "infracts"
+      t.datetime "cheirotheria", precision: nil, null: false
+      t.datetime "laggeds", precision: nil, null: false
+      t.text "aroars", size: :long
+    end
+
+    create_table "potamogetons", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "pugilistics", limit: 36, null: false
+      t.bigint "wynds", null: false
+      t.string "zygophorics", null: false
+      t.string "importlesses"
+      t.string "unrecusants", null: false
+      t.string "exclamationals"
+      t.datetime "tigerhoods", precision: nil, null: false
+      t.datetime "campholytics", precision: nil, null: false
+      t.datetime "undesigninglies", precision: nil, null: false
+      t.string "cephalochords"
+    end
+
+    create_table "cardiohepatics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "flankies"
+      t.decimal "atbashes", precision: 16, scale: 4
+      t.datetime "plushinesses", precision: nil
+      t.datetime "collectables", precision: nil
+      t.datetime "sandwiches", precision: nil
+      t.datetime "agrania", precision: nil
+      t.datetime "locomotilities", precision: nil
+      t.bigint "nearests"
+      t.string "cytomas"
+      t.string "lauraldehydes"
+      t.integer "misimagines"
+      t.string "serrulates", default: "72_HOUR", null: false
+    end
+
+    create_table "negotiators", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "silicospongiaes", null: false
+      t.date "electrodialyzers", null: false
+      t.datetime "qualityships", precision: nil, null: false
+      t.datetime "dissepimentals", precision: nil, null: false
+    end
+
+    create_table "escapelesses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.decimal "chrysopoetics", precision: 16, scale: 2, null: false
+      t.bigint "unalleviateds", null: false
+      t.bigint "brawns"
+      t.datetime "byronics", precision: nil
+      t.datetime "gradals", precision: nil
+      t.bigint "hemiglossals"
+      t.bigint "sarcoids"
+      t.integer "jabberwockians", limit: 1, default: 1
+      t.string "fibrinogenics"
+    end
+
+    create_table "achamoths", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.decimal "libelists", precision: 16, scale: 2, null: false
+      t.bigint "superrequirements", null: false
+      t.datetime "undisappointings", precision: nil
+      t.datetime "chanks", precision: nil
+      t.integer "easelesses", limit: 1, default: 0
+      t.bigint "ascidioidas"
+      t.bigint "dicyclicas"
+    end
+
+    create_table "previsors", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.decimal "reintuitives", precision: 16, scale: 2, null: false
+      t.date "caudles", null: false
+      t.bigint "lemurians", null: false
+      t.datetime "folkies", precision: nil
+      t.datetime "unmates", precision: nil
+      t.integer "afterhatches", limit: 1, default: 0
+    end
+
+    create_table "stratagemicals", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.date "prigdoms", null: false
+      t.date "dodgers"
+      t.decimal "overbumptious", precision: 16, scale: 2, null: false
+      t.bigint "showbirds"
+      t.string "tsetses"
+      t.string "address_line_1"
+      t.string "address_line_2"
+      t.string "address_line_3"
+      t.string "partners"
+      t.string "mutablenesses"
+      t.string "oitavas"
+      t.string "disconcertinglies"
+      t.string "branglings"
+      t.integer "etiologicallies"
+      t.datetime "seigneuries", precision: nil
+      t.string "interchondrals"
+      t.string "vicelesses"
+      t.integer "geometrines"
+      t.datetime "handeds", precision: nil
+      t.boolean "nitrolimes", default: false, null: false
+      t.date "discounters"
+      t.date "unattaineds"
+      t.bigint "pallies"
+      t.string "unsuspicions"
+      t.string "conchiforms", default: "sent", null: false
+      t.string "unconflictinglies"
+      t.datetime "pibcorns", precision: nil
+      t.datetime "mirthfulnesses", precision: nil
+      t.datetime "payments", precision: nil
+      t.integer "registrabilities", limit: 1, default: 1
+      t.integer "unsocials"
+      t.bigint "macignos"
+      t.string "geomanticals"
+      t.string "sargassos"
+      t.bigint "misinferences"
+      t.string "clinographics"
+    end
+
+    create_table "zeugobranchia", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "vinies"
+      t.bigint "recommands", null: false
+      t.string "yills", null: false
+      t.datetime "pectinids", precision: nil
+      t.datetime "libaments", precision: nil
+      t.string "tightlies", null: false
+      t.datetime "sulfindylics", precision: nil
+      t.integer "floccus"
+      t.bigint "submittals"
+    end
+
+    create_table "circumrotates", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "postpubics", null: false
+      t.string "misobediences", null: false
+      t.datetime "scintillouslies", precision: nil, null: false
+      t.datetime "xenagogues", precision: nil, null: false
+    end
+
+    create_table "grubhoods", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "preacquaints", null: false
+      t.string "poormasters"
+      t.bigint "obolets"
+      t.string "underlets"
+      t.datetime "trachealgia", precision: nil
+      t.datetime "procyoninaes", precision: nil
+      t.string "courtlies", null: false
+      t.datetime "dyadics", precision: nil
+    end
+
+    create_table "phytotaxonomies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "panmixia", null: false
+      t.bigint "ramnes", null: false
+      t.string "nonacquittals", null: false
+      t.string "termages", null: false
+      t.bigint "impeachables", null: false
+      t.datetime "monorhythmics", precision: nil, null: false
+      t.datetime "prebudgetaries", precision: nil, null: false
+      t.datetime "phytocidals", precision: nil, null: false
+    end
+
+    create_table "sloes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "dicodeines", null: false
+      t.string "clastics", null: false
+      t.text "checkmen"
+      t.string "anthracnoses", null: false
+      t.string "encrinoids", null: false
+      t.bigint "caboodles"
+      t.string "russomaniacs"
+      t.datetime "stosstons", precision: nil, null: false
+      t.datetime "rosalia", precision: nil
+      t.datetime "acetylizers", precision: nil
+      t.bigint "caliphates"
+      t.integer "interaulics", default: 0, null: false
+      t.datetime "dabbies", precision: nil
+      t.bigint "assaulters"
+      t.string "appendageds"
+      t.string "cribroses"
+    end
+
+    create_table "trachomas", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "hazardlesses"
+      t.string "nectarials", null: false
+      t.text "blusterous"
+      t.bigint "cerebrins"
+      t.string "minimalisms"
+      t.string "nyctitropics", null: false
+      t.string "talabons", null: false
+      t.integer "shepstares", default: 0, null: false
+      t.datetime "neuropsychiatrics", precision: nil
+      t.datetime "wiretails", precision: nil
+      t.bigint "colletes"
+      t.string "thermosettings"
+      t.string "atticomastoids"
+    end
+
+    create_table "faithworthies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "provostships", null: false
+      t.string "misunderstandinglies", null: false
+      t.datetime "unipolarities", precision: nil
+      t.datetime "launches", precision: nil
+      t.string "familiarizers", null: false
+      t.text "catocalids"
+    end
+
+    create_table "rerackers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "juxtapylorics"
+      t.string "podostomatous"
+      t.integer "unjilteds"
+      t.datetime "reactionarisms", precision: nil
+      t.datetime "aciculateds", precision: nil, null: false
+      t.datetime "dufoils", precision: nil, null: false
+      t.string "masonics"
+    end
+
+    create_table "myoendocarditis", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "forepreparations", null: false
+      t.string "choukas", null: false
+      t.datetime "treatylesses", precision: nil
+      t.datetime "itineracies", precision: nil
+      t.string "iwis", null: false
+      t.string "brachistocephalous"
+      t.string "sharons"
+      t.string "tupeks"
+      t.boolean "vasoconstrictives"
+    end
+
+    create_table "dubiousnesses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "forepasts"
+      t.string "chickarees"
+      t.bigint "flannels", null: false
+      t.datetime "unempoisoneds", precision: nil, null: false
+      t.datetime "shopfolks", precision: nil, null: false
+    end
+
+    create_table "psychrometrics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.datetime "tubiflorous", precision: nil
+      t.boolean "contemplators"
+      t.datetime "predisadvantages", precision: nil, null: false
+      t.datetime "lips", precision: nil, null: false
+    end
+
+    create_table "nasturtions", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "barghests"
+      t.string "nonlicenseds"
+      t.bigint "gallanilides"
+      t.string "duplicitas"
+      t.string "acis"
+      t.datetime "gynecics", precision: nil
+      t.datetime "ilicaceous", precision: nil
+      t.string "rhamnohexoses"
+      t.string "unthievishes"
+      t.string "weichselwoods"
+      t.bigint "chargees"
+      t.bigint "staphyloraphics"
+    end
+
+    create_table "tritocerebrals", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "meretriciouslies", null: false
+      t.string "pereiras", null: false
+      t.string "diazoics"
+      t.string "obtusilobous"
+      t.string "kelpers"
+      t.string "synthermals"
+      t.boolean "hydroperitoneums"
+      t.string "pseudophenanthrenes"
+      t.boolean "unparcelings"
+      t.datetime "unhasties", precision: nil
+      t.bigint "arsenicisms", null: false
+      t.datetime "paralepses", precision: nil, null: false
+      t.datetime "elizabethanisms", precision: nil, null: false
+      t.string "reflexologicals"
+      t.string "latookas"
+      t.bigint "gainings"
+      t.string "edriophthalmians"
+      t.string "adolescences"
+      t.string "leiotropics", limit: 36, null: false
+    end
+
+    create_table "floreta", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "whimlings", null: false
+      t.string "periosteorrhaphies", null: false
+      t.string "phacolyses", null: false
+      t.integer "nurtures", default: 0, null: false
+      t.datetime "alfaquis", precision: nil, null: false
+      t.datetime "firms", precision: nil, null: false
+      t.bigint "roaringlies"
+      t.string "falciparums"
+    end
+
+    create_table "altisonants", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "phosphorogenics", null: false
+      t.string "deathifies"
+      t.text "beardoms"
+      t.datetime "garibas", precision: nil
+      t.datetime "dinus", precision: nil
+      t.string "mucous", null: false
+      t.string "crookbilleds"
+    end
+
+    create_table "overbakes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "encoignures"
+      t.string "colombins"
+      t.string "oversecurities"
+      t.datetime "pseudoparaplegia", precision: nil, null: false
+      t.datetime "catabatics", precision: nil, null: false
+      t.bigint "equidistances"
+      t.bigint "compossibilities"
+      t.boolean "covites", default: false
+      t.bigint "jaspis"
+      t.string "burries"
+      t.boolean "impregnates", default: true
+      t.string "consolements"
+      t.string "dronies"
+      t.datetime "kingfishes", precision: nil
+      t.string "colloquialities"
+      t.boolean "hydroxylics", default: false
+      t.boolean "whirlwinds", default: false
+      t.string "tabbers"
+      t.string "proganosauria"
+      t.string "tarantularies"
+      t.string "crablikes"
+      t.string "preadolescents", limit: 36, null: false
+    end
+
+    create_table "provences", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "traverselies", null: false
+      t.bigint "perseites", null: false
+      t.datetime "maternals", precision: nil
+      t.datetime "attics", precision: nil
+      t.string "misconstructs"
+    end
+
+    create_table "washtroughs", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "hemachates", limit: 36, null: false
+      t.bigint "posticums", null: false
+      t.boolean "brogans", null: false
+      t.datetime "battlegrounds", precision: nil
+      t.datetime "uninconvenienceds", precision: nil
+    end
+
+    create_table "starringlies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "hotta", null: false
+      t.bigint "preteritions", null: false
+      t.boolean "prevalencies", default: false, null: false
+      t.string "peshkars"
+      t.string "butterbirds"
+      t.string "inauguratories"
+      t.string "monologicals"
+      t.datetime "slumpproofs", precision: nil, null: false
+      t.datetime "exopterygotous", precision: nil, null: false
+      t.boolean "antimerics", default: false, null: false
+      t.string "melanistics", limit: 36
+    end
+
+    create_table "gabionages", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "cradlemates", limit: 36, null: false
+      t.bigint "plenteous", null: false
+      t.bigint "cosmoramics", null: false
+      t.datetime "unbluestockingishes", precision: nil
+      t.datetime "shuttlecocks", precision: nil
+      t.text "pleurectomies"
+      t.datetime "skeeters", precision: nil, null: false
+      t.datetime "pamphiliidaes", precision: nil, null: false
+    end
+
+    create_table "apoblasts", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "nomistics", limit: 36, null: false
+      t.bigint "nonoverlappings", null: false
+      t.string "boomlets", null: false
+      t.string "pancreaticoduodenostomies", default: "not_started", null: false
+      t.datetime "spermaries", precision: nil, null: false
+      t.datetime "supramaximals", precision: nil, null: false
+    end
+
+    create_table "cacotypes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "multivoiceds"
+      t.bigint "flankers"
+      t.boolean "furthermosts"
+      t.datetime "heliometries", precision: nil
+      t.string "perbromides"
+      t.boolean "dentines"
+      t.integer "nagatelites", default: 0
+      t.datetime "cinderous", precision: nil
+      t.datetime "deciduals", precision: nil
+      t.boolean "luteolous"
+      t.datetime "tintinnabulants", precision: nil
+      t.string "sufficers"
+      t.text "azaleas"
+      t.text "antihemorrheidals"
+      t.boolean "aftershafts", default: false
+      t.text "factices"
+      t.integer "grandnesses"
+    end
+
+    create_table "trigonellas", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "ballers", limit: 36, null: false
+      t.bigint "misrealizes", null: false
+      t.text "spillovers"
+      t.text "onomatopoeians"
+      t.text "gandermooners"
+      t.text "bradyspermatisms"
+      t.text "jethros"
+      t.text "gonimia"
+      t.text "redubbers"
+      t.text "outpops"
+      t.text "fishhouses"
+      t.datetime "undersingings", precision: nil
+      t.datetime "wasps", precision: nil
+    end
+
+    create_table "unfacadeds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "replods", limit: 36, null: false
+      t.string "lenders", limit: 36, null: false
+      t.string "tumidnesses", null: false
+      t.string "objectivists"
+      t.datetime "contractibles", precision: nil
+      t.string "unpedagogicals"
+      t.datetime "nebaliidaes", precision: nil
+      t.datetime "elecampanes", precision: nil, null: false
+      t.datetime "uncharacters", precision: nil, null: false
+    end
+
+    create_table "plasmomas", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "unentanglements"
+      t.integer "submania"
+      t.decimal "septenates", precision: 16, scale: 2, default: "0.0", null: false
+      t.decimal "antimetatheses", precision: 16, scale: 2, default: "0.0", null: false
+      t.date "droitsmen"
+      t.datetime "puberties", precision: nil
+      t.datetime "buchanites", precision: nil
+      t.bigint "disenamours"
+      t.bigint "initiatresses"
+      t.decimal "anientes", precision: 16, scale: 2, default: "0.0"
+      t.string "dipters"
+      t.bigint "nepeta"
+      t.bigint "fowls"
+    end
+
+    create_table "acousticals", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "propessimists", limit: 36, null: false
+      t.bigint "squamiforms", null: false
+      t.string "amylenes", null: false
+      t.datetime "deracinations", precision: nil, null: false
+      t.datetime "monoblepses", precision: nil, null: false
+    end
+
+    create_table "cymoids", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "reabsorptions", null: false
+      t.bigint "redues", null: false
+      t.datetime "merismoids", precision: nil, null: false
+      t.datetime "joylesses", precision: nil, null: false
+    end
+
+    create_table "unverbalizeds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "tetanoids", null: false
+      t.integer "slumproofs", null: false
+      t.integer "nincompooperies"
+      t.datetime "speedinesses", precision: nil
+      t.datetime "remonstrants", precision: nil
+      t.decimal "enteropneustans", precision: 16, scale: 2
+      t.string "arpeggiandos"
+      t.boolean "hemeras", default: false
+      t.boolean "venenousnesses", default: true, null: false
+      t.bigint "counterimaginations"
+    end
+
+    create_table "monopolizes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "tottlishes"
+      t.string "agnoses", null: false
+      t.string "devotionallies", null: false
+      t.boolean "hanoverianizes", default: false
+      t.boolean "digeneous", default: true
+      t.datetime "preconfesses", precision: nil, null: false
+      t.datetime "symptoses", precision: nil, null: false
+      t.boolean "sightworthies", default: true
+      t.string "strophics", limit: 36, null: false
+      t.string "nondisjuncts", null: false
+      t.boolean "embracinglies"
+    end
+
+    create_table "ads", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "reconstructors", limit: 36, null: false
+      t.bigint "splayfoots", null: false
+      t.string "hypersusceptibles", limit: 36, null: false
+      t.string "sciuromorphs", null: false
+      t.string "redshirts", null: false
+      t.string "unbestoweds", null: false
+      t.string "undulatelies", null: false
+      t.datetime "reheaters", precision: nil
+      t.datetime "overracks", precision: nil
+    end
+
+    create_table "tumorlikes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "cylindrelloids", limit: 36, null: false
+      t.bigint "tongans", null: false
+      t.string "whences", null: false
+      t.datetime "synclinoria", precision: nil, null: false
+      t.datetime "labiduridaes", precision: nil, null: false
+    end
+
+    create_table "paleodendrologists", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.integer "margaropus", null: false
+      t.string "petzites", null: false
+      t.string "seemers"
+      t.string "crowsteppeds"
+      t.boolean "felicitators", null: false
+      t.datetime "overtoes", precision: nil, null: false
+      t.datetime "peripharyngeals", precision: nil
+      t.datetime "desuperheaters", precision: nil
+      t.string "antipellagrics", limit: 36, null: false
+      t.boolean "outbridges", default: true, null: false
+    end
+
+    create_table "enarthrodials", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "arrives", limit: 36, null: false
+      t.string "coinclines", null: false
+      t.string "seaweedies", null: false
+      t.string "volatilizations", null: false
+      t.string "exceedinglies", null: false
+      t.datetime "snaffs", precision: nil, null: false
+      t.datetime "gentianworts", precision: nil
+      t.datetime "rompers", precision: nil
+      t.string "wheeleds", limit: 36, null: false
+      t.boolean "kinoplasms", null: false
+      t.boolean "saddleries", null: false
+      t.boolean "animastics", null: false
+    end
+
+    create_table "rebroadcasts", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "besanctifies", limit: 36, null: false
+      t.string "indefinables", limit: 36, null: false
+      t.bigint "harmonicalnesses", null: false
+      t.string "switchbackers", null: false
+      t.string "stercorianisms"
+      t.string "magicalizes"
+      t.string "takoses"
+      t.string "antasthmatics"
+      t.string "apheticallies", null: false
+      t.string "risiblies"
+      t.string "superimpendings"
+      t.string "parvolins"
+      t.string "acetobacters"
+      t.datetime "hyperobtrusives", precision: nil
+      t.datetime "imbrues", precision: nil
+    end
+
+    create_table "pestologists", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "springinglies", limit: 36, null: false
+      t.bigint "vividialyses", null: false
+      t.decimal "knightlinesses", precision: 16, scale: 2, default: "0.0", null: false
+      t.datetime "terebinths", precision: nil, null: false
+      t.datetime "hypopodia", precision: nil, null: false
+    end
+
+    create_table "tenophonies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "unlawfullies"
+      t.bigint "quakerishes"
+      t.datetime "iodohydrins", precision: nil, null: false
+      t.datetime "astropectens", precision: nil, null: false
+      t.string "overgrievous"
+      t.date "misguidinglies"
+      t.boolean "unprobeds"
+      t.string "holometaboles"
+    end
+
+    create_table "shriekinesses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "longevities", limit: 36, null: false
+      t.bigint "prosthodontists", null: false
+      t.bigint "hyperazotemia", null: false
+      t.datetime "travellers", precision: nil
+      t.datetime "vicia", precision: nil
+      t.text "tonalists"
+      t.datetime "birders", precision: nil, null: false
+      t.datetime "catamounts", precision: nil, null: false
+    end
+
+    create_table "kurchines", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "godforsakens", null: false
+      t.bigint "fisheresses", null: false
+      t.date "tepidities"
+      t.datetime "tautologizes", precision: nil
+      t.datetime "oofbirds", precision: nil
+    end
+
+    create_table "piperideines", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "scaletails", limit: 36, null: false
+      t.string "polyploidics", limit: 36, null: false
+      t.string "microthyriaceaes", null: false
+      t.datetime "parametrics", precision: nil, null: false
+      t.datetime "cordiceps", precision: nil, null: false
+      t.date "pachydermata", null: false
+      t.date "unsuggestivenesses"
+      t.datetime "incompletions", precision: nil
+      t.datetime "trawlboats", precision: nil
+      t.string "employables", limit: 36
+      t.string "antiquas", null: false
+    end
+
+    create_table "tetragonia", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "titerations"
+      t.string "parapathies"
+      t.string "friedrichsdors"
+      t.date "tachysterols"
+      t.datetime "heliozoics", precision: nil, null: false
+      t.datetime "falsens", precision: nil, null: false
+      t.boolean "vasotripsies", default: false, null: false
+    end
+
+    create_table "bikols", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "bierbalks", limit: 36, null: false
+      t.bigint "racinesses", null: false
+      t.string "pomonals"
+      t.date "indictees"
+      t.datetime "arrearages", precision: nil, null: false
+      t.datetime "unchronologicals", precision: nil, null: false
+    end
+
+    create_table "ensepulchers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "superessentiallies", limit: 36, null: false
+      t.bigint "syssarcoses", null: false
+      t.string "geisotherms", null: false
+      t.string "lairs", null: false
+      t.datetime "worriables", precision: nil, null: false
+      t.datetime "fonticulus", precision: nil, null: false
+      t.datetime "culvertages", precision: nil, null: false
+      t.string "hoolocks"
+      t.string "bonteboks"
+    end
+
+    create_table "decolorations", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "redwoods"
+      t.string "islamizations"
+      t.boolean "conchuelas", default: true
+      t.bigint "unorganizeds"
+      t.datetime "redeemablies", precision: nil, null: false
+      t.datetime "nephrons", precision: nil, null: false
+      t.bigint "isokeraunographics"
+      t.boolean "barts", default: true
+      t.string "antiwarlikes"
+      t.bigint "immunogens"
+      t.datetime "mesoplasts", precision: nil
+      t.string "gloria"
+      t.string "furrowlikes"
+    end
+
+    create_table "hygienists", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "pryses", null: false
+      t.datetime "kerogens", precision: nil
+      t.datetime "orihons", precision: nil
+      t.string "persalts", null: false
+      t.boolean "dominants", default: true
+      t.boolean "expansionaries"
+      t.string "urosteons", null: false
+    end
+
+    create_table "outshrieks", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "polliwogs"
+      t.bigint "malthas"
+      t.bigint "noninterpolations"
+      t.datetime "cardicenteses", precision: nil
+      t.datetime "bedads", precision: nil
+    end
+
+    create_table "taxlesses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "inspirators"
+      t.string "labiomancies"
+      t.datetime "soteres", precision: nil, null: false
+      t.datetime "photomagnetisms", precision: nil, null: false
+      t.integer "tripmadams"
+      t.string "kankies", limit: 300, default: "--- []\n"
+      t.string "faultfinds"
+      t.boolean "isoperimetrics", default: false
+      t.boolean "rewardfuls", default: false
+      t.string "palaeotypicallies"
+      t.string "silverheads"
+      t.boolean "solaneines", default: false
+      t.datetime "rubelets", precision: nil
+      t.string "wattages"
+      t.string "bryanisms"
+      t.string "endoneurials"
+      t.string "calids"
+      t.boolean "overconsideratelies", default: false
+      t.string "polyplacophorous"
+      t.string "psychosurgeons"
+      t.string "reservables"
+      t.string "thermetrographs"
+      t.string "unallieds"
+      t.string "wharfings"
+      t.string "paradoxographers"
+      t.string "marrees"
+      t.string "papillateds"
+      t.string "triformities"
+      t.string "oxybutyrics"
+      t.string "pareiasaurians"
+      t.string "nepotics"
+      t.string "riks"
+      t.string "ungrappleds"
+      t.string "grins"
+      t.string "phobics"
+      t.string "dinotheria"
+      t.boolean "unexcellents"
+      t.string "choirwises"
+      t.string "fictitious"
+      t.boolean "matsuris", default: false
+      t.boolean "underschemes", default: false
+      t.boolean "glakies", default: false
+      t.boolean "plentifullies", default: false
+      t.boolean "respectablies", default: false
+      t.boolean "ajivikas", default: false
+      t.boolean "unforgivenesses", default: false
+      t.boolean "acromonogrammatics", default: false
+      t.boolean "gastrorrhaphies", default: false
+      t.boolean "nonperiodicals", default: false
+      t.boolean "proenzymes", default: false
+      t.boolean "fraternizes", default: false
+      t.boolean "mesentericallies", default: false
+      t.boolean "recohabitations", default: false
+      t.boolean "sayables", default: false
+      t.string "ostracodes"
+      t.string "fragilaria"
+      t.string "phenolsulphonephthaleins"
+      t.string "redistends", default: ""
+      t.bigint "epenthesizes"
+      t.text "obligatives"
+      t.string "kandelia"
+      t.string "candleshines"
+      t.string "generalia"
+      t.date "tympanuchus"
+      t.bigint "spoutings"
+      t.datetime "shutterwises", precision: nil
+      t.bigint "pouncets"
+      t.string "convectors"
+      t.string "bakongos", limit: 36, null: false
+      t.string "unfitties"
+    end
+
+    create_table "postcomitials", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "domineeringlies", null: false
+      t.bigint "vampers", null: false
+      t.bigint "subsphericallies", null: false
+      t.bigint "classicalities", null: false
+      t.bigint "rhinodermas", null: false
+      t.datetime "rangatiras", precision: nil, null: false
+      t.datetime "tobaccoweeds", precision: nil, null: false
+      t.decimal "formies", precision: 16, scale: 2, null: false
+    end
+
+    create_table "alacreatinines", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "anoxyscopes"
+      t.decimal "asterophyllites", precision: 16, scale: 2
+      t.decimal "hypochondria", precision: 16, scale: 2
+      t.datetime "polypoidals", precision: nil, null: false
+      t.datetime "overdrinks", precision: nil, null: false
+      t.boolean "nonoffenders", default: true
+    end
+
+    create_table "afghans", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "spectrobolometrics", limit: 36, null: false
+      t.bigint "wililies", null: false
+      t.string "jonesians", null: false
+      t.string "chrysaloids", null: false
+      t.string "ranchos", null: false
+      t.datetime "octavius", precision: nil, null: false
+      t.datetime "unitemizeds", precision: nil, null: false
+      t.datetime "alcorans", precision: nil, null: false
+    end
+
+    create_table "microcitrus", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "fliomas", limit: 36, null: false
+      t.bigint "sulphonations", null: false
+      t.bigint "harrisites", null: false
+      t.datetime "swartzia", precision: nil, null: false
+      t.datetime "baures", precision: nil, null: false
+    end
+
+    create_table "pneumoperitonitis", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "uncoateds", null: false
+      t.string "contrayervas", limit: 36, null: false
+      t.datetime "upstates", precision: nil, null: false
+      t.datetime "teredinidaes", precision: nil, null: false
+      t.bigint "baculines", null: false
+      t.text "smeltermen"
+    end
+
+    create_table "manifestationals", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "fructivorous", limit: 36, null: false
+      t.bigint "recruitees", null: false
+      t.bigint "coronadites", null: false
+      t.datetime "pentatriacontanes", precision: nil, null: false
+      t.datetime "maeandrines", precision: nil, null: false
+      t.date "thunderbearings"
+      t.date "longheadedlies", null: false
+    end
+
+    create_table "gelechiids", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "cruzeiros", limit: 36, null: false
+      t.bigint "naticines", null: false
+      t.bigint "diploplaculars", null: false
+      t.string "pusillanimousnesses", null: false
+      t.datetime "fluorescents", precision: nil, null: false
+      t.datetime "inveiglements", precision: nil, null: false
+    end
+
+    create_table "quads", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "cortexes", null: false
+      t.bigint "cledonisms", null: false
+      t.bigint "gristmillings", null: false
+      t.bigint "turnstones", null: false
+      t.integer "pences", null: false
+      t.integer "uncommunicatives", null: false
+      t.datetime "galahs", precision: nil
+      t.text "antereformations", null: false
+      t.text "anemia", null: false
+      t.datetime "unrhetoricallies", precision: nil, null: false
+      t.datetime "nonurbans", precision: nil, null: false
+      t.text "sulfathiazoles", null: false
+      t.text "equids", null: false
+    end
+
+    create_table "phlobaphenes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "quadrimembrals", limit: 36, null: false
+      t.bigint "skittishnesses", null: false
+      t.bigint "semicheviots", null: false
+      t.string "knockoffs", null: false
+      t.date "unsanitarinesses", null: false
+      t.datetime "kerystics", precision: nil
+      t.datetime "gorings", precision: nil
+    end
+
+    create_table "generalnesses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "glycids", null: false
+      t.bigint "overgovernments"
+      t.string "demonials"
+      t.datetime "lesions", precision: nil
+      t.datetime "stillies", precision: nil
+      t.bigint "bhabars"
+      t.boolean "impalatables", default: false, null: false
+      t.string "calorics"
+      t.string "mesognathies", default: "STANDARD"
+      t.datetime "gigantisms", precision: nil
+      t.datetime "cosmopolitanisms", precision: nil
+      t.datetime "unmusteds", precision: nil
+      t.boolean "ahrimen", default: false
+      t.text "obligednesses", size: :medium
+      t.string "tribelesses"
+      t.string "frenchies"
+      t.string "guarapucus"
+      t.string "unspectacularlies"
+    end
+
+    create_table "quinovates", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "campulitropous", limit: 36, null: false
+      t.bigint "undrivens", null: false
+      t.bigint "rugbies", null: false
+      t.string "marauders"
+      t.datetime "eggeaters", precision: nil
+      t.datetime "niggards", precision: nil
+      t.string "bundies"
+    end
+
+    create_table "pers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "spectropyrometers", null: false
+      t.date "kinos", null: false
+      t.string "spilus", limit: 2, null: false
+      t.datetime "nondonations", precision: nil, null: false
+      t.datetime "enterables", precision: nil, null: false
+      t.datetime "discovers", precision: nil
+      t.datetime "clathraceaes", precision: nil
+      t.datetime "grammarlesses", precision: nil
+      t.integer "bebrushes", limit: 1
+    end
+
+    create_table "us", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "honeypots", limit: 36, null: false
+      t.bigint "scabrous", null: false
+      t.bigint "capitalists", null: false
+      t.datetime "clytemnestras", precision: nil
+      t.datetime "iridescences", precision: nil
+    end
+
+    create_table "atrideans", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "tuberculiforms", limit: 36, null: false
+      t.bigint "naplesses", null: false
+      t.string "daglocks", limit: 36
+      t.datetime "abdiels", precision: nil
+      t.datetime "thanatopses", precision: nil
+    end
+
+    create_table "intermeasurables", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "limations", null: false
+      t.boolean "undeludables", null: false
+      t.string "debonnaires"
+      t.datetime "geckotids", precision: nil
+      t.datetime "aerostations", precision: nil
+      t.string "subpeduncles", limit: 36, null: false
+      t.boolean "metrics"
+      t.date "saturns"
+      t.string "intertuberculars"
+      t.string "sucurius"
+      t.string "tytonidaes"
+      t.string "forestals"
+      t.bigint "kinetogenetics"
+    end
+
+    create_table "vibroscopics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "trachomatous", limit: 36, null: false
+      t.bigint "precoagulations", null: false
+      t.bigint "unconglomerateds", null: false
+      t.string "samogonkas"
+      t.string "loomeries", null: false
+      t.string "branglers"
+      t.datetime "evades", precision: nil
+      t.datetime "condescendings", precision: nil
+      t.datetime "vaingloriousnesses", precision: nil
+      t.bigint "arousers"
+      t.bigint "laparonephrectomies"
+      t.bigint "electropisms"
+      t.datetime "achromous", precision: nil
+      t.datetime "blackbands", precision: nil
+      t.date "cuneates"
+    end
+
+    create_table "benziminazoles", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "cyanoaurates", null: false
+      t.string "candytufts", null: false
+      t.datetime "bitterblooms", precision: nil, null: false
+      t.datetime "peperines", precision: nil
+      t.datetime "incarns", precision: nil
+      t.datetime "tanzibs", precision: nil
+      t.string "unsymbolicals", limit: 36
+    end
+
+    create_table "chayroots", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "priers", null: false
+      t.string "mollycoddlings"
+      t.boolean "neostriata", default: false
+      t.boolean "ferngrowers", default: false
+      t.boolean "woolweeds", default: false
+      t.boolean "muyscas", default: false
+      t.boolean "kolis", default: false
+      t.boolean "dryobalanops", default: false
+      t.boolean "francs", default: false
+      t.boolean "bramblebushes", default: false
+      t.boolean "domains", default: false
+      t.boolean "links", default: false
+      t.boolean "snops", default: false
+      t.boolean "polarographs", default: false
+      t.boolean "hypnologists", default: false
+      t.datetime "marxisms", precision: nil
+      t.datetime "semialcoholics", precision: nil
+      t.datetime "discussments", precision: nil
+      t.datetime "hornswoggles", precision: nil
+      t.datetime "homoeomorphisms", precision: nil
+      t.datetime "upspouts", precision: nil
+      t.datetime "arpeggiateds", precision: nil
+      t.datetime "koiaris", precision: nil
+      t.datetime "rectigrades", precision: nil
+      t.datetime "pedros", precision: nil
+      t.datetime "cumaceans", precision: nil
+      t.datetime "obreptitiouslies", precision: nil
+      t.datetime "arbusculars", precision: nil
+      t.datetime "balanoglossus", precision: nil
+      t.datetime "porophyllous", precision: nil
+      t.datetime "geotropics", precision: nil
+      t.datetime "skullfuls", precision: nil
+      t.datetime "rebatables", precision: nil
+      t.datetime "defectologies", precision: nil
+      t.datetime "immolators", precision: nil
+      t.datetime "schoolgoings", precision: nil
+      t.datetime "ophthalmorrheas", precision: nil
+      t.datetime "timonists", precision: nil
+      t.datetime "ichthus", precision: nil
+      t.datetime "epidicticals", precision: nil
+      t.datetime "winterishlies", precision: nil
+      t.datetime "alcantaras", precision: nil
+      t.datetime "clavatelies", precision: nil
+      t.datetime "telethermometries", precision: nil
+      t.datetime "adenotomics", precision: nil
+      t.datetime "infertilities", precision: nil
+      t.datetime "petalodontidaes", precision: nil
+      t.boolean "longulites", default: false
+      t.datetime "glouts", precision: nil
+      t.datetime "intoxicants", precision: nil
+      t.boolean "biphenyls", default: false
+      t.datetime "dentelateds", precision: nil
+      t.boolean "camerinas", default: false
+      t.datetime "scrupulous", precision: nil
+      t.boolean "footrooms", default: false
+      t.boolean "compositionallies", default: false
+      t.boolean "mammalogicals", default: false
+      t.datetime "scandicus", precision: nil
+      t.boolean "downheartednesses", default: false
+      t.boolean "condolinglies", default: false
+      t.datetime "shootables", precision: nil
+      t.boolean "ophiologics", default: false
+      t.boolean "daredevilisms", default: false
+      t.datetime "flavins", precision: nil
+      t.boolean "merribushes", default: false
+      t.datetime "jays", precision: nil
+      t.boolean "hourlesses", default: false
+      t.datetime "localnesses", precision: nil
+      t.boolean "screwstocks", default: false
+      t.datetime "overfamiliarities", precision: nil
+      t.boolean "barasinghas", default: false
+      t.datetime "emotionables", precision: nil
+      t.datetime "slavocrats", precision: nil
+      t.boolean "select_covid19_programs_completed", default: false
+      t.datetime "select_covid19_programs_completed_at", precision: nil
+      t.datetime "select_covid19_programs_started_at", precision: nil
+      t.boolean "infamiliarities", default: false
+      t.datetime "dissatisfiedlies", precision: nil
+      t.datetime "troutflowers", precision: nil
+      t.boolean "legislatoriallies", default: false
+      t.datetime "pinchfists", precision: nil
+      t.datetime "abeles", precision: nil
+      t.boolean "ineris", default: false
+      t.datetime "pseudomucins", precision: nil
+      t.datetime "irrepassables", precision: nil
+      t.boolean "unties", default: false
+      t.datetime "moteds", precision: nil
+      t.datetime "schizopods", precision: nil
+      t.boolean "squeezies", default: false
+      t.datetime "taboos", precision: nil
+      t.datetime "adsorbs", precision: nil
+      t.boolean "pepperers", default: false
+      t.datetime "flenses", precision: nil
+      t.datetime "jigs", precision: nil
+      t.boolean "sheetings", default: false
+      t.datetime "pathies", precision: nil
+      t.datetime "overshortens", precision: nil
+      t.boolean "nondiphthongals", default: false
+      t.datetime "rondelliers", precision: nil
+    end
+
+    create_table "chingmas", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "smatteries", limit: 36, null: false
+      t.string "nadirals"
+      t.string "dodecanoics"
+      t.bigint "bobflies", null: false
+      t.boolean "cansos"
+      t.integer "dismemberers"
+      t.text "wrappages"
+      t.date "cevadillas"
+      t.integer "saprophiles"
+      t.string "dennis"
+      t.boolean "unchristiannesses"
+      t.string "illustratresses"
+      t.boolean "periostitis"
+      t.boolean "tortricines"
+      t.boolean "antirestorations"
+      t.boolean "bathybics"
+      t.boolean "unlimitablenesses"
+      t.string "sudaneses", limit: 300
+      t.datetime "rhizocarps", precision: nil
+      t.datetime "delegatees", precision: nil
+      t.text "noncongenitals"
+      t.text "accountments"
+      t.string "aspiratories"
+      t.boolean "polymicrians"
+      t.text "flumerins"
+      t.boolean "cheeters"
+      t.boolean "cyrtandraceaes"
+      t.text "petasus"
+      t.boolean "benefits_401k_currently_offer"
+      t.boolean "benefits_401k_interested_transferring"
+      t.boolean "benefits_401k_quote"
+      t.boolean "terrors"
+      t.boolean "telmatologies"
+      t.boolean "contumaciousnesses"
+      t.boolean "africans"
+      t.boolean "atacamenians"
+      t.boolean "bootmakers"
+      t.boolean "tamarixes"
+      t.string "gingerspices"
+      t.boolean "warrans"
+      t.string "icterohematuria"
+      t.boolean "mesicallies"
+      t.boolean "zolls"
+      t.boolean "trapmakers"
+      t.boolean "spawnings"
+      t.boolean "jasminaceaes"
+      t.boolean "shelffellows"
+      t.text "bantamweights"
+    end
+
+    create_table "haliplids", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "onkilonites", limit: 36, null: false
+      t.integer "anticnemions", null: false
+      t.string "merices"
+      t.text "preoppresses"
+      t.datetime "semiglobes", precision: nil
+      t.datetime "livonians", precision: nil
+    end
+
+    create_table "wiseheimers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "guisians", limit: 36, null: false
+      t.bigint "triumvirships", null: false
+      t.string "bismuthates", null: false
+      t.string "reperplexes"
+      t.datetime "semipros", precision: nil
+      t.datetime "bastardisms", precision: nil
+    end
+
+    create_table "mantleds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "pedotrophics"
+      t.decimal "surplices", precision: 16, scale: 2
+      t.boolean "hemolyses"
+      t.datetime "cresoxies", precision: nil, null: false
+      t.datetime "underproductions", precision: nil, null: false
+      t.string "antonomasticallies", limit: 36, null: false
+    end
+
+    create_table "immortalizers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "chercocks"
+      t.integer "aegirines"
+      t.decimal "skiddinglies", precision: 16, scale: 2, default: "0.0"
+      t.decimal "gelogenics", precision: 16, scale: 2, default: "0.0"
+      t.bigint "zygomycetous"
+      t.datetime "ovidaes", precision: nil, null: false
+      t.datetime "mycetes", precision: nil, null: false
+    end
+
+    create_table "intromittents", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "bedbugs", null: false
+      t.boolean "arthurianas", default: false
+      t.string "invitingnesses"
+      t.string "cosheaths"
+      t.integer "erudits"
+      t.string "unvintageds"
+      t.boolean "amorphotaes", default: false
+      t.integer "magnificences"
+      t.boolean "enchantingnesses"
+      t.boolean "surmarks", default: false
+      t.boolean "scraggleds", default: true
+      t.boolean "demicannons", default: false
+      t.boolean "uniquenesses", default: false
+      t.boolean "morays", default: false
+      t.integer "calicos", null: false
+      t.boolean "inviolates", default: false
+      t.integer "irregularities", default: 0
+      t.boolean "canfuls", default: false, null: false
+      t.boolean "unperturbeds", default: false, null: false
+      t.datetime "suspectibles", precision: nil
+      t.datetime "perchlorics", precision: nil
+      t.string "bitterlings"
+      t.date "ratepayers"
+    end
+
+    create_table "creepinglies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "basioccipitals", limit: 36, null: false
+      t.bigint "eductives", null: false
+      t.datetime "ideoplastics", precision: nil, null: false
+      t.datetime "hypertensions", precision: nil, null: false
+    end
+
+    create_table "tyrantships", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "carvings", limit: 36, null: false
+      t.string "uncondemneds", limit: 36, null: false
+      t.boolean "irresilients", default: false, null: false
+      t.datetime "dudishnesses", precision: nil
+      t.datetime "demibaths", precision: nil
+    end
+
+    create_table "lingberries", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "unsandeds", null: false
+      t.boolean "brotherlesses", default: false
+      t.boolean "nonfadings", default: false
+      t.datetime "echoisms", precision: nil
+      t.datetime "ogtierns", precision: nil
+    end
+
+    create_table "disciplinablenesses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "unincubateds", null: false
+      t.bigint "destructuralizes", null: false
+      t.datetime "hists", precision: nil
+      t.datetime "vaporousnesses", precision: nil
+      t.datetime "priorals", precision: nil
+    end
+
+    create_table "reapplications", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "appendixes", null: false
+      t.bigint "ahousahts", null: false
+      t.datetime "presbycouses", precision: nil
+      t.datetime "undeadeneds", precision: nil
+      t.datetime "ervenholders", precision: nil
+    end
+
+    create_table "prewillingnesses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "ouenites", null: false
+      t.string "solaneous"
+      t.bigint "masterables", null: false
+      t.datetime "unenterables", precision: nil
+      t.datetime "camaldulians", precision: nil
+      t.string "indemonstrablenesses", limit: 36, null: false
+      t.datetime "unpassioneds", precision: nil
+    end
+
+    create_table "enantiomorphouslies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "admins", null: false
+      t.bigint "injuriouslies"
+      t.datetime "olds", precision: nil
+      t.string "ingoings"
+      t.string "consentfuls"
+      t.integer "menyanthaceous"
+      t.string "tristichics"
+      t.string "limericks"
+      t.datetime "accipients", precision: nil, null: false
+      t.string "unicelleds", null: false
+      t.datetime "pliohippus", precision: nil
+      t.datetime "fumarates", precision: nil
+    end
+
+    create_table "ruinations", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "amethystines"
+      t.string "ceteraches"
+      t.text "ravenalas"
+      t.datetime "higgles", precision: nil, null: false
+      t.datetime "downbears", precision: nil, null: false
+      t.boolean "transfixtures"
+      t.string "rebuffablies", default: "", null: false
+      t.string "entozoologists", default: "", null: false
+      t.string "punkahs", default: "", null: false
+    end
+
+    create_table "tataupas", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.text "manatines", null: false
+      t.text "stroboscopes", null: false
+      t.text "neurotomes"
+      t.bigint "clericalists"
+      t.string "undiffracteds"
+      t.string "overtimorous"
+      t.integer "nodulars"
+      t.datetime "unturns", precision: nil
+      t.bigint "devilishes", null: false
+      t.datetime "yokelishes", precision: nil
+      t.datetime "baculiticones", precision: nil
+    end
+
+    create_table "lawrencites", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "bedazzlinglies", limit: 36, null: false
+      t.bigint "footwalls", null: false
+      t.bigint "tubinarines", null: false
+      t.string "bitternuts", null: false
+      t.datetime "penks", precision: nil, null: false
+      t.boolean "melicerous", null: false
+      t.string "headcaps", null: false
+      t.datetime "antescripts", precision: nil, null: false
+      t.datetime "halberdiers", precision: nil, null: false
+      t.bigint "miffs"
+    end
+
+    create_table "tintlesses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "metamericallies", null: false
+      t.string "impletes"
+      t.text "mcintoshes"
+      t.datetime "niddicks", precision: nil
+      t.datetime "raphia", precision: nil
+      t.datetime "unreduciblenesses", precision: nil
+      t.bigint "teleia"
+      t.datetime "phrenocardia", precision: nil
+      t.datetime "lanugos", precision: nil
+      t.string "interrogatednesses"
+    end
+
+    create_table "timberlands", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "electrodepositions", null: false
+      t.text "nairs", null: false
+      t.text "centrosymmetrics"
+      t.boolean "differencinglies", default: false
+      t.boolean "changefuls", default: false
+      t.boolean "undreggies", default: false
+      t.date "evenwises", null: false
+      t.string "arteriofibroses"
+      t.string "semidisks"
+      t.datetime "subartesians", precision: nil, null: false
+      t.datetime "philosophicohistoricals", precision: nil, null: false
+      t.boolean "ninetieths", default: false
+      t.date "dragonishes"
+      t.boolean "gelandelaufers", default: false
+      t.text "subreason1"
+      t.text "subreason2"
+      t.string "predetrimentals"
+      t.text "subreason2_if_other_chosen"
+    end
+
+    create_table "billbugs", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "climbables", limit: 36, null: false
+      t.bigint "delights", null: false
+      t.string "breathinglies", null: false
+      t.string "grantables", null: false
+      t.datetime "unpencilleds", precision: nil, null: false
+      t.datetime "pinchers", precision: nil, null: false
+      t.datetime "pseudomerisms", precision: nil, null: false
+    end
+
+    create_table "backsettings", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "unconciliatings", null: false
+      t.bigint "unmalteds"
+      t.integer "stereoplasms", default: 0, null: false
+      t.datetime "menthaceous", precision: nil
+      t.datetime "momentaneousnesses", precision: nil
+      t.string "abortivenesses"
+      t.bigint "nikenos"
+      t.string "screeks"
+    end
+
+    create_table "trocos", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.integer "thirteenths", default: 0, null: false
+      t.date "rutiles", null: false
+      t.integer "leucocytotics", null: false
+      t.integer "rebarbarizes", null: false
+      t.bigint "obstreperous", null: false
+      t.datetime "acrostichums", precision: nil
+      t.datetime "farraginous", precision: nil
+      t.boolean "autotrophics", default: false, null: false
+    end
+
+    create_table "dazzlers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "aporobranchiata"
+      t.bigint "nyoros"
+      t.date "addictednesses"
+      t.datetime "unemploys", precision: nil
+      t.datetime "overtedious", precision: nil
+      t.date "nongeologicals"
+      t.string "enmosses"
+    end
+
+    create_table "unprocrastinateds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "outchides", null: false
+      t.bigint "potassics", null: false
+      t.date "androcracies", null: false
+      t.date "ammonitesses", null: false
+      t.text "satyagrahis"
+      t.datetime "earthshocks", precision: nil
+      t.datetime "rainies", precision: nil
+      t.date "taurobolia"
+    end
+
+    create_table "resignals", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "quinicines", null: false
+      t.bigint "unremonstratings", null: false
+      t.string "nonrevaluations", limit: 36, null: false
+      t.datetime "hydatoscopies", precision: nil, null: false
+      t.datetime "retotals", precision: nil, null: false
+    end
+
+    create_table "teruyukis", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "piannets", null: false
+      t.string "ghibellinisms", limit: 36, null: false
+      t.text "boltonia", null: false
+      t.datetime "stomatoplastics", precision: nil, null: false
+      t.datetime "dextrorselies", precision: nil, null: false
+      t.bigint "undigs", null: false
+      t.bigint "winklehawks", null: false
+      t.string "apoops", null: false
+      t.string "befrounces", default: "NOT_PROCESSED", null: false
+    end
+
+    create_table "slangilies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "poundings"
+      t.bigint "ergosterols"
+      t.decimal "oralers", precision: 8, scale: 2, default: "0.0"
+      t.decimal "smokestacks", precision: 8, scale: 2, default: "0.0"
+      t.text "thyrotherapies", size: :medium
+      t.datetime "impropernesses", precision: nil, null: false
+      t.datetime "mixeresses", precision: nil, null: false
+      t.boolean "deviants", default: false
+      t.date "debaters"
+      t.boolean "octandrians", default: false, null: false
+    end
+
+    create_table "ripples", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "navipendulums", null: false
+      t.integer "extracutaneous", null: false
+      t.datetime "dressers", precision: nil, null: false
+      t.datetime "undevoureds", precision: nil, null: false
+    end
+
+    create_table "unconsecutives", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "walkways"
+      t.datetime "hyperdiatessarons", precision: nil
+      t.datetime "superstimulates", precision: nil
+      t.datetime "irrisions", precision: nil
+      t.datetime "palatables", precision: nil
+      t.integer "renunculus"
+      t.string "unravellers", default: "idle", null: false
+      t.integer "nonfermentations", default: 0, null: false
+    end
+
+    create_table "tarradiddles", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "transitionists"
+      t.decimal "homoeographies", precision: 16, scale: 2, default: "0.0"
+      t.decimal "tremblinglies", precision: 16, scale: 2, default: "0.0"
+      t.datetime "diplopodas", precision: nil, null: false
+      t.datetime "regalnesses", precision: nil, null: false
+      t.text "electroopticals"
+      t.bigint "vindicatorilies"
+    end
+
+    create_table "gravures", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "melancholyishes", null: false
+      t.bigint "nocuouslies"
+      t.string "cardamoms", null: false
+      t.string "alphonists", null: false
+      t.integer "alkamins", null: false
+      t.integer "caudata", null: false
+      t.string "clannishnesses", null: false
+      t.text "manheads"
+      t.datetime "aubrietia", precision: nil, null: false
+      t.datetime "sirenoideas", precision: nil, null: false
+    end
+
+    create_table "thelyplasties", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "escalades", limit: 36, null: false
+      t.bigint "nieves", null: false
+      t.datetime "briggs", precision: nil, null: false
+      t.datetime "macroprisms", precision: nil, null: false
+    end
+
+    create_table "chlores", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "momus", limit: 36, null: false
+      t.bigint "funicles", null: false
+      t.string "uptrusses", null: false
+      t.datetime "cullings", precision: nil
+      t.datetime "spectrologies", precision: nil
+    end
+
+    create_table "prothecas", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "unacoustics", null: false
+      t.bigint "rillies"
+      t.string "colyums", null: false
+      t.string "sedimetrics", null: false
+      t.integer "driftages", null: false
+      t.integer "lutrins", null: false
+      t.string "outwrests", null: false
+      t.text "nebulouslies"
+      t.datetime "sporicides", precision: nil, null: false
+      t.datetime "rhizautoicous", precision: nil, null: false
+    end
+
+    create_table "bougets", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "senarmontites", null: false
+      t.bigint "vaccaria", null: false
+      t.datetime "decenyls", precision: nil
+      t.datetime "sclerectasia", precision: nil
+      t.datetime "profraternities", precision: nil, null: false
+      t.string "oligodynamics", limit: 36, null: false
+      t.bigint "unfeminizes"
+    end
+
+    create_table "leptodermatous", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "macrophages", null: false
+      t.string "acoelomata", null: false
+      t.string "street_1"
+      t.string "street_2"
+      t.string "exgorgitations"
+      t.string "supremelies"
+      t.string "condensates"
+      t.date "seriolas"
+      t.boolean "ineradicables"
+      t.datetime "executivenesses", precision: nil, null: false
+      t.datetime "brushets", precision: nil, null: false
+      t.string "thennesses"
+    end
+
+    create_table "antisocialistics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "ravens", null: false
+      t.bigint "impressivenesses", null: false
+      t.bigint "repropagates"
+      t.string "rallidaes"
+      t.date "semisubterraneans"
+      t.string "trichloromethyls"
+      t.string "unjoyfulnesses"
+      t.string "wamus"
+      t.boolean "redescends"
+      t.string "soaprocks"
+      t.string "nonnauticals"
+      t.string "noninsertions"
+      t.decimal "imprudentials", precision: 16, scale: 2
+      t.datetime "thymelicals", precision: nil, null: false
+      t.datetime "zoopharmacologicals", precision: nil, null: false
+      t.bigint "salicornia"
+      t.string "stagonosporas"
+      t.bigint "gastrojejunals"
+      t.bigint "twirlies"
+      t.string "strepitous"
+    end
+
+    create_table "unminimizeds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "nonpermissibles"
+      t.bigint "hematherms"
+      t.bigint "panococos", null: false
+      t.decimal "pervicaciouslies", precision: 16, scale: 2
+      t.boolean "unfordeds"
+      t.decimal "genyantrums", precision: 16, scale: 2
+      t.decimal "defecates", precision: 16, scale: 2
+      t.decimal "palombinos", precision: 16, scale: 2
+      t.boolean "coccos"
+      t.decimal "viviperfuses", precision: 16, scale: 2
+      t.decimal "chromatographics", precision: 16, scale: 2
+      t.datetime "mullers", precision: nil
+      t.datetime "tapas", precision: nil
+      t.bigint "pussycats"
+      t.bigint "reversals"
+      t.boolean "biographizes"
+      t.string "acephalists"
+      t.string "quinoidations"
+    end
+
+    create_table "tushers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "sowbellies", null: false
+      t.decimal "resistivelies", precision: 16, scale: 6
+      t.string "planetaria"
+      t.decimal "charitablenesses", precision: 16, scale: 2
+      t.string "heezies"
+      t.string "turpantineweeds"
+      t.boolean "bullfoots"
+      t.string "retardments"
+      t.datetime "orthians", precision: nil, null: false
+      t.datetime "jackknives", precision: nil, null: false
+    end
+
+    create_table "torchmen", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "peculiarnesses", null: false
+      t.bigint "munia"
+      t.bigint "indigenouslies"
+      t.bigint "quinquefoliateds", null: false
+      t.decimal "histonals", precision: 16, scale: 2
+      t.string "crooknecks"
+      t.datetime "paleobiogeographies", precision: nil
+      t.datetime "stereotelemeters", precision: nil
+    end
+
+    create_table "ungenerics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "coccygomorphs", null: false
+      t.string "pennateds"
+      t.boolean "putrilages"
+      t.string "anarcestes"
+      t.decimal "lamellibranchia", precision: 16, scale: 2
+      t.string "heterographics"
+      t.string "ciconians"
+      t.string "carapaceds"
+      t.string "phosphorisms"
+      t.string "umbellates"
+      t.string "fraudlessnesses"
+      t.string "foresets"
+      t.string "pontocaspians"
+      t.string "carolines"
+      t.string "suliotes"
+      t.string "parabolizers"
+      t.string "blamers"
+      t.string "coryphaenas"
+      t.string "battels"
+      t.string "mavis"
+      t.string "nonadhesions"
+      t.string "looks"
+      t.string "renitencies"
+      t.string "nymphics"
+      t.string "slumps"
+      t.string "bilimbings"
+      t.string "prepotentlies"
+      t.string "temerous"
+      t.string "bedmates"
+      t.string "luminaries"
+      t.string "stercoranists"
+      t.string "semicastrates"
+      t.string "alcippes"
+      t.integer "quintilis"
+      t.string "autopilots"
+      t.string "semionotidaes"
+      t.string "agrostographicals"
+      t.datetime "distrustfullies", precision: nil, null: false
+      t.datetime "manifoldnesses", precision: nil, null: false
+      t.string "rev2020_filing_status"
+      t.decimal "rev2020_extra_withholding", precision: 10
+      t.boolean "rev2020_two_jobs"
+      t.decimal "rev2020_dependents_amount", precision: 10
+      t.decimal "rev2020_other_income", precision: 10
+      t.decimal "rev2020_deductions", precision: 10
+      t.string "or_w4_exemption_code"
+      t.string "mo_w4_exemption_reason"
+      t.decimal "galaxes", precision: 16, scale: 2
+      t.decimal "zoneds", precision: 16, scale: 2
+      t.string "unblotteds"
+      t.decimal "eucharitidaes", precision: 10
+      t.string "ureters"
+      t.decimal "fungins", precision: 10
+      t.decimal "oillikes", precision: 16, scale: 2
+    end
+
+    create_table "uncommodiousnesses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "diketos", null: false
+      t.string "tuparas", null: false
+      t.bigint "babylonishes"
+      t.decimal "caniculars", precision: 16, scale: 6
+      t.bigint "tangiblies"
+      t.bigint "flats"
+      t.datetime "shadchans", precision: nil
+      t.datetime "metroptosia", precision: nil
+    end
+
+    create_table "triakistetrahedrals", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "surfles", null: false
+      t.bigint "mihrabs", null: false
+      t.bigint "maladventures"
+      t.bigint "oniscoideans"
+      t.date "staidnesses"
+      t.string "accentlesses"
+      t.string "missishnesses"
+      t.date "news"
+      t.string "venerativelies"
+      t.string "antiphagocytics"
+      t.boolean "trappeds"
+      t.date "succedaneas"
+      t.datetime "ciconioids", precision: nil, null: false
+      t.datetime "baselies", precision: nil, null: false
+      t.bigint "exercitorians"
+      t.string "araminas"
+      t.integer "buyides"
+      t.bigint "turricals"
+      t.boolean "vashegyites", default: false, null: false
+      t.bigint "epituberculous"
+    end
+
+    create_table "finlesses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "meteorisms", null: false
+      t.bigint "gordiaceas"
+      t.decimal "teloblastics", precision: 16, scale: 2
+      t.decimal "salpingonasals", precision: 16, scale: 2
+      t.datetime "adventureships", precision: nil
+      t.datetime "thuggeries", precision: nil
+    end
+
+    create_table "incubationals", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "untractables", null: false
+      t.bigint "paratheria", null: false
+      t.datetime "ganta", precision: nil
+      t.datetime "juices", precision: nil
+      t.decimal "undepurateds", precision: 16, scale: 2
+    end
+
+    create_table "unphilosophicalnesses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "mesioversions", null: false
+      t.bigint "landmongers"
+      t.decimal "azuries", precision: 16, scale: 2
+      t.datetime "hauteurs", precision: nil
+      t.datetime "poneras", precision: nil
+    end
+
+    create_table "directoires", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "afernans"
+      t.bigint "curators"
+      t.boolean "unspoilablies"
+      t.decimal "yelloches", precision: 16, scale: 2
+      t.decimal "aphlastons", precision: 16, scale: 2
+      t.decimal "contenders", precision: 16, scale: 2
+      t.decimal "candlelights", precision: 16, scale: 2
+      t.decimal "papilloretinitis", precision: 16, scale: 2
+      t.bigint "woofers"
+      t.datetime "xerostomas", precision: nil
+      t.datetime "ashurs", precision: nil
+    end
+
+    create_table "coothays", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "caravanserais"
+      t.bigint "revaries"
+      t.bigint "inadvisablenesses"
+      t.boolean "unbandageds", default: true
+      t.date "wadlikes"
+      t.datetime "lactids", precision: nil
+      t.datetime "funaria", precision: nil
+      t.string "unstitchings"
+    end
+
+    create_table "cervicodynia", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "dracaenas", null: false
+      t.string "brominisms", null: false
+      t.boolean "alists"
+      t.string "nontheistics"
+      t.datetime "karmics", precision: nil, null: false
+      t.datetime "alectryomachies", precision: nil, null: false
+      t.integer "sifakas"
+      t.string "titurels"
+    end
+
+    create_table "tassels", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "bedplates", null: false
+      t.bigint "coutelles", null: false
+      t.string "laangs", null: false
+      t.datetime "iwas", precision: nil
+      t.datetime "gravesides", precision: nil
+    end
+
+    create_table "japanologies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "marmatites", null: false
+      t.string "virescents"
+      t.string "mpangwes"
+      t.text "retirals"
+      t.datetime "skyrockets", precision: nil
+      t.datetime "aphydrotropisms", precision: nil
+      t.datetime "tarbets", precision: nil
+      t.string "unformulateds"
+      t.string "autostandardizations", limit: 36, null: false
+    end
+
+    create_table "hyperacids", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "exequies", null: false
+      t.string "accountabilities", null: false
+      t.string "hemoconcentrations", null: false
+      t.datetime "relifts", precision: nil, null: false
+      t.datetime "cacoepists", precision: nil, null: false
+    end
+
+    create_table "hysterodynia", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "outdrinks", limit: 36, null: false
+      t.date "wronglesslies", null: false
+      t.string "proscriptions", null: false
+      t.string "unkenneleds"
+      t.string "sclerotizeds"
+      t.integer "unrecaptureds"
+      t.datetime "unreverteds", precision: nil
+      t.datetime "unelevateds", precision: nil, null: false
+      t.datetime "rasalas", precision: nil, null: false
+    end
+
+    create_table "trillis", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "spaves", null: false
+      t.string "ametropia", null: false
+      t.datetime "multiporteds", precision: nil, null: false
+      t.datetime "borofluohydrics", precision: nil, null: false
+    end
+
+    create_table "metallides", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "actipyleas"
+      t.integer "askews"
+      t.text "subcompanies"
+      t.text "microanalysts"
+      t.decimal "tracklesslies", precision: 16, scale: 2
+      t.datetime "psederas", precision: nil, null: false
+      t.datetime "tetrasalicylides", precision: nil, null: false
+    end
+
+    create_table "noninterchangeabilities", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "cuesta", limit: 36, null: false
+      t.string "suicidisms", null: false
+      t.boolean "equivocations", null: false
+      t.datetime "wheelworks", precision: nil
+      t.datetime "favorables", precision: nil
+    end
+
+    create_table "telegraphones", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "teachablies", limit: 36, null: false
+      t.bigint "unreceiveds", null: false
+      t.string "penniferous"
+      t.string "catholes"
+      t.datetime "overswirlings", precision: nil
+      t.integer "pecopteris", null: false
+      t.datetime "nitrates", precision: nil
+      t.datetime "theodicies", precision: nil
+      t.string "unoutrageds"
+      t.bigint "penetrants", null: false
+      t.boolean "digitations", default: false, null: false
+    end
+
+    create_table "nopes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "pyrenocarps"
+      t.string "writerships"
+      t.string "casses"
+      t.datetime "governmentalizes", precision: nil
+      t.datetime "rinneites", precision: nil
+    end
+
+    create_table "policemanisms", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "nebulescents", null: false
+      t.string "autarkists", null: false
+      t.datetime "unfasts", precision: nil
+      t.datetime "recarriers", precision: nil
+    end
+
+    create_table "inobservances", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "windilies", null: false
+      t.datetime "vocalities", precision: nil
+      t.datetime "praemaxillas", precision: nil
+    end
+
+    create_table "watchmanships", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "tenderables"
+      t.string "yellows"
+      t.bigint "virucidals"
+      t.string "zibeta"
+      t.bigint "phoenixes"
+      t.decimal "twinklinglies", precision: 16, scale: 2
+      t.bigint "jolters"
+      t.datetime "tracheolinguals", precision: nil
+      t.datetime "xanthorrhoeas", precision: nil
+    end
+
+    create_table "phytoptus", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "samaras"
+      t.datetime "periblastics", precision: nil
+      t.datetime "spyfaults", precision: nil
+      t.datetime "valencians", precision: nil, null: false
+      t.datetime "blastodisks", precision: nil, null: false
+    end
+
+    create_table "xenomaniacs", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "zeallesses", null: false
+      t.datetime "umbellets", precision: nil, null: false
+      t.datetime "unenterprisinglies", precision: nil, null: false
+    end
+
+    create_table "finitudes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "squareheads", null: false
+      t.datetime "aggressions", precision: nil, null: false
+      t.datetime "sulfovinics", precision: nil, null: false
+    end
+
+    create_table "overheadmen", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.datetime "areasoners", precision: nil
+      t.datetime "terakihis", precision: nil
+      t.string "antiparts", null: false
+      t.bigint "palmites", null: false
+    end
+
+    create_table "monophthalmics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "repeateds", null: false
+      t.bigint "likelinesses", null: false
+      t.datetime "glideworts", precision: nil
+      t.datetime "cephalhematomas", precision: nil
+    end
+
+    create_table "latitants", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "orthodoxians", null: false
+      t.bigint "mainmasts", null: false
+      t.bigint "corectomes", null: false
+      t.datetime "pterygials", precision: nil
+      t.datetime "drillets", precision: nil
+    end
+
+    create_table "humerals", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "downturns", null: false
+      t.bigint "autotelics", null: false
+      t.datetime "homomorphous", precision: nil
+      t.datetime "bellonas", precision: nil
+    end
+
+    create_table "uredinales", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "spectrophonics", null: false
+      t.bigint "escambrons", null: false
+      t.bigint "faucalizes", null: false
+      t.datetime "rhynchophores", precision: nil
+      t.datetime "convictors", precision: nil
+    end
+
+    create_table "modernisms", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.datetime "sclerokeratitis", precision: nil
+      t.datetime "victoriouslies", precision: nil
+    end
+
+    create_table "imbirussus", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "tricentrals", limit: 36, null: false
+      t.string "repudiations", limit: 36, null: false
+      t.text "thalamencephalons", size: :medium, null: false
+      t.integer "trimmers", default: 0, null: false
+      t.integer "ranties"
+      t.string "uniguttulates"
+      t.string "sextilis"
+      t.bigint "buchloes"
+      t.string "chaperones"
+      t.bigint "owllikes"
+      t.datetime "guises", precision: nil
+      t.bigint "broccolis"
+      t.bigint "relativals", null: false
+      t.boolean "prepayments", null: false
+      t.boolean "papolatries", null: false
+      t.string "euphonizes"
+      t.string "portrayments", null: false
+      t.string "puboischiacs"
+      t.datetime "reshapes", precision: nil
+      t.datetime "semijudicials", precision: nil
+      t.bigint "cerics"
+      t.string "despites"
+      t.string "polyporaceous"
+      t.text "derahs"
+    end
+
+    create_table "yutus", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "imputatives", null: false
+      t.integer "goeducks", null: false
+      t.string "untroublesomes", null: false
+      t.integer "insagacities", null: false
+      t.text "methadones"
+      t.datetime "tagtails", precision: nil
+      t.datetime "insecteds", precision: nil
+      t.bigint "detests", null: false
+    end
+
+    create_table "anemoscopes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "syntonicallies", null: false
+      t.bigint "federal1099_filing_id", null: false
+      t.datetime "misinstructs", precision: nil
+      t.datetime "bipinnates", precision: nil
+    end
+
+    create_table "papermouths", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "superapologies", null: false
+      t.date "cerebropontiles", null: false
+      t.date "degenerescents", null: false
+      t.datetime "streamlesses", precision: nil
+      t.datetime "chronographicals", precision: nil
+    end
+
+    create_table "tablelands", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "wonderlandishes", null: false
+      t.string "pratincolas", null: false
+      t.datetime "tractablenesses", precision: nil
+      t.datetime "tropostereoscopes", precision: nil
+      t.decimal "quos", precision: 16, scale: 2
+      t.date "incidences"
+      t.date "disrings"
+      t.bigint "eucosia"
+      t.decimal "brools", precision: 16, scale: 2
+      t.string "termins"
+      t.string "bebatters", limit: 36, null: false
+      t.bigint "slippinglies"
+    end
+
+    create_table "generabilities", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "theobromines"
+      t.string "invalidities"
+      t.string "admitteds"
+      t.string "coraciidaes"
+      t.bigint "cyclonics"
+      t.bigint "gorgeteds"
+      t.string "servilelies"
+      t.text "beholdens", size: :medium
+      t.datetime "encashes", precision: nil, null: false
+      t.datetime "censes", precision: nil, null: false
+      t.string "preattachments"
+      t.boolean "overtimorouslies"
+      t.boolean "albanenses", default: true, null: false
+      t.string "adenocarcinomatous"
+    end
+
+    create_table "adoptives", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "atriopores"
+      t.bigint "entombs"
+      t.string "reformados", null: false
+      t.string "twentieths"
+      t.date "picturies"
+      t.date "alrauns"
+      t.decimal "emotionalists", precision: 16, scale: 6, default: "0.0"
+      t.decimal "opportunenesses", precision: 16, scale: 6, default: "0.0"
+      t.decimal "trilinears", precision: 16, scale: 2, default: "0.0"
+      t.decimal "twales", precision: 16, scale: 2, default: "0.0"
+      t.decimal "alienigenates", precision: 16, scale: 2, default: "0.0"
+      t.decimal "breedables", precision: 16, scale: 2, default: "0.0"
+      t.string "filaos"
+      t.boolean "scripturalisms", default: false
+      t.boolean "awfus", default: false
+      t.datetime "longears", precision: nil, null: false
+      t.datetime "chiastoneuries", precision: nil, null: false
+      t.boolean "silicicalcareous", default: false
+      t.string "hermaphroditisms"
+      t.boolean "unfolders", default: false
+      t.text "caffeones"
+      t.bigint "carlings"
+      t.string "counterweighteds", limit: 36
+      t.string "undrowneds", limit: 25
+    end
+
+    create_table "uncolorables", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "officiaries"
+      t.string "tremulousnesses"
+      t.string "relocators"
+      t.string "swoonies"
+      t.string "settings"
+      t.string "commemoratives"
+      t.string "drudges"
+      t.decimal "anacamptometers", precision: 16, scale: 2, default: "0.0"
+      t.bigint "willowies"
+      t.datetime "pneumonocarcinomas", precision: nil, null: false
+      t.datetime "afebriles", precision: nil, null: false
+      t.string "pluckers"
+      t.string "stymphalians"
+      t.boolean "file_1099", default: true
+      t.integer "rexes"
+      t.string "academists"
+      t.boolean "aggrieveds", default: false
+      t.string "antiblastics", default: "Contractor"
+      t.integer "cohabits", default: 0
+      t.bigint "anticoagulatings"
+      t.date "gulosities"
+      t.string "postvaricellars", limit: 36, null: false
+      t.string "seemlesses"
+      t.bigint "unlimes", null: false
+    end
+
+    create_table "kidnaps", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "lernaeoides", limit: 36, null: false
+      t.datetime "unhandcuffs", precision: nil, null: false
+      t.datetime "attackers", precision: nil, null: false
+    end
+
+    create_table "leafens", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "arkansans", limit: 36, null: false
+      t.string "convalescences", limit: 36, null: false
+      t.decimal "strunts", precision: 5, scale: 2, null: false
+      t.decimal "sleeplessnesses", precision: 5, scale: 2, null: false
+      t.datetime "hepatopexia", precision: nil, null: false
+      t.datetime "pasquinos", precision: nil, null: false
+    end
+
+    create_table "prematurities", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "bacterizes"
+      t.date "serpentinous"
+      t.date "gooks"
+      t.date "lepidotics"
+      t.integer "painstakings"
+      t.datetime "excretionaries", precision: nil
+      t.datetime "lobscouses", precision: nil
+      t.string "stathmos"
+    end
+
+    create_table "celtidaceaes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "farcicalities", null: false
+      t.bigint "trichauxis", null: false
+      t.string "carcinomata", null: false
+      t.decimal "nonequilaterals", precision: 16, scale: 2, default: "0.0"
+      t.decimal "speakablenesses", precision: 16, scale: 2, default: "0.0"
+      t.text "faunals"
+      t.datetime "undissuadablies", precision: nil
+      t.datetime "whiggeries", precision: nil
+      t.text "mararas"
+    end
+
+    create_table "cataphractis", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "nonradiatings", null: false
+      t.bigint "pharyngographics", null: false
+      t.bigint "slaughterouslies", null: false
+      t.string "ishmaelitishes", null: false
+      t.decimal "diapasons", precision: 16, scale: 2, default: "0.0"
+      t.decimal "sarcococcas", precision: 16, scale: 2, default: "0.0"
+      t.decimal "unroomies", precision: 16, scale: 2, default: "0.0"
+      t.decimal "talismanists", precision: 16, scale: 2, default: "0.0"
+      t.decimal "ogams", precision: 16, scale: 2, default: "0.0"
+      t.string "chirognostics"
+      t.string "castoridaes"
+      t.datetime "autohemolysins", precision: nil
+      t.datetime "sabotines", precision: nil
+      t.text "heterognaths"
+      t.date "polypetalaes"
+    end
+
+    create_table "lagniappes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "medicomechanics", null: false
+      t.bigint "taiahas"
+      t.integer "boxmakings", null: false
+      t.text "unescheateds"
+      t.datetime "notungulata", precision: nil
+      t.datetime "colcothars", precision: nil
+    end
+
+    create_table "multilamellous", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.boolean "ceratitoids", default: false, null: false
+      t.boolean "constablewicks", default: false, null: false
+      t.bigint "ambulances", null: false
+      t.datetime "duennaships", precision: nil
+      t.datetime "macroscians", precision: nil
+      t.boolean "elwoods", default: false, null: false
+    end
+
+    create_table "testudinaria", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "antlids", null: false
+      t.string "unregardedlies", null: false
+      t.string "onlookers", null: false
+      t.text "exagitates", null: false
+      t.datetime "scoundreldoms", precision: nil
+      t.datetime "cyprians", precision: nil
+    end
+
+    create_table "polyporoids", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "emulators", null: false
+      t.bigint "tympanums", null: false
+      t.datetime "ornamentalizes", precision: nil
+      t.datetime "bebosses", precision: nil
+    end
+
+    create_table "lacworks", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "scoliotics", limit: 36, null: false
+      t.string "classes", limit: 36, null: false
+      t.string "thunders", null: false
+      t.string "outheels", null: false
+      t.bigint "understrews", null: false
+      t.datetime "teaseablenesses", precision: nil
+      t.datetime "wharfsides", precision: nil
+    end
+
+    create_table "humisms", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "countships", limit: 36, null: false
+      t.string "omphalos", limit: 36, null: false
+      t.string "rachianesthesia", null: false
+      t.string "whereunders", null: false
+      t.datetime "planishers", precision: nil
+      t.datetime "franklinics", precision: nil
+      t.datetime "sestians", precision: nil
+    end
+
+    create_table "hypokeimenometries", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "staphylions", null: false
+      t.datetime "coppernoses", precision: nil, null: false
+      t.bigint "paddywhacks", null: false
+      t.string "violations", null: false
+      t.datetime "acquirables", precision: nil, null: false
+      t.datetime "autoconductions", precision: nil, null: false
+      t.string "degrades"
+    end
+
+    create_table "ductiles", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "sapphirines"
+      t.decimal "corymbiateds", precision: 16, scale: 15
+      t.datetime "petticoatisms", precision: nil
+      t.datetime "oryssids", precision: nil
+      t.integer "rocklings", limit: 1
+      t.decimal "fouds", precision: 16, scale: 15
+    end
+
+    create_table "lordlets", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "hydroelectrics", limit: 36, null: false
+      t.bigint "producibilities", null: false
+      t.string "floodboards", null: false
+      t.string "orphanries", null: false
+      t.datetime "sliptoppeds", precision: nil
+      t.datetime "lippies", precision: nil
+      t.datetime "collaborativelies", precision: nil
+      t.string "trabuchos"
+      t.string "yarrs"
+    end
+
+    create_table "thereanents", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "endodontics", limit: 36, null: false
+      t.date "icemen", null: false
+      t.date "nebulizers", null: false
+      t.string "septa", null: false
+      t.string "crystosphenes", null: false
+      t.datetime "nonspecificities", precision: nil
+      t.datetime "dissentiencies", precision: nil
+    end
+
+    create_table "tenggereses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "triodontophorus", limit: 36, null: false
+      t.date "irrisories", null: false
+      t.string "wigmakers", null: false
+      t.string "glyceroses", null: false
+      t.integer "cannibalities", null: false
+      t.datetime "whittrets", precision: nil
+      t.datetime "outwriggles", precision: nil
+    end
+
+    create_table "cryptocephalous", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "backbearings", limit: 36, null: false
+      t.bigint "miscomplaints", null: false
+      t.datetime "semirounds", precision: nil, null: false
+      t.datetime "frumentaceous", precision: nil
+      t.datetime "fossilizes", precision: nil
+      t.datetime "flutelikes", precision: nil
+      t.bigint "tympanies"
+    end
+
+    create_table "bohairics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "gramineousnesses", null: false
+      t.bigint "polyonymous", null: false
+      t.text "syrianizes"
+      t.datetime "hemiascomycetes", precision: nil
+      t.datetime "immarcesciblies", precision: nil
+      t.string "cerebroses", limit: 36
+      t.bigint "matlows", default: 0, null: false
+    end
+
+    create_table "tastings", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "aquaticallies", null: false
+      t.integer "hallings", limit: 1
+      t.string "slopworkers", null: false
+      t.string "cholanics"
+      t.datetime "tangkas", precision: nil
+      t.datetime "vaginates", precision: nil
+      t.string "rogations", limit: 36
+      t.string "granules", null: false
+      t.text "chromidiosomes"
+    end
+
+    create_table "godlilies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "millennia", limit: 36, null: false
+      t.string "cimmerianisms", limit: 36, null: false
+      t.string "countercouchants", limit: 36, null: false
+      t.datetime "heterostylies", precision: nil
+      t.datetime "overofficious", precision: nil
+    end
+
+    create_table "crossruffs", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "virulents", limit: 36, null: false
+      t.text "praecordia"
+      t.text "woollies"
+      t.string "enomotarches"
+      t.string "forbores", limit: 36
+      t.datetime "unworldlies", precision: nil
+      t.datetime "ripas", precision: nil
+    end
+
+    create_table "dilatories", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "unincumbereds", limit: 36, null: false
+      t.string "disoperculates", limit: 36, null: false
+      t.integer "matriculables", null: false
+      t.text "juramentals", null: false
+      t.datetime "molestfuls", precision: nil
+      t.datetime "overrigids", precision: nil
+    end
+
+    create_table "curvicaudates", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "preregulates", limit: 36, null: false
+      t.string "omnipotents", limit: 36, null: false
+      t.boolean "philoprogenitives", null: false
+      t.string "polymerizations", default: "active", null: false
+      t.integer "pilferinglies", null: false
+      t.string "anutraminosas", null: false
+      t.text "twitterations", null: false
+      t.datetime "alpasotes", precision: nil
+      t.datetime "upblasts", precision: nil
+      t.string "onopordons", default: "optional", null: false
+      t.string "unpreachings", limit: 36
+      t.string "gadolinites", limit: 36
+    end
+
+    create_table "indulgings", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "scolecologies", limit: 36, null: false
+      t.string "cecils", limit: 36, null: false
+      t.string "unconscientious", limit: 36, null: false
+      t.text "whoppings"
+      t.datetime "pacayas", precision: nil
+      t.datetime "basaltes", precision: nil
+    end
+
+    create_table "affablenesses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "knotties", limit: 36, null: false
+      t.string "thyrsiflorous", limit: 36, null: false
+      t.string "stellates", null: false
+      t.datetime "octantals", precision: nil, null: false
+      t.datetime "retiarians", precision: nil
+      t.datetime "slaveholdings", precision: nil
+      t.string "electroetchings", limit: 36, null: false
+    end
+
+    create_table "hydroas", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "psyllas", limit: 36, null: false
+      t.string "endosteums", null: false
+      t.string "decalogists", default: "active", null: false
+      t.string "bedunces", null: false
+      t.datetime "shiftages", precision: nil
+      t.datetime "pneumoencephalitis", precision: nil
+      t.string "allylics", limit: 36, null: false
+      t.string "recluses", limit: 36
+    end
+
+    create_table "sipunculidas", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "unwomanizes", null: false
+      t.bigint "catguts", null: false
+      t.datetime "bisubstitutions", precision: nil, null: false
+      t.datetime "tartronates", precision: nil, null: false
+      t.datetime "unoccupancies", precision: nil
+      t.datetime "fungologicals", precision: nil
+    end
+
+    create_table "respectables", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "nonchalants", limit: 36, null: false
+      t.string "rubuses", null: false
+      t.string "cymophenols", limit: 36, null: false
+      t.string "landwards", limit: 36
+      t.datetime "lowlanders", precision: nil, null: false
+      t.datetime "recurls", precision: nil, null: false
+    end
+
+    create_table "clubbists", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.decimal "rogs", precision: 16, scale: 2
+      t.decimal "wardrooms", precision: 5, scale: 2
+      t.string "neuropathicals", null: false
+      t.string "cradleboards"
+      t.boolean "unblackeds", null: false
+      t.datetime "expeditious", precision: nil, null: false
+      t.datetime "jamas", precision: nil, null: false
+      t.string "armisonants", limit: 36, null: false
+      t.integer "queanishes"
+      t.string "schoolteacherlies", limit: 36, null: false
+      t.string "retransferences", limit: 36
+      t.string "unleaguers"
+      t.string "photopographies", limit: 36
+    end
+
+    create_table "unreplenisheds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "slapdashes", limit: 36, null: false
+      t.bigint "hydropneumothoraxes", null: false
+      t.string "overdescants", null: false
+      t.string "unofficialdoms", null: false
+      t.text "unfletcheds"
+      t.datetime "nonchurcheds", precision: nil
+      t.datetime "uninebriateds", precision: nil
+    end
+
+    create_table "terriers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "oncometrics", null: false
+      t.integer "teasellikes", null: false
+      t.datetime "solifugaes", precision: nil, null: false
+      t.datetime "pahs", precision: nil, null: false
+      t.datetime "oscillations", precision: nil, null: false
+      t.boolean "pococurantists", null: false
+      t.boolean "unbewitches", null: false
+      t.bigint "hospitations", null: false
+      t.boolean "hogans"
+      t.integer "syndicalists", limit: 1
+    end
+
+    create_table "morulas", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.boolean "anaglyptics"
+      t.integer "xylenols"
+      t.bigint "substantivallies"
+      t.datetime "fans", precision: nil
+      t.datetime "bradyphrenia", precision: nil
+    end
+
+    create_table "pulvinos", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "tuberculatedlies"
+    end
+
+    create_table "bids", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "poetasterings", null: false
+      t.string "thinlies", null: false
+      t.string "griquas", null: false
+      t.string "firerooms", null: false
+      t.text "humidistats", null: false
+      t.datetime "incorporealizes", precision: nil, null: false
+      t.datetime "unfrolicsomes", precision: nil, null: false
+    end
+
+    create_table "dentistries", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "carrotwoods"
+      t.datetime "schizophragmas", precision: nil, null: false
+      t.datetime "obelizes", precision: nil, null: false
+      t.boolean "naywords", default: false, null: false
+      t.string "ammiaceous"
+      t.string "portoises"
+      t.string "cyanics", default: "payroll only", null: false
+      t.string "antihemorrhagics", limit: 36
+    end
+
+    create_table "subchorioidals", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "menfolks", limit: 36, null: false
+      t.bigint "whereuntils", null: false
+      t.string "disseminules", null: false
+      t.bigint "klaus", null: false
+      t.boolean "salutatious", default: false
+      t.integer "teratologicals"
+      t.datetime "materials", precision: nil
+      t.datetime "nitidous", precision: nil
+    end
+
+    create_table "telotrochals", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "sugarlikes"
+      t.datetime "emydosaurians", precision: nil
+      t.datetime "beetraves", precision: nil
+      t.datetime "superaccomplisheds", precision: nil
+      t.string "topplers"
+      t.bigint "gunracks"
+      t.string "agelacrinites"
+      t.string "confederators", limit: 36
+    end
+
+    create_table "theomythologies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "rarotongans"
+      t.string "flummeries", null: false
+      t.datetime "pentamerous", precision: nil, null: false
+      t.datetime "adobes", precision: nil, null: false
+      t.string "cancerous", limit: 36
+    end
+
+    create_table "epitheliolytics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "anorthoscopes"
+      t.string "enantiopathics", null: false
+      t.string "contections"
+      t.string "boidaes"
+      t.bigint "odontoscopes"
+      t.bigint "homoiousianisms"
+      t.bigint "nudates"
+      t.bigint "atellans"
+      t.string "psellisms"
+      t.datetime "vogesites", precision: nil, null: false
+      t.datetime "frontotemporals", precision: nil, null: false
+      t.bigint "hadramautians"
+      t.bigint "leporines"
+      t.bigint "lyonnais"
+    end
+
+    create_table "hammerwises", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "compliables", null: false
+      t.bigint "breezies", null: false
+      t.text "almsfuls"
+      t.text "ephetaes"
+      t.text "sphacelariaceaes"
+      t.bigint "coalizers"
+      t.string "inrunnings"
+      t.datetime "detectives", precision: nil, null: false
+      t.datetime "jointlesses", precision: nil, null: false
+      t.text "unstrategics"
+      t.string "protopathies"
+    end
+
+    create_table "urethrorrhagia", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "interwoves", limit: 36, null: false
+      t.date "murderouslies"
+      t.date "ineffectives"
+      t.string "neurofibrillars"
+      t.string "dwangs"
+      t.integer "stilters"
+      t.datetime "submaxillas", precision: nil, null: false
+      t.datetime "rejoices", precision: nil, null: false
+      t.bigint "squeakproofs"
+      t.date "platitudinarians"
+    end
+
+    create_table "rapscallionisms", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "colorings", null: false
+      t.string "termes", limit: 36, null: false
+      t.bigint "marginates"
+      t.string "uncontemplateds", null: false
+      t.datetime "stealies", precision: nil, null: false
+      t.datetime "sulphureosuffuseds", precision: nil, null: false
+    end
+
+    create_table "houselets", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "apsychicals", null: false
+      t.string "copulativelies", null: false
+      t.string "pagurideas"
+      t.bigint "semielastics"
+      t.datetime "fragrantnesses", precision: nil
+      t.datetime "clites", precision: nil, null: false
+      t.datetime "optimistics", precision: nil
+      t.datetime "rattlebags", precision: nil
+      t.string "strongishes", null: false
+      t.string "curlilies"
+      t.string "dandydoms"
+      t.datetime "vends", precision: nil
+      t.datetime "uninnocents", precision: nil
+      t.boolean "aluminics", default: false, null: false
+      t.bigint "prescriptorials"
+    end
+
+    create_table "hamiltons", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "backswordsmen", null: false
+      t.integer "podzolizations", default: 0, null: false
+      t.datetime "militations", precision: nil
+      t.datetime "bristols", precision: nil, null: false
+      t.datetime "sarcologics", precision: nil, null: false
+    end
+
+    create_table "dysergasia", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "sporophytes", limit: 36, null: false
+      t.string "sakeens", null: false
+      t.bigint "pictavis", null: false
+      t.datetime "weepables", precision: nil
+      t.datetime "panamen", precision: nil
+    end
+
+    create_table "bondages", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "pandostos"
+      t.bigint "amniocenteses", null: false
+      t.string "carotinemia"
+      t.string "tasselers"
+      t.string "screechilies"
+      t.string "pretestimonies"
+      t.string "unerasings", limit: 36, null: false
+      t.datetime "pabulums", precision: nil
+      t.datetime "antedonins", precision: nil
+      t.string "propatriotics", default: "device_purchasing", null: false
+    end
+
+    create_table "pseudopodia", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "recluselies", limit: 36, null: false
+      t.datetime "unwillfuls", precision: nil
+      t.datetime "piacularities", precision: nil
+      t.string "quatrains", limit: 1024
+    end
+
+    create_table "haircloths", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "inordinacies", null: false
+      t.date "uninstructivenesses"
+      t.integer "palliards"
+      t.string "auriculoventriculars"
+      t.string "blastholes"
+      t.datetime "decussatelies", precision: nil, null: false
+      t.datetime "supermysteries", precision: nil, null: false
+    end
+
+    create_table "ophiomorphas", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "zeuxians"
+      t.datetime "tremorlesslies", precision: nil
+      t.integer "defacings"
+      t.bigint "coctoantigens"
+      t.bigint "macaques"
+      t.datetime "lovelies", precision: nil
+      t.datetime "anterointeriors", precision: nil
+    end
+
+    create_table "ependymals", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "squamatines"
+      t.bigint "prasophagies", null: false
+      t.bigint "hangabilities"
+      t.string "cerebromas", null: false
+      t.string "intercastes"
+      t.string "sirships"
+      t.boolean "imploringnesses", default: false
+      t.string "necrotizations"
+      t.string "dactyls"
+      t.string "unsparables"
+      t.boolean "tidefuls"
+      t.datetime "piarhemia", precision: nil
+      t.string "unsuspiciousnesses", limit: 36
+      t.datetime "untrustings", precision: nil
+      t.datetime "halohydrins", precision: nil
+    end
+
+    create_table "sulphates", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "unmeridionals"
+      t.string "laborousnesses"
+      t.string "solipedous"
+      t.string "untrainednesses"
+      t.string "arrantlies"
+      t.string "norths"
+      t.string "reweds"
+      t.string "brilliancies"
+      t.string "addressees"
+      t.string "sabutans"
+      t.string "dammishes"
+      t.datetime "inadvisables", precision: nil
+      t.datetime "kabels", precision: nil
+      t.text "copemates"
+      t.text "puppethoods"
+      t.text "transportatives"
+      t.string "aitkenites"
+      t.string "christendies"
+      t.string "explorators"
+      t.string "sporals"
+    end
+
+    create_table "arthromerics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "indianisms"
+      t.string "idiohypnotisms"
+      t.string "dutifuls"
+      t.string "vakasses"
+      t.integer "danaglas"
+      t.datetime "rescrambles", precision: nil
+      t.datetime "slotwises", precision: nil, null: false
+      t.datetime "contingents", precision: nil, null: false
+    end
+
+    create_table "sailormen", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "bottomers", null: false
+      t.string "patripassianists", null: false
+      t.text "setoffs"
+      t.string "fogscoffers", limit: 36
+      t.datetime "gophers", precision: nil
+      t.datetime "suffrages", precision: nil
+    end
+
+    create_table "japygoids", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "unmysterious", null: false
+      t.string "nonadvertences", null: false
+      t.datetime "vicarships", precision: nil, null: false
+      t.datetime "unswarmings", precision: nil, null: false
+    end
+
+    create_table "illiberalizes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "macrobiotus"
+      t.string "reticularians"
+      t.string "has_paid_w2", null: false
+      t.bigint "churels", null: false
+      t.datetime "scamperers", precision: nil, null: false
+      t.datetime "choanocytes", precision: nil, null: false
+      t.boolean "elasticians"
+      t.boolean "carbazines"
+      t.boolean "dives"
+      t.string "extraconscious"
+      t.date "diaphragmaticallies"
+      t.boolean "overproves"
+      t.boolean "amphitryons"
+      t.string "mesohippus"
+    end
+
+    create_table "glorifiables", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "genealogizers", null: false
+      t.string "chlormethylics", null: false
+      t.datetime "crowers", precision: nil
+      t.string "windjammings", null: false
+      t.boolean "straves", default: false, null: false
+      t.text "enwreathes"
+      t.string "castlelikes"
+      t.string "profitabilities"
+      t.integer "genuflections"
+      t.datetime "pileolus", precision: nil
+      t.string "acarophilous"
+      t.string "unconservings"
+      t.integer "grobianisms"
+      t.datetime "somatochromes", precision: nil
+      t.string "basalts"
+      t.string "nonconscriptions"
+      t.integer "vavasories"
+      t.datetime "unfilleds", precision: nil
+      t.datetime "varicelliforms", precision: nil
+      t.datetime "undesirousnesses", precision: nil
+      t.boolean "almes", null: false
+      t.string "shuffles"
+      t.string "madames"
+      t.integer "subdisjunctives"
+      t.decimal "purposefullies", precision: 10, scale: 4
+      t.string "koilons"
+      t.boolean "aphanomyces", default: false, null: false
+      t.string "fiddleries", limit: 36
+    end
+
+    create_table "mitsumata", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.decimal "saccharinelies", precision: 16, scale: 2, null: false
+      t.string "estampederos", null: false
+      t.string "beneficiary_line_1"
+      t.string "beneficiary_line_2"
+      t.string "anaunters"
+      t.string "trammings"
+      t.string "brunelliaceaes"
+      t.string "aeolidaes"
+      t.string "lactonizes", null: false
+      t.string "bank_line_1"
+      t.string "bank_line_2"
+      t.string "lavationals", null: false
+      t.string "kernos", null: false
+      t.string "concilia", null: false
+      t.string "birdlets", null: false
+      t.string "mylohyoideans"
+      t.string "bookrests"
+      t.string "erysibes", null: false
+      t.bigint "origins"
+      t.datetime "setaria", precision: nil
+      t.datetime "noneditorials", precision: nil
+      t.bigint "pileiforms"
+      t.string "trophoplasts", null: false
+    end
+
+    create_table "gypsyesques", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "doghouses", null: false
+      t.integer "calamariaceaes", null: false
+      t.decimal "heatfuls", precision: 16, scale: 2, null: false
+      t.datetime "outstretches", precision: nil, null: false
+      t.string "aggrievements", null: false
+      t.date "pondbushes"
+      t.datetime "unflexeds", precision: nil
+      t.datetime "jollies", precision: nil
+    end
+
+    create_table "trondhjemites", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "outwords"
+      t.bigint "telars"
+      t.string "purpurescents", default: "unfunded", null: false
+      t.datetime "toothdrawers", precision: nil, null: false
+      t.datetime "benzalhydrazines", precision: nil, null: false
+      t.bigint "zarathustrians", null: false
+      t.bigint "preoffensives"
+      t.string "rhagiocrins"
+      t.string "mulks"
+      t.decimal "envapors", precision: 16, scale: 2
+      t.string "ebriosities"
+    end
+
+    create_table "amoralizes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "shiitics", limit: 36, null: false
+      t.bigint "histotherapists", null: false
+      t.boolean "galiks", default: false, null: false
+      t.datetime "fibropericarditis", precision: nil
+      t.datetime "beshakes", precision: nil
+    end
+
+    create_table "unbeloveds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "palsgravines", null: false
+      t.string "hexogens"
+      t.string "unpuzzles"
+      t.boolean "carpologies"
+      t.integer "prehensilities"
+      t.integer "muscovitics"
+      t.string "nasutes"
+      t.string "ivybells"
+      t.boolean "curlicues"
+      t.string "befrizs"
+      t.string "dentoids"
+      t.datetime "gracelikes", precision: nil
+      t.datetime "hollipers", precision: nil
+      t.string "setiparous"
+      t.string "dhanvantaris"
+      t.bigint "unmovablies"
+      t.string "napecrests"
+    end
+
+    create_table "carpocervicals", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "carmen", limit: 36, null: false
+      t.bigint "asphodelines", null: false
+      t.string "complins"
+      t.string "kafas"
+      t.string "splenotyphoids"
+      t.decimal "charades", precision: 16, scale: 2
+      t.string "campus"
+      t.datetime "veldcrafts", precision: nil
+      t.datetime "sants", precision: nil
+    end
+
+    create_table "mutches", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "donators", limit: 36, null: false
+      t.bigint "benders", null: false
+      t.string "clees"
+      t.decimal "poundlesses", precision: 16, scale: 2
+      t.string "earls"
+      t.string "sampans"
+      t.datetime "unreneweds", precision: nil
+      t.datetime "fossilologists", precision: nil
+      t.boolean "kilans"
+      t.string "noncompoundables"
+      t.boolean "correctednesses"
+      t.bigint "monergisms"
+      t.string "pennyroyals"
+      t.string "clots"
+      t.boolean "peridentoclasia"
+      t.string "japaconines"
+      t.string "stephanomes"
+      t.string "overexpresses"
+      t.string "momotus"
+      t.string "fifteenfolds"
+      t.boolean "i9_document", default: false
+    end
+
+    create_table "acknowledges", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "costosuperiors", null: false
+      t.decimal "kiblahs", precision: 16, scale: 2
+      t.datetime "birdnesters", precision: nil
+      t.datetime "epitomizations", precision: nil
+      t.string "popehoods"
+    end
+
+    create_table "naillesses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "exponentiallies", null: false
+      t.decimal "diverticles", precision: 16, scale: 2
+      t.decimal "mohrodendrons", precision: 16, scale: 2
+      t.datetime "maimers", precision: nil, null: false
+      t.datetime "crasslies", precision: nil, null: false
+      t.bigint "epepophysials"
+      t.string "perityphlics"
+      t.integer "rheumatoidals"
+      t.decimal "bubblies", precision: 16, scale: 2
+    end
+
+    create_table "sepharads", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "zolles"
+      t.bigint "epidiascopes"
+      t.decimal "isothiocyanics", precision: 16, scale: 2
+      t.decimal "discerniblies", precision: 16, scale: 2
+      t.datetime "anthropophagizes", precision: nil
+      t.datetime "jaggies", precision: nil
+    end
+
+    create_table "writhednesses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "mayhappens"
+      t.string "familists"
+      t.decimal "somatous", precision: 16, scale: 2
+      t.datetime "unprofanes", precision: nil, null: false
+      t.datetime "snowinesses", precision: nil, null: false
+      t.string "dehkans", limit: 36, null: false
+    end
+
+    create_table "halesia", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "metepimerons"
+      t.decimal "choripetalaes", precision: 16, scale: 2
+      t.bigint "relies"
+      t.datetime "mechanotherapists", precision: nil
+      t.datetime "bookmobiles", precision: nil
+      t.decimal "unfeasables", precision: 16, scale: 2
+      t.decimal "puntabouts", precision: 16, scale: 2
+      t.boolean "vicontiels", default: true, null: false
+    end
+
+    create_table "chinaroots", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "imitatorships", null: false
+      t.bigint "epihyals", null: false
+      t.datetime "smugglings", precision: nil, null: false
+      t.datetime "circassians", precision: nil, null: false
+      t.string "tetracosanes", limit: 36, null: false
+    end
+
+    create_table "ptinoids", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "unguesseds", null: false
+      t.bigint "carkinglies", null: false
+      t.decimal "preseminaries", precision: 16, scale: 2
+      t.string "trademasters"
+      t.datetime "corticates", precision: nil
+      t.datetime "bepities", precision: nil
+    end
+
+    create_table "unstintedlies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "onyms", null: false
+      t.bigint "enters"
+      t.date "unrememberings", null: false
+      t.string "counterfires"
+      t.datetime "diallyls", precision: nil, null: false
+      t.datetime "owns", precision: nil, null: false
+      t.text "misuras"
+      t.bigint "rebudgets"
+      t.date "ancestrians"
+      t.date "alcoholisms"
+      t.date "oilproofs"
+      t.datetime "rizzoms", precision: nil
+      t.boolean "heliciforms", default: false, null: false
+      t.string "preaches", limit: 36, null: false
+      t.boolean "unexclusivelies", default: false, null: false
+    end
+
+    create_table "amphicyonidaes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "trichotillomania", null: false
+      t.string "amioideis", null: false
+      t.string "gyronnies", null: false
+      t.datetime "uncongregateds", precision: nil
+      t.datetime "unskimmeds", precision: nil
+      t.text "enhydras", size: :medium
+      t.integer "overdelicates"
+      t.integer "cholecyanines", null: false
+      t.datetime "pensivelies", precision: nil
+      t.datetime "pumpellyites", precision: nil
+    end
+
+    create_table "practicablenesses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "rumneys", null: false
+      t.bigint "psychodramas", null: false
+      t.string "alumnols", limit: 36, null: false
+      t.datetime "finders", precision: nil
+      t.datetime "amicabilities", precision: nil
+    end
+
+    create_table "resawers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "centerwards", limit: 36, null: false
+      t.bigint "postdigitals", null: false
+      t.bigint "oes"
+      t.bigint "presolutions"
+      t.bigint "cuppings"
+      t.bigint "oligidria"
+      t.boolean "unrebellious"
+      t.boolean "soars"
+      t.date "atropas"
+      t.string "undernsongs", null: false
+      t.string "heterologous"
+      t.string "reunifications"
+      t.string "sibbers"
+      t.string "rhodeswoods"
+      t.string "unrevengings"
+      t.string "unpredacious"
+      t.string "overuberous"
+      t.string "limekilns"
+      t.string "pseudomalaria"
+      t.string "similizes"
+      t.string "prickings"
+      t.decimal "psychicals", precision: 16, scale: 2
+      t.string "shampooers"
+      t.string "forereadings"
+      t.string "internasals"
+      t.decimal "importuners", precision: 16, scale: 2
+      t.string "swathables"
+      t.datetime "necrophilistics", precision: nil
+      t.datetime "inconsolablenesses", precision: nil
+      t.boolean "subchordals"
+      t.string "afters"
+      t.string "bepastes", default: "basics", null: false
+      t.bigint "tannaims"
+      t.boolean "pretabulates", default: true, null: false
+      t.boolean "subobtuses", default: false, null: false
+      t.integer "meadowsweets", default: 0, null: false
+      t.date "coeffluentials"
+      t.string "jasponyxes"
+    end
+
+    create_table "palaeethnologics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "antimatrimonialists", limit: 36, null: false, collation: "ascii_general_ci"
+      t.bigint "busybodyisms", null: false
+      t.bigint "perfusions", null: false
+      t.decimal "anglicans", precision: 16, scale: 2, default: "0.0"
+      t.decimal "this", precision: 16, scale: 2, default: "0.0"
+      t.decimal "hydracids", precision: 16, scale: 2, default: "0.0"
+      t.string "pulpectomies"
+      t.datetime "naamen", precision: nil
+      t.datetime "aneroids", precision: nil
+    end
+
+    create_table "uncarnivorous", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "tunnelists", limit: 36, null: false, collation: "ascii_general_ci"
+      t.bigint "tallets", null: false
+      t.bigint "unornamentallies", null: false
+      t.string "arthels"
+      t.boolean "myotomics", default: false
+      t.datetime "hospices", precision: nil
+      t.datetime "mahris", precision: nil
+    end
+
+    create_table "overbusies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "awans", limit: 36, null: false, collation: "ascii_general_ci"
+      t.bigint "abruptedlies", null: false
+      t.date "crowneds"
+      t.date "crucilies"
+      t.boolean "nonculminations", default: false
+      t.string "trypanolysins"
+      t.date "microphallus"
+      t.date "unlawfulnesses"
+      t.datetime "esquamates", precision: nil
+      t.boolean "cosmatis", default: true
+      t.datetime "unclosables", precision: nil
+      t.datetime "subcoastals", precision: nil
+    end
+
+    create_table "odalmen", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "brechams", limit: 36, null: false
+      t.bigint "painties", null: false
+      t.integer "havingnesses"
+      t.boolean "transformatives", default: false
+      t.integer "bitumes"
+      t.boolean "deposables", default: false
+      t.datetime "periapts", precision: nil, null: false
+      t.datetime "exoascaceaes", precision: nil, null: false
+      t.boolean "undermaths", default: false, null: false
+      t.boolean "overinflatives", default: false
+      t.boolean "marques", default: false
+      t.bigint "biscayanisms"
+    end
+
+    create_table "selfishnesses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "imperils"
+      t.date "iberisms"
+      t.datetime "apertureds", precision: nil
+      t.datetime "fernies", precision: nil
+    end
+
+    create_table "angelots", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "quaveries", null: false
+      t.string "aerotonometers", null: false
+      t.datetime "subseptuples", precision: nil
+      t.datetime "glumpies", precision: nil
+    end
+
+    create_table "milkfishes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "prebendates", null: false
+      t.datetime "understimulus", precision: nil
+      t.datetime "craterids", precision: nil
+      t.bigint "psychoclinics"
+    end
+
+    create_table "osazones", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "platymeries", null: false
+      t.text "yus", null: false
+      t.datetime "temporocentrals", precision: nil
+      t.datetime "prelumbars", precision: nil
+      t.bigint "rhizostomata"
+      t.bigint "sectiles", null: false
+    end
+
+    create_table "fanons", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "somacules", null: false
+      t.boolean "oversweeps"
+      t.text "strata"
+      t.datetime "nonautomotives", precision: nil
+      t.datetime "antheriforms", precision: nil
+      t.boolean "basiscopics", default: false
+      t.integer "chorographics", default: 0
+      t.boolean "superindulgences", default: false
+    end
+
+    create_table "pleuritis", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.datetime "leptocephalis", precision: nil
+      t.bigint "overtrains", null: false
+      t.decimal "hollandites", precision: 16, scale: 2, null: false
+      t.bigint "tripeptides"
+      t.bigint "genoeses"
+      t.bigint "subsidiarinesses"
+      t.datetime "heptamerous", precision: nil, null: false
+      t.datetime "noils", precision: nil, null: false
+      t.integer "hemiprisms", limit: 1, default: 1, null: false
+      t.string "oreodons", default: "Tax department payment", null: false
+      t.string "camestres", default: "", null: false
+      t.bigint "ungrievings"
+      t.integer "seasoners"
+    end
+
+    create_table "witloofs", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.datetime "videttes", precision: nil
+      t.decimal "unpots", precision: 16, scale: 2, default: "0.0", null: false
+      t.bigint "lamellates"
+      t.bigint "unforgettings"
+      t.integer "pseudodiagnoses"
+      t.datetime "geneticallies", precision: nil
+      t.datetime "fraternallies", precision: nil
+      t.integer "manubriateds", limit: 1, default: 1, null: false
+      t.string "thermometrics"
+      t.integer "censurables"
+    end
+
+    create_table "totalizators", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "chilognaths"
+      t.boolean "copperizes", default: true, null: false
+      t.bigint "mozarabics"
+      t.datetime "nationalistics", precision: nil
+      t.datetime "mantispidaes", precision: nil
+    end
+
+    create_table "postsphygmics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "bashmurics", null: false
+      t.string "illiteratenesses"
+      t.datetime "chylificatories", precision: nil, null: false
+      t.datetime "beloeilites", precision: nil, null: false
+    end
+
+    create_table "teleostomis", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "occasionaries"
+      t.string "gignates"
+      t.integer "beblotches"
+      t.string "woads"
+      t.string "laryngographies"
+      t.text "antivaccinists", size: :medium
+      t.string "unbestarreds"
+    end
+
+    create_table "veratrylidenes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "renovatories", null: false
+      t.datetime "excitables", precision: nil, null: false
+      t.datetime "cossas", precision: nil, null: false
+      t.bigint "bdellotomies", null: false
+    end
+
+    create_table "ticktacks", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "selectmen", limit: 36, null: false
+      t.bigint "fictioneers", null: false
+      t.datetime "paradichlorbenzenes", precision: nil
+      t.datetime "acarologies", precision: nil
+      t.string "phosphoriferous", default: "OTHER", null: false
+      t.integer "innervates", null: false
+    end
+
+    create_table "interactionisms", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "illaqueations"
+      t.boolean "tartarins", default: true
+      t.datetime "laminars", precision: nil
+      t.datetime "skelves", precision: nil
+    end
+
+    create_table "pontificious", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "reconsigns", limit: 36, null: false
+      t.string "chrismaries", limit: 36, null: false
+      t.bigint "mycelioids", null: false
+      t.datetime "sads", precision: nil
+      t.string "taxonomies"
+      t.datetime "mausoleans", precision: nil
+      t.datetime "planispherics", precision: nil
+      t.string "dottles"
+      t.datetime "pathlessnesses", precision: nil
+    end
+
+    create_table "pythonomorphas", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "bakeovens"
+      t.string "gametoids"
+      t.string "testifies"
+      t.string "neoterics"
+      t.string "homotypicals"
+      t.datetime "participates", precision: nil
+      t.datetime "swellishnesses", precision: nil
+      t.string "miseducations", limit: 36
+      t.bigint "physeters"
+    end
+
+    create_table "gayishes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "dusklies", limit: 36, null: false
+      t.bigint "europia", null: false
+      t.date "algebraizations", null: false
+      t.datetime "burlilies", precision: nil
+      t.datetime "preadamiticals", precision: nil
+    end
+
+    create_table "cocowoods", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "peridiastolics", null: false
+      t.bigint "reindeers", null: false
+      t.boolean "nonequatorials", default: false, null: false
+      t.date "shrups", null: false
+      t.date "orthographists"
+      t.datetime "ramadas", precision: nil, null: false
+      t.datetime "electromers", precision: nil, null: false
+      t.boolean "epilogues"
+      t.string "gestics", limit: 36, null: false
+    end
+
+    create_table "reckons", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "thunderfuls", null: false
+      t.bigint "unelementals", null: false
+    end
+
+    create_table "shards", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "immanentisms", null: false
+      t.bigint "paromoeons", null: false
+      t.datetime "nonsymptomatics", precision: nil, null: false
+      t.datetime "nonresidentials", precision: nil, null: false
+    end
+
+    create_table "boxerisms", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "pneumatotactics", null: false
+      t.integer "pseudamphoras", null: false
+      t.integer "millmen", null: false
+      t.date "tumoreds"
+      t.datetime "pinfeatherers", precision: nil, null: false
+      t.datetime "apyonins", precision: nil, null: false
+      t.decimal "kameelthorns", precision: 16, scale: 2
+    end
+
+    create_table "polylogies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "nondamageables"
+      t.bigint "fussifications"
+      t.decimal "syntonies", precision: 16, scale: 2, default: "0.0"
+      t.decimal "vegetants", precision: 16, scale: 2
+      t.datetime "crotals", precision: nil, null: false
+      t.datetime "hydromonoplanes", precision: nil, null: false
+      t.decimal "backwoodsies", precision: 16, scale: 2, default: "0.0"
+      t.decimal "preperuses", precision: 16, scale: 2
+      t.boolean "unascertaineds", default: false
+      t.boolean "brewers", default: false
+      t.boolean "baluchitheria", default: false
+      t.integer "lamellatelies"
+      t.boolean "undoubtednesses", default: true
+      t.string "cornbells"
+      t.bigint "patrioteers"
+      t.decimal "eyeglances", precision: 16, scale: 2
+      t.integer "khowars", default: 0
+      t.datetime "reconcretes", precision: nil
+      t.date "pamprodactylous", null: false
+      t.date "usurpings", null: false
+      t.string "viceregallies", limit: 36
+      t.string "noncurrencies"
+      t.boolean "bandicoots", default: false
+      t.string "yis"
+      t.string "streelers", limit: 36, null: false
+    end
+
+    create_table "septifolious", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.date "ascanians"
+      t.date "bunkums"
+      t.text "cypselines"
+      t.bigint "quins"
+      t.bigint "metromania"
+      t.datetime "ichoglans", precision: nil, null: false
+      t.datetime "scopines", precision: nil, null: false
+    end
+
+    create_table "unoffendinglies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "exiles"
+      t.bigint "prosies"
+      t.datetime "asiphonogamas", precision: nil, null: false
+      t.datetime "forenoons", precision: nil, null: false
+      t.bigint "cynomoria"
+    end
+
+    create_table "liners", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "autophonies"
+      t.bigint "rangerships"
+      t.string "laterotemporals", null: false
+      t.datetime "saucemakings", precision: nil, null: false
+      t.datetime "nonentityisms", precision: nil, null: false
+      t.decimal "phonetics", precision: 16, scale: 2
+    end
+
+    create_table "purlmen", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "protriaenes"
+      t.bigint "ethnographicallies"
+      t.decimal "starvers", precision: 16, scale: 2, default: "0.0"
+      t.decimal "hemautographics", precision: 6, scale: 3, default: "0.0"
+      t.boolean "hypsophyllous", default: true
+      t.datetime "sosos", precision: nil, null: false
+      t.datetime "exorbitations", precision: nil, null: false
+    end
+
+    create_table "monumentlesses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "unsatanics", limit: 36, null: false
+      t.bigint "diallages", null: false
+      t.datetime "artillerists", precision: nil
+      t.datetime "dissipatedlies", precision: nil
+    end
+
+    create_table "jeans", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "danielics", null: false
+      t.bigint "luridnesses", null: false
+      t.datetime "shanghais", precision: nil, null: false
+      t.datetime "albespines", precision: nil, null: false
+    end
+
+    create_table "peristeropodes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "obtusangulars", null: false
+      t.boolean "i9_document", default: false
+      t.boolean "snippinesses", default: true
+      t.boolean "stalkings", default: false
+      t.datetime "bedsprings", precision: nil
+      t.datetime "calvers", precision: nil
+      t.datetime "palagonites", precision: nil
+      t.datetime "trabecularisms", precision: nil
+      t.boolean "endoplastrons", default: false
+      t.boolean "rocks", default: false
+      t.text "stylidia"
+      t.text "chelonians"
+      t.text "crabeaters"
+      t.string "peltatifids", limit: 36
+    end
+
+    create_table "cardinalists", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "hemoleucocytics", null: false
+      t.string "monoousians", null: false
+      t.decimal "reappreciates", precision: 16, scale: 2, default: "0.0"
+      t.string "compassionlesses"
+      t.date "ixionians"
+      t.datetime "crurogenitals", precision: nil, null: false
+      t.datetime "cryptogamicals", precision: nil, null: false
+      t.string "squaddies"
+      t.string "saginas"
+      t.boolean "multiturns", default: false, null: false
+      t.string "exuberations", limit: 36
+    end
+
+    create_table "transferribilities", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "tridecylenes", null: false
+      t.datetime "tricephals", precision: nil
+      t.datetime "effluents", precision: nil
+      t.bigint "mores", null: false
+      t.date "stellaria", null: false
+      t.date "spinulosogranulates", null: false
+    end
+
+    create_table "laboulbenia", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "ureterolithiases"
+      t.decimal "laminates", precision: 16, scale: 6
+      t.datetime "dullsomes", precision: nil, null: false
+      t.datetime "gymnarchidaes", precision: nil, null: false
+      t.boolean "turcos", default: true, null: false
+      t.boolean "unauthorishes"
+      t.string "torridlies"
+      t.boolean "orangs", default: true, null: false
+      t.string "yogas", limit: 36, null: false
+    end
+
+    create_table "overtenses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "ditrochees", null: false
+      t.bigint "aristotelianisms", null: false
+      t.date "seborrheics", null: false
+      t.datetime "insenses", precision: nil, null: false
+      t.datetime "tuberculomas", precision: nil, null: false
+      t.string "loofs"
+      t.string "disacknowledgements", limit: 36
+    end
+
+    create_table "taxeaters", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "fijians"
+      t.string "colchicaceaes"
+      t.decimal "meteorologicals", precision: 16, scale: 2, default: "0.0"
+      t.integer "interallies"
+      t.datetime "slickeries", precision: nil, null: false
+      t.datetime "liegers", precision: nil, null: false
+    end
+
+    create_table "unmotivatedlies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "parsonizes", limit: 36, null: false
+      t.string "flustras", null: false
+      t.string "foliiforms", limit: 36
+      t.datetime "rabbits", precision: nil
+      t.datetime "varlets", precision: nil
+      t.datetime "whiggarchies", precision: nil
+    end
+
+    create_table "ospreys", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "conceits"
+      t.string "gymnocalycia", null: false
+      t.decimal "scunners", precision: 16, scale: 2
+      t.boolean "canines", default: true
+      t.datetime "glaucophanizations", precision: nil, null: false
+      t.datetime "undyings", precision: nil, null: false
+      t.boolean "munshis", default: true
+      t.string "steers", limit: 36
+      t.string "achaetous", limit: 36, null: false
+      t.bigint "continuers"
+    end
+
+    create_table "granitelikes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.datetime "bankriders", precision: nil, null: false
+      t.datetime "beadeds", precision: nil, null: false
+      t.integer "hamelia", null: false
+      t.integer "sicklies", null: false
+      t.date "undrunkens", null: false
+      t.date "unspherings", null: false
+      t.bigint "paternalities", null: false
+      t.boolean "headframes", default: false, null: false
+    end
+
+    create_table "parachors", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "agroans"
+      t.string "coremia"
+      t.decimal "gastrohysterotomies", precision: 16, scale: 2, default: "0.0"
+      t.boolean "pipewoods"
+      t.decimal "arapahos", precision: 16, scale: 2, default: "0.0"
+      t.decimal "coterminous", precision: 16, scale: 2, default: "0.0"
+      t.decimal "slavdoms", precision: 16, scale: 2, default: "0.0"
+      t.datetime "thores", precision: nil, null: false
+      t.datetime "fulminics", precision: nil, null: false
+    end
+
+    create_table "sublaryngeals", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "eardroppers"
+      t.integer "amortizes"
+      t.string "sclerous"
+      t.datetime "phils", precision: nil, null: false
+      t.datetime "albuminaturia", precision: nil, null: false
+      t.decimal "woolenets", precision: 16, scale: 2, default: "0.0"
+      t.boolean "mandarinisms"
+      t.string "dipsaceaes"
+      t.text "betonies"
+      t.boolean "pleasemen", default: true
+      t.string "phajus"
+      t.string "jauks", limit: 36
+    end
+
+    create_table "tetralemmas", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "bitheisms"
+      t.string "implicants"
+      t.string "mounts"
+      t.string "fimbrillates"
+      t.date "characterisms"
+      t.string "unhippeds"
+      t.boolean "voicelessnesses", default: false
+      t.datetime "beakermen", precision: nil, null: false
+      t.datetime "inhales", precision: nil, null: false
+      t.integer "grandiloquences"
+      t.string "dishexecontahedroids"
+      t.string "manualiters"
+      t.boolean "provocants", default: false
+      t.boolean "enlodgements", default: true
+      t.integer "strigaes"
+      t.integer "consciencelesslies"
+      t.boolean "tunkets", default: true
+      t.bigint "linearlies"
+      t.bigint "uniridescents"
+      t.boolean "unidirecteds", default: false, null: false
+      t.string "carbocinchomeronics", limit: 36, null: false
+      t.string "orthopteroideas", null: false
+      t.bigint "alexipyretics", null: false
+      t.datetime "superseptals", precision: nil
+    end
+
+    create_table "losts", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "wildsomes", limit: 36, null: false
+      t.bigint "beproses", null: false
+      t.string "antimarks"
+      t.string "kommos"
+      t.date "ammoniates"
+      t.datetime "pseudocotyledonals", precision: nil, null: false
+      t.datetime "bohunks", precision: nil, null: false
+      t.string "subintellections", null: false
+    end
+
+    create_table "archegoniates", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "spectrohelioscopes", limit: 36, null: false
+      t.string "shabbifies", limit: 36, null: false
+      t.string "uromyces", limit: 36
+      t.string "corrigibilities", limit: 36, null: false
+      t.string "nonzonates", limit: 36
+      t.string "pigeonables", null: false
+      t.bigint "luminals", null: false
+      t.string "dermoplasties", limit: 36, null: false
+      t.datetime "malmseys", precision: nil, null: false
+      t.datetime "soulfuls", precision: nil
+      t.datetime "karyologicallies", precision: nil, null: false
+      t.datetime "unzealousnesses", precision: nil, null: false
+    end
+
+    create_table "tizzies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "isoagglutinogens"
+      t.date "wittifieds", null: false
+      t.date "intrusions"
+      t.boolean "storaxes", default: false
+      t.boolean "lokmen", default: false
+      t.boolean "nonpartisans"
+      t.date "theriacs"
+      t.string "amaterialistics"
+      t.date "preposterouslies"
+      t.datetime "bubastids", precision: nil
+      t.datetime "reoffenses", precision: nil
+      t.date "emcees"
+      t.boolean "unstintinglies", default: false, null: false
+      t.string "tiemakers", limit: 36, null: false
+    end
+
+    create_table "synchromeshes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.datetime "xeranthemums", precision: nil, null: false
+      t.datetime "heptaces", precision: nil, null: false
+      t.string "semiexposeds", limit: 36, null: false
+      t.bigint "unseals"
+      t.bigint "beloveds", null: false
+      t.string "asteisms", null: false
+      t.string "loas"
+      t.string "murderings"
+    end
+
+    create_table "waistcoatings", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "tetrabranchia", limit: 36, null: false
+      t.string "simultaneouslies", null: false
+      t.text "lusitania"
+      t.text "rituallies"
+      t.decimal "thalassiophytes", precision: 6, scale: 2
+      t.datetime "sulphantimonides", precision: nil
+      t.datetime "belights", precision: nil
+    end
+
+    create_table "steatolytics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "gallinaceaes", limit: 36, null: false
+      t.bigint "ceroxylons", null: false
+      t.string "coagitates", null: false
+      t.string "dabihs"
+      t.text "semitorpids"
+      t.datetime "extravagates", precision: nil, null: false
+      t.datetime "cotyligerous", precision: nil, null: false
+    end
+
+    create_table "unmodifiables", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "miscooks", limit: 36, null: false
+      t.bigint "unbehelds"
+      t.datetime "sworns", precision: nil, null: false
+      t.string "peromelous", default: "draft", null: false
+      t.datetime "ependymomas", precision: nil, null: false
+      t.datetime "bulleteds", precision: nil, null: false
+      t.string "stereographies"
+      t.text "bescrapes"
+      t.bigint "accustomeds"
+      t.string "negatednesses"
+      t.datetime "subgeometrics", precision: nil
+      t.datetime "pretastes", precision: nil
+    end
+
+    create_table "correlativisms", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.datetime "yawroots", precision: nil, null: false
+      t.datetime "touchstones", precision: nil, null: false
+      t.string "drumlies", limit: 36, null: false
+      t.string "metapterygia", null: false
+      t.bigint "brans", null: false
+      t.boolean "pinguiculas", null: false
+      t.bigint "seagoings", null: false
+      t.date "odontists"
+      t.date "superdyings"
+    end
+
+    create_table "undrippings", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "tetracolics", limit: 36, null: false
+      t.decimal "palemen", precision: 16, scale: 2
+      t.string "owlishlies", null: false
+      t.decimal "copperers", precision: 16, scale: 2
+      t.string "carabidoids", null: false
+      t.decimal "subcontinuals", precision: 16, scale: 2
+      t.string "outswifts", null: false
+      t.string "elaphures", null: false
+      t.text "barids"
+      t.text "firefangeds"
+      t.date "brines", null: false
+      t.string "aurigas", null: false
+      t.string "epigonations", null: false
+      t.date "mingles"
+      t.datetime "inswells", precision: nil
+      t.datetime "murderinglies", precision: nil
+      t.bigint "donatiaceaes", null: false
+    end
+
+    create_table "conclaves", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "effaces", limit: 36, null: false
+      t.string "fellinics"
+      t.string "completements"
+      t.decimal "pedagogics", precision: 16, scale: 2
+      t.text "untailorlies"
+      t.date "basketworks"
+      t.string "colubrines"
+      t.bigint "hemopoieses", null: false
+      t.string "untemptings"
+      t.string "lateriflorous", null: false
+      t.date "drawtubes"
+      t.bigint "deceivinglies"
+      t.boolean "apioidals", default: false
+      t.datetime "craftsmasters", precision: nil, null: false
+      t.datetime "laconicas", precision: nil, null: false
+      t.string "monactinellidans", null: false
+    end
+
+    create_table "cardiarctia", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "cowlicks", limit: 36, null: false
+      t.string "wiredrawns", limit: 36
+      t.string "osphradials", limit: 36
+      t.bigint "bridlers", null: false
+      t.string "adulterates"
+      t.datetime "vilehearteds", precision: nil
+      t.string "prawns"
+      t.string "knackers"
+      t.string "emmets"
+      t.string "preinductions"
+      t.string "overdashes"
+      t.boolean "okapis"
+      t.datetime "inspectives", precision: nil
+      t.string "capomos"
+      t.string "paradefuls"
+      t.string "moonjahs"
+      t.datetime "gelations", precision: nil, null: false
+      t.datetime "pronegotiations", precision: nil, null: false
+    end
+
+    create_table "coshers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "alantics", limit: 36, null: false
+      t.bigint "minionships", null: false
+      t.string "semiessays", null: false
+      t.decimal "contractiblenesses", precision: 16, scale: 2
+      t.string "arabilities", null: false
+      t.decimal "carburometers", precision: 16, scale: 2
+      t.string "magisterials", null: false
+      t.text "masonries"
+      t.text "origenics"
+      t.string "unravelments", null: false
+      t.date "garderobes"
+      t.datetime "dissolutenesses", precision: nil
+      t.datetime "hopelessnesses", precision: nil
+      t.boolean "odontomous", default: false
+    end
+
+    create_table "frisolees", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "gopuras", limit: 36, null: false
+      t.string "papesses", null: false
+      t.string "aerosiderites", null: false
+      t.string "tormentinglies", null: false
+      t.string "pyrologists"
+      t.string "pterygoquadrates", null: false
+      t.string "enravishments", null: false
+      t.string "conveniencies", null: false
+      t.date "dianders", null: false
+      t.string "microcosms", null: false
+      t.string "cantboards"
+      t.string "ovenlies"
+      t.string "ruminates"
+      t.float "scanics", null: false
+      t.string "processes", null: false
+      t.string "sonchus", null: false
+      t.float "undecimen", null: false
+      t.float "whifflings"
+      t.float "oologies"
+      t.float "tartens"
+      t.float "filices"
+      t.float "acnemia"
+      t.float "uncontentious"
+      t.float "spinthariscopes"
+      t.float "baseballdoms"
+      t.float "neophytes"
+      t.float "broweds"
+      t.float "rivetlesses"
+      t.float "epichorials"
+      t.float "goburras"
+      t.float "broadways", null: false
+      t.bigint "powerfullies", null: false
+      t.bigint "thrums", null: false
+      t.float "talers", null: false
+      t.float "inhumes", null: false
+      t.datetime "lesseners", precision: nil
+      t.datetime "caducities", precision: nil
+      t.float "josies", null: false
+    end
+
+    create_table "bentangs", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "slaglesses", limit: 36, null: false
+      t.bigint "dokos", null: false
+      t.bigint "abistons", null: false
+      t.text "homoeopathics", null: false
+      t.datetime "interdestructivenesses", precision: nil, null: false
+      t.datetime "laris", precision: nil, null: false
+    end
+
+    create_table "uniparous", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "comals", limit: 36, null: false
+      t.string "cedents", null: false
+      t.string "tubbals", null: false
+      t.string "sinkages", null: false
+      t.string "grummeters"
+      t.string "latonians", null: false
+      t.string "groomishes", null: false
+      t.string "syphilous", null: false
+      t.date "wisers", null: false
+      t.string "icterogenetics", null: false
+      t.string "helminthisms"
+      t.string "panoptics"
+      t.string "dikages"
+      t.float "iscariotisms", null: false
+      t.string "trichomonas", null: false
+      t.string "skedgewiths", null: false
+      t.float "detaxes", null: false
+      t.float "soothingnesses"
+      t.float "pilars"
+      t.float "perilabyrinthitis"
+      t.float "asbestos"
+      t.float "awbers"
+      t.float "shelvers"
+      t.float "nonimperials"
+      t.float "dianas"
+      t.float "demipremisses"
+      t.float "isoimmunizes"
+      t.float "symposia"
+      t.float "theogonists"
+      t.float "oppugnances"
+      t.float "paraphrasters", null: false
+      t.bigint "volutins"
+      t.bigint "schules", null: false
+      t.bigint "postpharyngeals", null: false
+      t.float "quavers", null: false
+      t.float "hazards", null: false
+      t.datetime "snurs", precision: nil
+      t.datetime "idolothytes", precision: nil
+      t.float "cardiomyoliposes", null: false
+    end
+
+    create_table "tammanies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "tellers", limit: 36, null: false
+      t.string "isuretines"
+      t.string "usselves"
+      t.decimal "fluentnesses", precision: 16, scale: 2
+      t.text "subclovers"
+      t.date "indefectiblies"
+      t.date "phonophorous"
+      t.date "sakis"
+      t.integer "hollowfaceds"
+      t.string "hemerobiids"
+      t.bigint "unfiles", null: false
+      t.string "policemanlikes", null: false
+      t.boolean "provokables", default: false
+      t.datetime "chondrogenies", precision: nil, null: false
+      t.datetime "interimistics", precision: nil, null: false
+      t.string "accepteds", null: false
+    end
+
+    create_table "octodontidaes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "undominicals", limit: 36, null: false
+      t.bigint "huterians", null: false
+      t.integer "globosphaerites", null: false
+      t.datetime "vivisects", precision: nil, null: false
+      t.datetime "benedictives", precision: nil, null: false
+      t.datetime "scuppernongs", precision: nil, null: false
+    end
+
+    create_table "limners", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "counteravouches", limit: 36, null: false
+      t.string "coapprisers", limit: 36, null: false
+      t.string "unbeaueds", limit: 36, null: false
+      t.bigint "crescentades", null: false
+      t.bigint "colipyelitis"
+      t.datetime "parteds", precision: nil, null: false
+      t.string "unexpungeds", null: false
+      t.string "unaffables", null: false
+      t.datetime "buphthalmia", precision: nil, null: false
+      t.datetime "trypanosomics", precision: nil, null: false
+      t.string "tectibranchiates", null: false
+      t.bigint "cocaines"
+    end
+
+    create_table "aldrovandas", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "nephrostomous", null: false
+      t.bigint "windways", null: false
+      t.string "munchers", limit: 36, null: false
+      t.datetime "orinasals", precision: nil
+      t.datetime "protopoetics", precision: nil
+    end
+
+    create_table "groundsels", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "precontends", null: false
+      t.bigint "underroasts", null: false
+      t.bigint "indehiscences", null: false
+      t.datetime "cochlears", precision: nil, null: false
+      t.datetime "pyrosomes", precision: nil, null: false
+    end
+
+    create_table "irreversibilities", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "sourcakes", null: false
+      t.boolean "uppricks", null: false
+      t.text "historizes", null: false
+      t.datetime "tetraketones", precision: nil, null: false
+      t.datetime "corniculates", precision: nil, null: false
+    end
+
+    create_table "drummies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.integer "lyreflowers", null: false
+      t.string "multisegmentates", null: false
+      t.string "hysterolaparotomies", null: false
+      t.string "popularists", null: false
+      t.text "beaglings"
+      t.text "spindrifts", null: false
+      t.text "obsequiences"
+      t.datetime "doctrinisms", precision: nil, null: false
+      t.datetime "trousereds", precision: nil, null: false
+      t.text "goldenperts"
+    end
+
+    create_table "rectectomies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.integer "ectoplasms", default: 0, null: false
+      t.bigint "feifs", null: false
+      t.integer "remisslies", null: false
+      t.datetime "sculptographs", precision: nil
+      t.datetime "phelloplastics", precision: nil
+      t.bigint "undishearteneds"
+      t.string "spectaclemakings"
+    end
+
+    create_table "keratolyses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "traceabilities", null: false
+      t.bigint "pythiads", null: false
+      t.string "cirrhotics"
+      t.datetime "globuliforms", precision: nil, null: false
+      t.datetime "crenellates", precision: nil, null: false
+      t.datetime "expalpates", precision: nil
+      t.datetime "toms", precision: nil
+    end
+
+    create_table "fermentatives", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "coobas", null: false
+      t.bigint "intercondyloids", null: false
+      t.datetime "fondaks", precision: nil, null: false
+      t.datetime "bumblebees", precision: nil, null: false
+      t.datetime "footsores", precision: nil
+      t.datetime "loses", precision: nil
+    end
+
+    create_table "cephalalgia", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "aceldamas"
+      t.string "unstigmatizeds"
+      t.bigint "mordants"
+      t.bigint "typotheria"
+      t.string "nonadverbials"
+      t.text "monosomes"
+      t.datetime "benzylidenes", precision: nil, null: false
+      t.datetime "landeds", precision: nil, null: false
+      t.bigint "sportulaes"
+    end
+
+    create_table "ocreaceous", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "collapses", limit: 36, null: false, collation: "ascii_general_ci"
+      t.string "unpolarizables", limit: 36, null: false, collation: "ascii_general_ci"
+      t.datetime "eminencies", precision: nil, null: false
+      t.datetime "solanaceaes", precision: nil
+      t.datetime "supermannishes", precision: nil
+      t.datetime "learnerships", precision: nil
+    end
+
+    create_table "unclothedlies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "radiobroadcasters", limit: 36, null: false, collation: "ascii_general_ci"
+      t.string "rewidens", limit: 36, null: false, collation: "ascii_general_ci"
+      t.datetime "polygynia", precision: nil, null: false
+      t.datetime "salmiacs", precision: nil
+      t.datetime "fluelesses", precision: nil
+      t.datetime "nonvassals", precision: nil
+    end
+
+    create_table "trichodontidaes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "kaisers", limit: 36, null: false, collation: "ascii_general_ci"
+      t.string "homoeogenics", limit: 36, null: false, collation: "ascii_general_ci"
+      t.boolean "obreptions", null: false
+      t.datetime "antihypochondriacs", precision: nil
+      t.datetime "orichalcums", precision: nil
+    end
+
+    create_table "eriogonums", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "gravics", limit: 36, null: false, collation: "ascii_general_ci"
+      t.integer "longobardics", null: false
+      t.string "plurifies", limit: 36, null: false, collation: "ascii_general_ci"
+      t.string "hymeneallies", null: false
+      t.datetime "scyphostomas", precision: nil, null: false
+      t.datetime "overglasses", precision: nil
+      t.datetime "overmellows", precision: nil
+      t.string "primarieds"
+      t.string "pyropes"
+    end
+
+    create_table "dishpanfuls", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "eremologies", limit: 36, null: false
+      t.string "brimborions", null: false
+      t.datetime "budgers", precision: nil, null: false
+      t.datetime "metallines", precision: nil, null: false
+      t.datetime "squidges", precision: nil, null: false
+      t.bigint "skimpilies"
+      t.bigint "hydronephelites"
+    end
+
+    create_table "prankishlies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "dionaeas"
+      t.string "pukkas"
+      t.datetime "scholions", precision: nil, null: false
+      t.datetime "griffons", precision: nil, null: false
+      t.bigint "disministers"
+      t.date "anapterygotous"
+      t.boolean "sylvages"
+    end
+
+    create_table "unexclusives", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "grinds", null: false
+      t.date "malics"
+      t.string "forgettinglies"
+      t.datetime "inguinocutaneous", precision: nil
+      t.datetime "bubalines", precision: nil
+      t.string "blesses"
+      t.string "rechisels"
+      t.integer "inappealables"
+      t.datetime "gelatins", precision: nil
+      t.string "slackings", limit: 36, null: false
+    end
+
+    create_table "koffs", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "otogenics", null: false
+      t.string "pairs"
+      t.string "pileds"
+      t.string "euphonisms"
+      t.datetime "bowlings", precision: nil, null: false
+      t.datetime "schizomycetes", precision: nil, null: false
+      t.integer "translays"
+      t.string "satanophanies"
+      t.boolean "immensurates", default: false
+    end
+
+    create_table "inguinals", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "typifiers", limit: 36, null: false
+      t.string "external401k_contribution_scheme_uuid", limit: 36, null: false
+      t.decimal "matchbooks", precision: 16, scale: 6
+      t.decimal "dyschiria", precision: 16, scale: 6
+      t.decimal "sodalists", precision: 16, scale: 6
+      t.string "reproachlessnesses"
+      t.datetime "schizolysigenous", precision: nil
+      t.datetime "osteodentinals", precision: nil
+    end
+
+    create_table "spiros", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "stahlisms", limit: 36, null: false
+      t.bigint "alaskites"
+      t.string "external401k_plan_record_uuid", limit: 36, null: false
+      t.string "apagogics", null: false
+      t.string "cocillanas"
+      t.datetime "hideous", precision: nil
+      t.datetime "misotheists", precision: nil
+    end
+
+    create_table "tyrannicides", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "subjugations", limit: 36, null: false
+      t.bigint "noninstructions", null: false
+      t.string "onychophorous", null: false
+      t.string "malloseismics", null: false
+      t.datetime "tetraphosphates", precision: nil, null: false
+      t.datetime "mummichogs", precision: nil, null: false
+      t.text "barytophyllites"
+      t.string "patterns"
+    end
+
+    create_table "pianettes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "grandfatherishes", limit: 36, null: false
+      t.bigint "phototropies", null: false
+      t.string "peathouses"
+      t.string "profitproofs"
+      t.string "oligopsychia"
+      t.string "dacyorrheas"
+      t.datetime "succinates", precision: nil
+      t.datetime "clivers", precision: nil
+    end
+
+    create_table "scourweeds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "compostures", null: false
+      t.string "phyllopodes", null: false
+      t.text "luscious", null: false
+      t.string "bipontines", null: false
+      t.bigint "applejohns"
+      t.string "pentiodides"
+      t.integer "codes", default: 0, null: false
+      t.datetime "clifflets", precision: nil, null: false
+      t.datetime "persuasibles", precision: nil, null: false
+      t.bigint "diazides"
+      t.string "trixies"
+      t.string "inexistents"
+      t.datetime "interweds", precision: nil
+      t.string "quercetagetins"
+      t.string "nehemiahs", default: "NONE", null: false
+      t.string "unmeddlingnesses", limit: 36
+    end
+
+    create_table "zootaxies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "maclureas", limit: 36, null: false
+      t.string "propagators", null: false
+      t.string "feminologies", null: false
+      t.string "dasturis", null: false
+      t.bigint "unquarrieds"
+      t.datetime "boondocks", precision: nil
+      t.datetime "hystricisms", precision: nil
+    end
+
+    create_table "unscarifieds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "crystallizers", limit: 36, null: false
+      t.decimal "bathetics", precision: 36, scale: 2, null: false
+      t.bigint "disinvaginations", null: false
+      t.string "unstraddleds", limit: 8, null: false
+      t.string "outlookers", limit: 280, null: false
+      t.string "unpleaseds", null: false
+      t.datetime "homodromous", precision: nil
+      t.datetime "neutrophilics", precision: nil
+      t.date "unattainings", null: false
+      t.datetime "asides", precision: nil
+      t.datetime "coenobiars", precision: nil
+      t.datetime "cuttlebones", precision: nil
+      t.string "thoroughspeds", null: false
+      t.bigint "excandescents", null: false
+    end
+
+    create_table "chronotropics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "pharmacopolists", limit: 36, null: false
+      t.string "theandrics", null: false
+      t.string "toglesses", null: false
+      t.string "edifices"
+      t.string "sextants"
+      t.string "overpampers"
+      t.bigint "unfurls"
+      t.datetime "godowns", precision: nil, null: false
+      t.datetime "zooses", precision: nil, null: false
+      t.string "sulphamidics", null: false
+      t.string "championships"
+    end
+
+    create_table "rhabditiforms", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "corectors", null: false
+      t.boolean "headstrongs", default: false, null: false
+      t.boolean "coccygerectors", default: false, null: false
+      t.bigint "semipyramidals"
+      t.datetime "bustics", precision: nil, null: false
+      t.datetime "understrungs", precision: nil, null: false
+      t.boolean "rephotographs", default: false, null: false
+    end
+
+    create_table "hivers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.date "unmodishes"
+      t.bigint "unsalines"
+      t.string "savins"
+      t.bigint "biocoenotics"
+      t.bigint "flajolotites"
+      t.bigint "fiendisms"
+      t.string "rejectives"
+      t.boolean "sinistrogyrics", default: false
+      t.datetime "pannades", precision: nil
+      t.datetime "tolerates", precision: nil
+    end
+
+    create_table "orthopsychiatrists", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "schoolhouses"
+      t.integer "electroreductions"
+      t.datetime "highjackers", precision: nil
+      t.datetime "hygrostatics", precision: nil, null: false
+      t.datetime "recentnesses", precision: nil, null: false
+      t.string "spraddles"
+    end
+
+    create_table "euphonetics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "pillarists", null: false
+      t.date "fumaria", null: false
+      t.boolean "earthshakers", default: true, null: false
+      t.integer "oppositivenesses", limit: 1, default: 0, null: false
+      t.datetime "visionics", precision: nil, null: false
+      t.datetime "rhizocephalas", precision: nil, null: false
+    end
+
+    create_table "thimblelikes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "intumesces"
+      t.boolean "borts", default: false
+      t.boolean "corbiculas", default: false
+      t.integer "censorious", limit: 1
+      t.integer "mormyrids", limit: 1
+      t.datetime "hopperettes", precision: nil
+      t.datetime "kiestlesses", precision: nil
+      t.boolean "diplocephalies", default: false
+      t.boolean "pulverizers", default: false
+      t.string "trichinellas"
+      t.string "obligativenesses"
+      t.datetime "plankwises", precision: nil
+      t.string "matchablenesses"
+      t.datetime "contrahents", precision: nil
+    end
+
+    create_table "numskulleds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "topazolites", limit: 36, null: false
+      t.bigint "warlesslies", null: false
+      t.bigint "staphyleas", null: false
+      t.string "exanimations", null: false
+      t.string "rhagionids", null: false
+      t.boolean "cymbocephalous", null: false
+      t.datetime "sandmen", precision: nil, null: false
+      t.datetime "woundworts", precision: nil, null: false
+    end
+
+    create_table "thundersmites", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.integer "trioeciouslies", limit: 1, null: false
+      t.bigint "spiries", null: false
+      t.boolean "yagnobs", default: false, null: false
+      t.datetime "overgrieves", precision: nil
+      t.datetime "dexters", precision: nil
+      t.string "reinterventions"
+      t.bigint "unfrizzs"
+    end
+
+    create_table "quatrocentists", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "splashes", null: false
+      t.integer "constructs", limit: 1
+      t.integer "flackers", limit: 1
+      t.datetime "shires", precision: nil
+      t.datetime "pseudoconcludes", precision: nil
+      t.datetime "myriapodas", precision: nil
+      t.datetime "bungarus", precision: nil
+      t.datetime "rakeages", precision: nil
+      t.datetime "pinelands", precision: nil
+    end
+
+    create_table "quintessentialities", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "unuprightnesses"
+      t.string "ovoviviparities"
+      t.decimal "malaxages", precision: 16, scale: 2, null: false
+      t.decimal "gonnardites", precision: 16, scale: 2, null: false
+      t.bigint "handygrips"
+      t.datetime "skateables", precision: nil
+      t.datetime "metabolous", precision: nil
+      t.bigint "cycloganoideis"
+      t.boolean "myoepicardials", default: false
+      t.datetime "atterns", precision: nil
+      t.datetime "thwarts", precision: nil
+      t.boolean "cabiris", default: false, null: false
+      t.integer "constrainables", default: 0, null: false
+      t.integer "palaeolithicals", limit: 1, default: 0, null: false
+      t.boolean "etiquetticals", default: false
+      t.integer "orbitars", limit: 1, default: 0, null: false
+      t.string "syntelomes"
+      t.bigint "gedackts"
+      t.boolean "orangewoods", default: false
+      t.datetime "becards", precision: nil
+      t.string "praeacetabulars"
+      t.integer "bridgekeepers", limit: 1
+      t.integer "thysanourous", limit: 1
+      t.decimal "credit_limit_v2", precision: 16, scale: 2
+      t.boolean "pledgors", default: false
+      t.decimal "birdclappers", precision: 16, scale: 2, default: "0.0"
+    end
+
+    create_table "polymetochics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "aetobatidaes", limit: 36, null: false
+      t.bigint "posttussives", null: false
+      t.boolean "thorninesses", null: false
+      t.string "autarchoglossas", null: false
+      t.string "hypoeliminators"
+      t.date "ups", null: false
+      t.date "sphaeriidaes"
+      t.date "galvanoglyphs"
+      t.bigint "crystalloluminescences"
+      t.string "benthonics"
+      t.datetime "refrustrates", precision: nil
+      t.datetime "erostrates", precision: nil
+    end
+
+    create_table "nonunanimous", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "anchoretishes", limit: 36, null: false
+      t.bigint "donets", null: false
+      t.string "carbohydrates", null: false
+      t.string "retinoids", null: false
+      t.datetime "malkins", precision: nil, null: false
+      t.datetime "improficiences", precision: nil, null: false
+      t.integer "porterships"
+      t.string "intestinenesses"
+      t.string "topiarians", default: "0.0.1"
+    end
+
+    create_table "notariates", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "selenologicals", null: false
+      t.string "clubsters"
+      t.boolean "branchiurous", default: false, null: false
+      t.integer "reprovisions"
+      t.datetime "salferns", precision: nil, null: false
+      t.datetime "overslights", precision: nil, null: false
+    end
+
+    create_table "stupes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "nengahibas", null: false
+      t.integer "flamencos", null: false
+      t.datetime "phasianus", precision: nil
+      t.text "necrophilics"
+      t.datetime "gedders", precision: nil
+      t.datetime "antilegomenas", precision: nil
+      t.integer "rheumaticals", default: 0, null: false
+      t.bigint "anakineses"
+      t.bigint "hemipinnates"
+    end
+
+    create_table "fatidicallies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "fumisteries"
+      t.bigint "stridhanums", null: false
+      t.datetime "electrometricallies", precision: nil, null: false
+      t.datetime "hierarchics", precision: nil, null: false
+    end
+
+    create_table "decumanus", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "dyewares", limit: 36, null: false
+      t.bigint "electropathologies", null: false
+      t.string "spurwingeds", null: false
+      t.string "merwomen", null: false
+      t.string "socialites"
+      t.text "interagrees"
+      t.decimal "eskimoics", precision: 16, scale: 2
+      t.decimal "chaulmoogras", precision: 16, scale: 2
+      t.decimal "computations", precision: 16, scale: 2
+      t.decimal "coxcomicallies", precision: 16, scale: 2
+      t.integer "liltingnesses"
+      t.boolean "bulrushies"
+      t.datetime "indigoids", precision: nil
+      t.datetime "cixos", precision: nil
+      t.string "inflationisms"
+    end
+
+    create_table "dictyosiphonaceous", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "inexpugnables", null: false
+      t.bigint "marmosas", null: false
+      t.string "songs", null: false
+      t.datetime "nasalis", precision: nil
+      t.datetime "copus", precision: nil
+    end
+
+    create_table "sanctionlesses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "keepables"
+      t.string "concubinates"
+      t.bigint "exsuctions"
+      t.datetime "litterers", precision: nil, null: false
+      t.datetime "elderwoods", precision: nil, null: false
+      t.datetime "quitteds", precision: nil
+      t.string "celtologues"
+      t.text "interfertiles"
+      t.text "counterproposals"
+      t.text "decapitations"
+      t.text "catwalks"
+      t.string "immanifestnesses"
+    end
+
+    create_table "cariamaes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "protaxations"
+      t.string "quindecims"
+      t.string "bines"
+      t.string "decumbencies"
+      t.integer "archduchies"
+      t.datetime "chrysops", precision: nil
+      t.datetime "semimercerizeds", precision: nil
+      t.string "tangelos"
+    end
+
+    create_table "litsters", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "otoblennorrheas"
+      t.date "dungeonlikes"
+      t.string "gallicisms"
+      t.boolean "mobbies", default: false
+      t.datetime "haggishnesses", precision: nil, null: false
+      t.datetime "monophyodonts", precision: nil, null: false
+      t.boolean "akpeks", default: false
+    end
+
+    create_table "vesiculata", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "almeriites", limit: 36, null: false
+      t.bigint "procomedies", null: false
+      t.bigint "osteitis", null: false
+      t.string "serodermatoses", null: false
+      t.string "dindymenes", null: false
+      t.decimal "dephlogisticates", precision: 16, scale: 2, null: false
+      t.decimal "pseudohemals", precision: 16, scale: 2, null: false
+      t.text "vanelikes", null: false
+      t.datetime "rectangulates", precision: nil, null: false
+      t.datetime "unhastes", precision: nil, null: false
+      t.string "unleafeds", limit: 64
+      t.text "hemocoeles"
+      t.string "medicophysicals"
+      t.bigint "hydrosulphates"
+      t.datetime "euconjugataes", precision: nil
+    end
+
+    create_table "hearthrugs", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "quadrangularlies", limit: 36, null: false
+      t.bigint "yotes", null: false
+      t.bigint "spoliaria", null: false
+      t.string "taconians", null: false
+      t.string "nobblers", null: false
+      t.datetime "periodontologists", precision: nil
+      t.datetime "transelements", precision: nil
+    end
+
+    create_table "mataderos", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "witwalls", null: false
+      t.datetime "projectionists", precision: nil
+      t.datetime "tubiforms", precision: nil
+      t.datetime "epidiorites", precision: nil
+      t.datetime "zealotisms", precision: nil
+      t.bigint "organozincs", null: false
+    end
+
+    create_table "cantefables", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "precivilizations", null: false
+      t.integer "noctipotents"
+      t.integer "annihilatives"
+      t.string "horatios"
+      t.text "nonmaterialistics"
+      t.bigint "unreassuringlies", null: false
+      t.integer "gadus"
+      t.string "dunelikes"
+      t.string "applicablies"
+      t.boolean "unexemplaries", default: false, null: false
+      t.boolean "tandemers", default: false, null: false
+      t.boolean "numskulls", default: false, null: false
+      t.datetime "tallishes", precision: nil
+      t.datetime "porcateds", precision: nil
+      t.string "disanswerables"
+      t.boolean "sourens"
+      t.boolean "asclepiadaes", default: true, null: false
+      t.string "samen"
+    end
+
+    create_table "basaltoids", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "submarines"
+      t.string "solidagos"
+      t.integer "adulterators"
+      t.datetime "christhoods", precision: nil
+      t.date "nonaeratings", null: false
+      t.datetime "sephirothics", precision: nil, null: false
+      t.datetime "northernnesses", precision: nil, null: false
+    end
+
+    create_table "rewhirls", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "myatonies", null: false
+      t.date "hubbites", null: false
+      t.date "parovariotomies"
+      t.decimal "epiclidals", precision: 16, scale: 2, default: "0.0"
+      t.datetime "caribbeans", precision: nil
+      t.datetime "melancholists", precision: nil
+      t.date "subfixes", null: false
+    end
+
+    create_table "autosciences", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "plectopters", null: false
+      t.datetime "dirds", precision: nil
+      t.datetime "wistlessnesses", precision: nil
+    end
+
+    create_table "unignitables", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "scrubgrasses", null: false
+      t.datetime "moringuoids", precision: nil
+      t.datetime "holytides", precision: nil
+    end
+
+    create_table "dreamts", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "ofttimes", null: false
+      t.string "phytomonadinas", null: false
+      t.text "inessentials"
+      t.datetime "overexertions", precision: nil
+      t.datetime "antelucans", precision: nil
+    end
+
+    create_table "preresolves", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "algebraics", null: false
+      t.datetime "duplications", precision: nil
+      t.datetime "polyphemians", precision: nil
+      t.string "unflayeds", null: false
+    end
+
+    create_table "unmooteds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "unbleedings", null: false
+      t.bigint "reviviscencies", null: false
+      t.datetime "strontics", precision: nil
+      t.datetime "ungranteds", precision: nil
+      t.datetime "utopistics", precision: nil
+      t.datetime "organistics", precision: nil
+      t.string "dicyemidaes"
+      t.boolean "uniconstants", default: false
+      t.boolean "abnormalists", default: false, null: false
+      t.boolean "kassus", default: false, null: false
+      t.string "potentiallies", limit: 36, null: false
+    end
+
+    create_table "orpines", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "wisecrackers", null: false
+      t.decimal "perenniallies", precision: 16, scale: 2, null: false
+      t.string "crossbolts", null: false
+      t.bigint "heliozoans", null: false
+      t.string "rhizocauls", null: false
+      t.datetime "underclasses", precision: nil
+      t.datetime "taintables", precision: nil
+    end
+
+    create_table "dasypaedics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "unimplorables", null: false
+      t.bigint "cockboats"
+      t.string "inhumen"
+      t.decimal "gunneras", precision: 16, scale: 2, null: false
+      t.string "peakers", null: false
+      t.datetime "uramilics", precision: nil
+      t.datetime "disestablishes", precision: nil
+      t.string "mortlings"
+      t.string "dephosphorizes"
+      t.bigint "dishonorablies"
+    end
+
+    create_table "rhinos", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "vertibilities", null: false
+      t.bigint "haemoconcentrations", null: false
+      t.string "moonlets", null: false
+      t.text "amalgamatizes"
+      t.datetime "misotramontanisms", precision: nil
+      t.datetime "asweats", precision: nil
+      t.string "pantoscopes"
+    end
+
+    create_table "dichromatics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "sobersideds", limit: 36, null: false
+      t.bigint "marks", null: false
+      t.bigint "idiomatics"
+      t.datetime "sublates", precision: nil
+      t.datetime "sublumbars", precision: nil, null: false
+      t.datetime "underditches", precision: nil, null: false
+      t.datetime "inshaves", precision: nil
+    end
+
+    create_table "grainerings", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "untouchabilities"
+      t.string "pannuscoria"
+      t.string "mascoutens"
+      t.datetime "chabuks", precision: nil, null: false
+      t.datetime "syndectomies", precision: nil, null: false
+      t.bigint "anighs"
+    end
+
+    create_table "undertwigs", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "stenotics", null: false
+      t.boolean "interfretteds", default: false, null: false
+      t.boolean "elateds", default: false, null: false
+      t.decimal "unshrunkens", precision: 16, scale: 2
+      t.text "ilmenorutiles"
+      t.date "pipefuls"
+      t.datetime "quaequaes", precision: nil
+      t.datetime "throblesses", precision: nil
+      t.bigint "claiths"
+      t.string "primarinesses", limit: 36, null: false
+    end
+
+    create_table "uncriticiseds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "nepidaes", null: false
+      t.bigint "unescapables", null: false
+      t.datetime "terrences", precision: nil
+      t.datetime "researches", precision: nil
+      t.datetime "creoles", precision: nil
+    end
+
+    create_table "naams", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "epigynums", null: false
+      t.datetime "governs", precision: nil
+      t.datetime "titres", precision: nil
+      t.datetime "mussables", precision: nil
+      t.datetime "hadjemis", precision: nil
+      t.string "alcheras"
+      t.string "overasserts", limit: 36, null: false
+    end
+
+    create_table "flybelts", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.decimal "opisthocoelous", precision: 16, scale: 2, null: false
+      t.string "disruptabilities"
+      t.string "transurania"
+      t.bigint "staddles"
+      t.datetime "gurries", precision: nil
+      t.decimal "pulverizes", precision: 16, scale: 2, null: false
+      t.bigint "roseries"
+      t.datetime "leucobryaceaes", precision: nil
+      t.datetime "alimentativenesses", precision: nil, null: false
+      t.datetime "umbilicaria", precision: nil, null: false
+      t.string "nonsanities"
+      t.string "eruptions"
+      t.string "mynpachts"
+      t.datetime "larboards", precision: nil
+    end
+
+    create_table "camoodis", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.datetime "illicitnesses", precision: nil
+      t.string "tetrachlorids", limit: 36, null: false
+      t.bigint "floods", null: false
+      t.datetime "solis", precision: nil, null: false
+      t.datetime "obsolesces", precision: nil, null: false
+    end
+
+    create_table "incompliantlies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "senilizes"
+      t.datetime "pinhooks", precision: nil
+      t.datetime "asparagus", precision: nil
+    end
+
+    create_table "caddies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "drenchinglies", null: false
+      t.decimal "offscums", precision: 16, scale: 2, null: false
+      t.date "carinianas", null: false
+      t.datetime "procurers", precision: nil, null: false
+      t.datetime "serratodenticulates", precision: nil, null: false
+      t.bigint "galwegians"
+    end
+
+    create_table "seculars", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "semicircumferentors"
+      t.string "baptisia"
+      t.bigint "cancers"
+      t.decimal "excusings", precision: 16, scale: 2
+      t.string "hyaluronidases"
+      t.datetime "osculations", precision: nil
+      t.datetime "recurvopatents", precision: nil
+      t.bigint "widens"
+      t.string "corinnas"
+      t.string "riverwards", limit: 36, null: false
+    end
+
+    create_table "decamerous", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "livistonas", null: false
+      t.string "factionaries", null: false
+      t.datetime "subsorters", precision: nil
+      t.datetime "rhinophis", precision: nil
+      t.boolean "waesucks"
+      t.string "karyogamies"
+    end
+
+    create_table "retentives", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "ramifies", null: false
+      t.decimal "dipteras", precision: 16, scale: 2, null: false
+      t.decimal "readmissions", precision: 16, scale: 2, null: false
+      t.decimal "cuticulates", precision: 16, scale: 2, null: false
+      t.decimal "myrmecologicals", precision: 16, scale: 2, null: false
+      t.decimal "polyatomicities", precision: 16, scale: 2, null: false
+      t.integer "palaeodictyopterous", null: false
+      t.datetime "incommutabilities", precision: nil, null: false
+      t.datetime "peripherophoses", precision: nil, null: false
+    end
+
+    create_table "reastinesses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "eriometers"
+      t.bigint "yenders"
+      t.string "tychisms"
+      t.date "flotillas"
+      t.date "contrariouslies"
+      t.date "periumbilicals"
+      t.date "pats"
+      t.decimal "cadinenes", precision: 16, scale: 2, default: "0.0"
+      t.datetime "mesotroches", precision: nil
+      t.datetime "inertnesses", precision: nil
+      t.string "soulacks"
+      t.string "dizens"
+      t.string "subs"
+      t.date "noncommittals"
+      t.bigint "scuttlings"
+      t.boolean "pippinfaces", default: false
+      t.string "hydroperiods", limit: 36, null: false
+    end
+
+    create_table "vignerons", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "hebraisms"
+      t.string "craniata"
+      t.datetime "dyspepticallies", precision: nil
+      t.datetime "defenses", precision: nil
+      t.string "inassimilations"
+      t.string "samanthas"
+    end
+
+    create_table "folletages", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.datetime "unexotics", precision: nil
+      t.datetime "imprecatories", precision: nil
+      t.datetime "supererogatorilies", precision: nil
+    end
+
+    create_table "jagongs", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "tengeres", null: false
+      t.datetime "irradiateds", precision: nil
+      t.datetime "brimfullies", precision: nil
+    end
+
+    create_table "propugnacleds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "acholurics", null: false
+      t.datetime "hydrophytous", precision: nil
+      t.datetime "zooblasts", precision: nil
+      t.datetime "milters", precision: nil
+    end
+
+    create_table "urases", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "clavials", null: false
+      t.date "projicientlies", null: false
+      t.string "monogonies"
+      t.datetime "hetaerics", precision: nil, null: false
+      t.datetime "rumbustious", precision: nil, null: false
+      t.bigint "limpilies"
+    end
+
+    create_table "tealeafies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "uruguayans", null: false
+      t.date "chittamwoods", null: false
+      t.datetime "headsets", precision: nil, null: false
+      t.datetime "blickeys", precision: nil
+      t.datetime "overbrilliants", precision: nil, null: false
+      t.datetime "multifidous", precision: nil, null: false
+    end
+
+    create_table "hypolepticallies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "zooplanktonics", null: false
+      t.bigint "galvanocauteries"
+      t.datetime "desirefulnesses", precision: nil
+      t.datetime "azelates", precision: nil
+      t.datetime "aetomorphaes", precision: nil
+    end
+
+    create_table "unfleetings", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "wetnesses"
+      t.bigint "equiglacials"
+      t.date "cheerios"
+      t.string "blackfellows"
+      t.string "hydrometridaes"
+      t.bigint "pathoradiographies"
+      t.datetime "kinglies", precision: nil, null: false
+      t.datetime "debarbarizes", precision: nil, null: false
+      t.string "outdistricts"
+      t.string "defaces"
+      t.integer "forefaces"
+      t.datetime "skewerers", precision: nil
+      t.text "phlegmas"
+      t.string "anthemideaes"
+      t.integer "absinthols", default: 0
+      t.text "frankpledges"
+      t.bigint "speakablies"
+      t.bigint "sabulums"
+      t.datetime "mohammedists", precision: nil
+      t.string "everlastinglies"
+      t.boolean "terminalizations", default: true, null: false
+      t.boolean "brayeras", default: false, null: false
+      t.string "prosupports"
+      t.text "unwinsomes", size: :medium
+      t.integer "stethophonometers"
+      t.integer "gerips"
+      t.boolean "murgas", default: false
+      t.bigint "volapukisms"
+      t.string "filipinianas"
+      t.boolean "denaries", default: false
+      t.bigint "hoffmannites"
+      t.string "splanchnographicals"
+      t.bigint "afterglides"
+      t.string "postaxiads"
+      t.string "rachioplegia", limit: 36, null: false
+    end
+
+    create_table "garnisheements", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "awhiles"
+      t.bigint "multigaps"
+      t.string "garrulinaes"
+      t.text "cyclopentenes"
+      t.string "polioses", limit: 36, null: false
+      t.datetime "arrides", precision: nil
+      t.datetime "bodhisattvas", precision: nil
+    end
+
+    create_table "transversospinals", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "weftages", limit: 36, null: false
+      t.bigint "antirumors", null: false
+      t.integer "catchcries", limit: 2
+      t.integer "interpretorials", limit: 1
+      t.integer "doublegangers", limit: 1
+      t.integer "ridgeds", limit: 1
+      t.integer "inulases", limit: 1
+      t.integer "recharters", limit: 1
+      t.integer "swordplays", limit: 1
+      t.string "reason_code_1"
+      t.string "reason_code_2"
+      t.string "reason_code_3"
+      t.string "reason_code_4"
+      t.string "reason_code_5"
+      t.string "reason_code_6"
+      t.datetime "scandinavia", precision: nil
+      t.datetime "overnarrows", precision: nil
+      t.bigint "pugnacities"
+    end
+
+    create_table "nonexportables", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "insensibilizations"
+      t.bigint "precipitates"
+      t.date "lieds"
+      t.string "sadducisms"
+      t.integer "churchianities"
+      t.decimal "trabants", precision: 16, scale: 2
+      t.decimal "supergratifications", precision: 16, scale: 2, default: "0.0"
+      t.decimal "cankerberries", precision: 16, scale: 2, default: "0.0"
+      t.decimal "ramanas", precision: 16, scale: 2, default: "0.0"
+      t.decimal "embryologists", precision: 16, scale: 2, default: "0.0"
+      t.decimal "untellings", precision: 16, scale: 2, default: "0.0"
+      t.decimal "vergencies", precision: 16, scale: 2, default: "0.0"
+      t.decimal "aerographics", precision: 16, scale: 2, default: "0.0"
+      t.date "collieds"
+      t.string "unacceptablenesses"
+      t.bigint "trypsinogens"
+      t.text "heterologicallies"
+      t.text "outriggerlesses"
+      t.text "polydimensionals"
+      t.datetime "tripaleolates", precision: nil
+      t.datetime "unconfidences", precision: nil
+      t.date "intracarpals"
+      t.string "adjutants"
+      t.string "sonneratiaceaes"
+      t.string "evaluatives", limit: 36
+    end
+
+    create_table "fluorhydrics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "recantinglies", null: false
+      t.string "willies"
+      t.boolean "unposthumous", default: true
+      t.datetime "slidages", precision: nil, null: false
+      t.datetime "digenics", precision: nil, null: false
+      t.datetime "antagonizations", precision: nil
+      t.integer "resplits"
+      t.boolean "ventrifixations", default: true, null: false
+      t.string "heliotherapies", default: "debit_date", null: false
+      t.string "panegyricums"
+      t.bigint "causeries"
+      t.string "delegations"
+      t.string "goggas"
+    end
+
+    create_table "unassassinateds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "inalimentals", null: false
+      t.bigint "vulcanizates", null: false
+      t.bigint "euomphalids", null: false
+      t.string "pyrotechnicals"
+      t.datetime "bombycidaes", precision: nil
+      t.string "ornoites"
+    end
+
+    create_table "pubis", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "antigigmanics", null: false
+      t.string "disembowelments", null: false
+      t.datetime "sublecturers", precision: nil
+      t.date "cliftonites"
+      t.datetime "hoarstones", precision: nil
+      t.datetime "trithionics", precision: nil
+      t.bigint "unofficiouslies"
+    end
+
+    create_table "melliferas", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "fluozirconics"
+      t.bigint "vaporishes"
+      t.string "marshlands"
+      t.decimal "macrozamia", precision: 16, scale: 2
+      t.datetime "scelalgia", precision: nil
+      t.datetime "craticulars", precision: nil
+      t.bigint "emissives"
+    end
+
+    create_table "myrrhs", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "lectorships", null: false
+      t.string "trochiferous", null: false
+      t.integer "sylvicolidaes", null: false
+      t.integer "phenmiazines", null: false
+      t.datetime "reloves", precision: nil
+      t.bigint "comparers"
+      t.decimal "campanulous", precision: 16, scale: 2
+      t.datetime "tiribas", precision: nil
+      t.datetime "rutherfordites", precision: nil
+      t.string "blashes"
+      t.boolean "epalpates"
+      t.bigint "pyrotechnists"
+      t.string "fibromyositis", null: false
+    end
+
+    create_table "pseudotuberculars", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "panidroses", null: false
+      t.datetime "pedomotors", precision: nil, null: false
+      t.datetime "robustnesses", precision: nil
+      t.datetime "misdescriptives", precision: nil
+    end
+
+    create_table "hadendoas", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "upwounds", null: false
+      t.decimal "splaymouths", precision: 16, scale: 2, null: false
+      t.decimal "seedages", precision: 16, scale: 2
+      t.decimal "harebrains", precision: 16, scale: 2, null: false
+      t.datetime "carbolfuchsins", precision: nil
+      t.datetime "dacryocystoptoses", precision: nil
+    end
+
+    create_table "gillies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "sexagenaries", null: false
+      t.string "nonconformities", null: false
+      t.decimal "juxtapositionals", precision: 16, scale: 2, null: false
+      t.boolean "tornades", default: true, null: false
+      t.datetime "unconventionals", precision: nil, null: false
+      t.datetime "becrosses", precision: nil, null: false
+      t.integer "galvanizations", null: false
+      t.boolean "unthreadables", default: true
+      t.decimal "amatorians", precision: 16, scale: 2
+      t.boolean "thoroughpins", default: false, null: false
+      t.boolean "araguatos", default: false, null: false
+      t.decimal "skewbalds", precision: 16, scale: 2
+      t.integer "monotheletisms"
+      t.decimal "obdiplostemonous", precision: 16, scale: 2
+      t.string "sabianisms", limit: 36
+    end
+
+    create_table "sebaceous", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "talpidaes", limit: 36, null: false
+      t.integer "becommas"
+      t.bigint "solidungulars", null: false
+      t.datetime "roachbacks", precision: nil
+      t.datetime "girts", precision: nil
+    end
+
+    create_table "glutteries", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "street_1", null: false
+      t.string "durbars", null: false
+      t.string "nonmenials", null: false
+      t.string "desks", null: false
+      t.string "phonographs", null: false
+      t.string "truthies"
+      t.string "spices", null: false
+      t.string "chromaffins", null: false
+      t.string "nepenthes", null: false
+      t.string "protospasms", null: false
+      t.string "swahilians"
+      t.string "silverbellies"
+      t.string "ecaudata"
+      t.string "troglodytics"
+      t.string "presentimentals"
+      t.string "hipbones"
+      t.string "unorbeds"
+      t.string "syntonizes"
+      t.datetime "ownhoods", precision: nil
+      t.datetime "lavatorials", precision: nil
+    end
+
+    create_table "elaborations", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "nisperos"
+    end
+
+    create_table "circuiteers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "costives", null: false
+      t.string "schizodinics", null: false
+      t.datetime "bedarks", precision: nil
+      t.datetime "cummers", precision: nil
+      t.boolean "discorporates", default: true
+      t.boolean "dejerates", default: true
+    end
+
+    create_table "uncounterfeits", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "vandalroots", null: false
+      t.datetime "hydroxyacetics", precision: nil
+      t.string "concinnous"
+      t.string "edentates"
+      t.string "nonobservances"
+      t.string "longsomenesses"
+      t.string "autocopists"
+      t.datetime "uncountervaileds", precision: nil
+      t.datetime "spermolytics", precision: nil
+      t.datetime "holoparasitics", precision: nil
+      t.string "smethes"
+      t.datetime "metaxylenes", precision: nil
+      t.datetime "adaptionals", precision: nil
+      t.string "penitents"
+    end
+
+    create_table "volatilizables", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "rufescences", limit: 36, null: false
+      t.bigint "hyperkineses", null: false
+      t.datetime "jibis", precision: nil
+      t.datetime "hunnics", precision: nil
+    end
+
+    create_table "strucks", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.datetime "doorposts", precision: nil, null: false
+      t.text "electrokinematics"
+      t.datetime "hepatotoxemia", precision: nil
+      t.datetime "vomerobasilars", precision: nil
+      t.bigint "roughets", null: false
+      t.string "insolents"
+    end
+
+    create_table "cuddlies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "insectiferous", limit: 36, null: false, collation: "ascii_general_ci"
+      t.string "miscarriages", limit: 36, null: false, collation: "ascii_general_ci"
+      t.boolean "excursories", null: false
+      t.text "cryptologies"
+      t.datetime "pasteurelleaes", precision: nil
+      t.datetime "unexplainings", precision: nil
+      t.string "crocuseds", default: "monthly", null: false
+    end
+
+    create_table "paraphernalia", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "inappertinents", limit: 36, null: false, collation: "ascii_general_ci"
+      t.string "deciduitis", limit: 36, null: false, collation: "ascii_general_ci"
+      t.text "polymoleculars", null: false
+      t.text "conusees"
+      t.text "periodontics"
+      t.datetime "cushags", precision: nil
+      t.datetime "citterns", precision: nil
+      t.string "reboundingnesses", limit: 36, null: false
+    end
+
+    create_table "crampies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "asperous", limit: 36, null: false, collation: "ascii_general_ci"
+      t.string "excitements", limit: 36, null: false, collation: "ascii_general_ci"
+      t.text "bananivorous", null: false
+      t.text "unapparentnesses"
+      t.string "daityas", null: false
+      t.datetime "firebolts", precision: nil, null: false
+      t.datetime "hatlessnesses", precision: nil, null: false
+      t.datetime "dolmen", precision: nil, null: false
+      t.datetime "extensivelies", precision: nil, null: false
+      t.datetime "rencounters", precision: nil
+      t.string "candleboxes", limit: 36, null: false
+    end
+
+    create_table "neofetals", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "tractites", null: false
+      t.string "unhangeds", null: false
+      t.string "planxties", null: false
+      t.datetime "ceylons", precision: nil, null: false
+      t.bigint "buttonholders", null: false
+      t.datetime "salpingorrhaphies", precision: nil, null: false
+      t.datetime "diacetamides", precision: nil, null: false
+      t.string "antiphylloxerics", null: false
+    end
+
+    create_table "unbendables", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "untogglers"
+      t.string "steplesses"
+      t.string "sumpits"
+      t.string "ethylamides"
+      t.string "pilocystics"
+      t.string "loggerheads"
+      t.string "counterformulas"
+      t.datetime "unprosecutables", precision: nil
+      t.datetime "attends", precision: nil
+      t.boolean "wearisomelies", default: false, null: false
+    end
+
+    create_table "ogives", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "albertins", null: false
+      t.bigint "brachistochronous", null: false
+      t.string "flogmasters", null: false
+      t.boolean "curabilities", default: true, null: false
+      t.text "pliancies"
+      t.boolean "jiquis", default: false, null: false
+      t.datetime "blastoporics", precision: nil, null: false
+      t.datetime "bandors", precision: nil, null: false
+    end
+
+    create_table "mannequins", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "foraneens", null: false
+      t.string "neurosarcomas", null: false
+      t.string "subherds"
+      t.string "chieftaincies"
+      t.bigint "screwers", null: false
+      t.boolean "zimmes", default: false
+      t.datetime "ailings", precision: nil, null: false
+      t.datetime "fatherlesses", precision: nil, null: false
+    end
+
+    create_table "nitridizations", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "acephalia", limit: 36, null: false
+      t.bigint "pelmatozoans", null: false
+      t.string "bestowings", null: false
+      t.datetime "moorburns", precision: nil
+      t.datetime "unsensiblenesses", precision: nil
+      t.boolean "pupillaries", default: false, null: false
+    end
+
+    create_table "snarleyyows", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "terminablies", null: false
+      t.bigint "unsoothables", null: false
+      t.string "petites", null: false
+      t.boolean "polychromates", default: true, null: false
+      t.text "ventilatings"
+      t.datetime "slackages", precision: nil, null: false
+      t.datetime "roxburghs", precision: nil, null: false
+      t.boolean "needments", default: false, null: false
+      t.datetime "acrogamies", precision: nil
+    end
+
+    create_table "solacers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "floormen", limit: 36, null: false
+      t.bigint "intercessions", null: false
+      t.string "cystocarpics", null: false
+      t.string "nagnags"
+      t.bigint "grossnesses"
+      t.datetime "shwanpans", precision: nil
+      t.datetime "compounds", precision: nil
+    end
+
+    create_table "stripelesses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "podargus", limit: 36, null: false
+      t.bigint "perviabilities", null: false
+      t.string "hylotheistics"
+      t.string "outswindles", null: false
+      t.string "ladderings"
+      t.bigint "bronchoceles", null: false
+      t.datetime "unhumbles", precision: nil
+      t.datetime "uterectomies", precision: nil
+    end
+
+    create_table "barographics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "aposaturnia", limit: 36, null: false
+      t.string "egocentrics", null: false
+      t.bigint "echinostomiases", null: false
+      t.datetime "aurides", precision: nil, null: false
+      t.datetime "knabbles", precision: nil, null: false
+    end
+
+    create_table "modificationists", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "fitouts", limit: 36, null: false
+      t.string "witties", null: false
+      t.string "aphidids"
+      t.bigint "comparativelies"
+      t.datetime "dartmoors", precision: nil, null: false
+      t.datetime "paraheliotropics", precision: nil, null: false
+    end
+
+    create_table "archigonics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "unperformeds", null: false
+      t.bigint "pridefullies", null: false
+      t.string "demilitarizations", null: false
+      t.string "rewords", null: false
+      t.string "purposelesslies", limit: 32, null: false
+      t.bigint "hampshires", null: false
+      t.datetime "nychthemerals", precision: nil
+      t.datetime "luteocobaltics", precision: nil
+    end
+
+    create_table "ruficoccins", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "sardonics", null: false
+      t.datetime "anchises", precision: nil
+      t.datetime "sarcoglia", precision: nil
+    end
+
+    create_table "cultirostres", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "dentiloquists", limit: 36, null: false
+      t.string "microspherics"
+      t.string "leanders"
+      t.string "dibenzyls"
+      t.string "cetonia"
+      t.string "unfactious"
+      t.string "business_address_1"
+      t.string "business_address_2"
+      t.string "oysterlings"
+      t.string "consequencies"
+      t.string "continualnesses"
+      t.string "finitelies"
+      t.string "semipurulents"
+      t.string "etudes"
+      t.string "ruttishlies"
+      t.string "gudgeons"
+      t.string "linkedIn_url"
+      t.string "provings"
+      t.string "niccoliferous"
+      t.string "lurdanisms"
+      t.integer "antisyndicalisms"
+      t.boolean "lemoniidaes"
+      t.string "unessentialnesses"
+      t.string "pansophies"
+      t.string "ronsdorfers"
+      t.boolean "obsesses"
+      t.string "membranelesses"
+      t.string "nabobships"
+      t.boolean "smoothens"
+      t.datetime "salmoniforms", precision: nil, null: false
+      t.datetime "fattilies", precision: nil, null: false
+      t.string "khokas"
+      t.boolean "osteitics"
+    end
+
+    create_table "bucerotidaes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.datetime "perlidaes", precision: nil
+      t.datetime "velaries", precision: nil
+      t.boolean "indispensabilities", default: false
+      t.integer "preconfigures"
+      t.string "whickers", limit: 300, default: "--- []\n"
+      t.boolean "bourbonisms"
+      t.boolean "calcitestaceous"
+      t.boolean "suppressors"
+      t.boolean "imagists"
+      t.boolean "utriculariaceaes"
+      t.boolean "devulgarizes"
+      t.boolean "nards"
+      t.boolean "forementioneds"
+      t.string "insecticidals"
+      t.string "undomicilables"
+      t.string "lammers"
+      t.date "runlets"
+      t.date "nants"
+      t.date "southeasterns"
+      t.text "vedists"
+      t.bigint "procreatives"
+      t.datetime "uneloquentlies", precision: nil
+    end
+
+    create_table "antepaschals", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "magnochromites", null: false
+      t.text "cockers"
+      t.datetime "macrochiras", precision: nil
+      t.datetime "reduvius", precision: nil
+      t.datetime "coenenchymes", precision: nil
+      t.string "seahs"
+      t.datetime "grudgments", precision: nil
+    end
+
+    create_table "baruches", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "acoelomates"
+      t.datetime "buddhaships", precision: nil
+      t.datetime "upcaughts", precision: nil
+      t.datetime "stereotypists", precision: nil
+    end
+
+    create_table "bourignonists", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "flagellariaceaes", null: false
+      t.bigint "prunellidaes", null: false
+      t.string "aburabozus"
+      t.datetime "kahus", precision: nil
+      t.datetime "gastrolaters", precision: nil
+      t.bigint "autophytes"
+    end
+
+    create_table "yawninglies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "unviolables", null: false
+      t.string "stercorariinaes"
+      t.string "undescendables"
+      t.datetime "chaldaeis", precision: nil
+      t.datetime "deslimes", precision: nil
+    end
+
+    create_table "uropoetics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "wolffia", null: false
+      t.string "sheepstealers", null: false
+      t.datetime "footstones", precision: nil
+      t.datetime "lations", precision: nil
+      t.datetime "hectoringlies", precision: nil
+    end
+
+    create_table "incorporeallies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "extemporaneousnesses", null: false
+      t.string "overplumes"
+      t.datetime "kharuas", precision: nil
+      t.datetime "veronalisms", precision: nil
+      t.bigint "brickmakers"
+    end
+
+    create_table "bemucks", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.integer "nahanes", null: false
+      t.string "nongovernmentals", null: false
+      t.string "braces", limit: 36, null: false
+      t.datetime "scyllas", precision: nil
+      t.datetime "campanillas", precision: nil
+    end
+
+    create_table "ultrawealthies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "palaeoplains", null: false
+      t.bigint "hydrofluoborics", null: false
+      t.string "pharos", null: false
+      t.text "overfamiliars", null: false
+      t.string "bes", null: false
+      t.datetime "denumerants", precision: nil
+      t.datetime "autarchics", precision: nil
+    end
+
+    create_table "impressivelies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "spodomancies", null: false
+      t.integer "counterstreams", default: 2
+      t.datetime "suffumigations", precision: nil, null: false
+      t.datetime "butleresses", precision: nil, null: false
+      t.integer "gruffilies", default: 0
+      t.boolean "peckishlies", default: false
+      t.date "dipotassia"
+      t.date "syphilizations"
+      t.boolean "myotalpas", default: false
+      t.boolean "terpodions", default: false
+      t.string "preharmoniousnesses"
+      t.text "nonconnotatives"
+      t.decimal "cuppies", precision: 16, scale: 2
+    end
+
+    create_table "obliterables", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.boolean "pistonlikes", default: false, null: false
+      t.boolean "lecyths", default: false, null: false
+      t.boolean "stends", default: false, null: false
+      t.boolean "aphanipteras", default: false, null: false
+      t.boolean "warpeds", default: false, null: false
+      t.boolean "organogenists", default: false, null: false
+      t.bigint "springlets", null: false
+      t.datetime "apargia", precision: nil
+      t.datetime "felonesses", precision: nil
+      t.boolean "manucodia", default: false, null: false
+    end
+
+    create_table "ascaridiases", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "radiolucencies"
+      t.decimal "undespaireds", precision: 16, scale: 2, default: "0.0"
+      t.decimal "superachievements", precision: 16, scale: 2, default: "0.0"
+      t.string "tenontographies"
+      t.datetime "oligomeries", precision: nil, null: false
+      t.datetime "mazopathia", precision: nil, null: false
+      t.integer "peppilies"
+    end
+
+    create_table "sagittids", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "nonforms", null: false
+      t.decimal "delphinites", precision: 16, scale: 2, default: "0.0"
+      t.bigint "ulemas", null: false
+      t.datetime "antispreadings", precision: nil
+      t.datetime "pillars", precision: nil
+    end
+
+    create_table "terminativelies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "providorings"
+      t.decimal "colauxes", precision: 16, scale: 2, default: "0.0"
+      t.bigint "interpenetrants"
+      t.datetime "intercontorteds", precision: nil, null: false
+      t.datetime "scrapmongers", precision: nil, null: false
+      t.decimal "inclusivenesses", precision: 16, scale: 2, default: "0.0"
+      t.decimal "tetralogics", precision: 16, scale: 2, default: "0.0"
+      t.decimal "ortyginaes", precision: 16, scale: 2, default: "0.0"
+      t.decimal "saturnia", precision: 16, scale: 2, default: "0.0"
+      t.string "planlesslies"
+    end
+
+    create_table "psychoorganics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "photogenics"
+      t.bigint "hematozoons"
+      t.decimal "rollers", precision: 16, scale: 2
+      t.datetime "listlesses", precision: nil, null: false
+      t.datetime "nuggets", precision: nil, null: false
+      t.decimal "theologues", precision: 16, scale: 2
+      t.decimal "isokeraunics", precision: 16, scale: 2
+      t.boolean "epuloids", default: false
+      t.decimal "olafs", precision: 16, scale: 2, default: "0.0"
+      t.decimal "sables", precision: 16, scale: 2, default: "0.0"
+      t.string "trets"
+      t.string "epiplastrons"
+      t.text "stevedores"
+      t.boolean "philosophisters", default: false
+    end
+
+    create_table "cantus", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "canvasses", null: false
+      t.bigint "ostiaries", null: false
+      t.bigint "infarctates", null: false
+      t.datetime "moleheads", precision: nil, null: false
+      t.datetime "syncranterics", precision: nil, null: false
+    end
+
+    create_table "prepublications", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "vermicularlies", null: false
+      t.bigint "crackednesses"
+      t.datetime "aeronauticallies", precision: nil
+      t.string "underpraises", null: false
+      t.text "campfires"
+      t.bigint "skatikas", null: false
+      t.bigint "availablenesses"
+      t.bigint "bhojpuris"
+      t.datetime "reslays", precision: nil, null: false
+      t.datetime "schoolables", precision: nil, null: false
+      t.bigint "dominantlies"
+    end
+
+    create_table "sketchabilities", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "photodecompositions"
+      t.date "watchmanlies"
+      t.datetime "alliterations", precision: nil, null: false
+      t.datetime "mice", precision: nil, null: false
+      t.boolean "antiarthritics", default: false
+      t.boolean "disassociations", default: false
+      t.bigint "conveniences"
+      t.string "sacrococcygeans"
+    end
+
+    create_table "uneuphonious", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "superterrenes"
+      t.decimal "tubuliferous", precision: 16, scale: 2
+      t.datetime "exhibitives", precision: nil, null: false
+      t.datetime "fruitlessnesses", precision: nil, null: false
+      t.bigint "galeproofs"
+      t.bigint "gamins"
+    end
+
+    create_table "pyrocottons", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.decimal "historiographers", precision: 16, scale: 2, default: "0.0", null: false
+      t.bigint "pectinals", null: false
+      t.date "screenables", null: false
+      t.bigint "hautboys"
+      t.datetime "punctulateds", precision: nil, null: false
+      t.datetime "trithings", precision: nil, null: false
+    end
+
+    create_table "sages", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "photoionizations"
+      t.bigint "embrittlements"
+      t.decimal "noncorrespondences", precision: 16, scale: 2, default: "0.0"
+      t.date "streptolysins"
+      t.datetime "berengelites", precision: nil, null: false
+      t.datetime "multilobates", precision: nil, null: false
+    end
+
+    create_table "tunicins", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "untactfullies"
+      t.bigint "monitories"
+      t.decimal "turbos", precision: 16, scale: 2
+      t.text "preterhumen", size: :medium
+      t.datetime "archfoes", precision: nil, null: false
+      t.datetime "cableds", precision: nil, null: false
+    end
+
+    create_table "mboris", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "chroatols", null: false
+      t.text "phantomships"
+      t.datetime "porencephalons", precision: nil, null: false
+      t.datetime "endoceratites", precision: nil, null: false
+      t.boolean "summerishes", default: true, null: false
+      t.string "dragsawings", limit: 36
+    end
+
+    create_table "bullyraggings", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "electroplates", limit: 36, null: false
+      t.string "thereunders", null: false
+      t.string "undeceptious", null: false
+      t.string "quadriplanars", null: false
+      t.datetime "hydrotropisms", precision: nil
+      t.datetime "unglazes", precision: nil
+      t.datetime "uterocystotomies", precision: nil, null: false
+      t.datetime "subspontaneous", precision: nil, null: false
+    end
+
+    create_table "superprintings", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "jinglings", null: false
+      t.integer "unexplicables"
+      t.datetime "subcontrarieties", precision: nil
+      t.datetime "proromances", precision: nil
+      t.datetime "vomitories", precision: nil
+      t.string "oversubtleties", limit: 36
+      t.string "kos"
+      t.string "scribbleisms"
+      t.boolean "contestables", default: false
+      t.boolean "suggestresses", default: true
+      t.text "malapertnesses"
+      t.text "inurements"
+    end
+
+    create_table "smokeds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "austerlitzs", null: false
+      t.bigint "i9_authorization_id", null: false
+      t.boolean "gnawinglies", default: false
+      t.string "disincorporations"
+      t.string "pleosporas"
+      t.string "farcinomas"
+      t.date "spoonlesses"
+      t.string "multifibereds"
+      t.datetime "uninterruptednesses", precision: nil
+      t.datetime "gentlewomanlikes", precision: nil
+      t.string "oophoridia"
+      t.string "snows", limit: 36
+    end
+
+    create_table "guys", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "acotyledons", null: false
+      t.string "niantics"
+      t.datetime "ascophores", precision: nil
+      t.datetime "tristams", precision: nil
+      t.string "neuroganglions"
+      t.string "bicrescentics"
+      t.string "wraitlies"
+      t.string "praefoliations"
+      t.date "unenforcedlies"
+      t.bigint "unresumeds"
+      t.string "unemployablies"
+      t.datetime "occipitothalamics", precision: nil
+      t.string "exhaustions"
+      t.string "interkineses"
+      t.string "cacothelines"
+      t.boolean "reflexivenesses", default: false, null: false
+      t.string "lackwittedlies", limit: 36
+      t.text "sapharensians"
+      t.boolean "divata"
+    end
+
+    create_table "medisects", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "nialls", limit: 36, null: false
+      t.string "suffixions", null: false
+      t.string "demitubes", null: false
+      t.string "erythrogeneses", null: false
+      t.string "hydrographics", null: false
+      t.integer "gaves"
+      t.string "ungues"
+      t.bigint "saintlesses", null: false
+      t.datetime "boastfulnesses", precision: nil
+      t.datetime "apicads", precision: nil
+    end
+
+    create_table "ingluvies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "anacromyodians"
+      t.datetime "carinations", precision: nil
+      t.string "deevilicks"
+      t.datetime "forgathers", precision: nil, null: false
+      t.datetime "schopenhauereanisms", precision: nil, null: false
+      t.text "effectuates", size: :medium
+      t.bigint "inverts"
+      t.string "gourmanders"
+      t.bigint "nonazotizeds", default: 0, null: false
+    end
+
+    create_table "insinuendos", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "amorphus", limit: 36, null: false
+      t.string "prohydrotropisms", null: false
+      t.datetime "grenelles", precision: nil
+      t.datetime "entomostracous", precision: nil
+    end
+
+    create_table "autotuberculins", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "forebowels"
+      t.string "unlanguishings"
+      t.datetime "unconfinements", precision: nil, null: false
+      t.datetime "grosses", precision: nil, null: false
+    end
+
+    create_table "enteroneuritis", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "undefameds"
+      t.string "unrobusts"
+      t.string "carboniferous"
+      t.datetime "dacryosolenitis", precision: nil, null: false
+      t.datetime "thelodontidaes", precision: nil, null: false
+      t.text "morenesses"
+      t.text "genarchships"
+      t.string "connochaetes"
+      t.text "cordialities"
+      t.bigint "unhopefuls"
+      t.string "harmproofs"
+    end
+
+    create_table "lusiads", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "sectionallies"
+      t.string "bovista"
+      t.text "protragicals"
+      t.datetime "quickbeams", precision: nil, null: false
+      t.datetime "averts", precision: nil, null: false
+    end
+
+    create_table "fluctiferous", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "unleaveds", null: false
+      t.string "seminarcoses"
+      t.text "rudolphus"
+      t.text "nymphishes"
+      t.string "unaffieds"
+      t.text "mesoscapulars"
+      t.string "watchkeepers", null: false
+      t.datetime "alluringlies", precision: nil
+      t.datetime "ungrammaticallies", precision: nil
+      t.boolean "vahines"
+    end
+
+    create_table "unscornfuls", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "sandwoods"
+      t.string "unprecises"
+      t.string "unpromoteds", null: false
+      t.text "regardings"
+      t.string "garces"
+      t.string "epaulets"
+      t.bigint "dourlies"
+      t.bigint "brabants"
+      t.bigint "calelectricals", null: false
+      t.text "rudentures"
+      t.datetime "theodidacts", precision: nil
+      t.datetime "bareheads", precision: nil
+      t.text "diversionaries"
+      t.datetime "unascendables", precision: nil
+      t.boolean "uninfluenceables", default: false
+      t.string "shredcocks", limit: 36
+    end
+
+    create_table "vicariates", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "vonsenites", limit: 36, null: false, collation: "ascii_general_ci"
+      t.string "chickenhearteds", limit: 36, null: false, collation: "ascii_general_ci"
+      t.string "caramels", null: false
+      t.datetime "hangables", precision: nil
+      t.datetime "torneses", precision: nil
+      t.datetime "contours", precision: nil
+      t.datetime "tuberales", precision: nil
+    end
+
+    create_table "algores", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "goneoclinics", null: false
+      t.string "spreadinglies", null: false
+      t.string "caffeisms"
+      t.datetime "schemas", precision: nil
+      t.string "repudiates"
+      t.boolean "nonlipoidals", default: false
+      t.string "breadthlesses"
+      t.string "antirealistics"
+      t.date "pleurodirans"
+      t.boolean "communicativelies", default: false, null: false
+      t.boolean "infants", default: false, null: false
+      t.text "nonions"
+      t.boolean "autopticallies", default: false
+      t.datetime "unflangeds", precision: nil
+      t.datetime "staphylococcics", precision: nil
+      t.string "unflouteds"
+      t.string "harborages"
+      t.string "niels", null: false
+      t.bigint "prepolices"
+      t.string "dogships", limit: 4
+      t.string "scotchinesses"
+    end
+
+    create_table "lorens", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.datetime "unbasteds", precision: nil, null: false
+      t.bigint "orthogenics", null: false
+      t.datetime "tendinousnesses", precision: nil
+      t.datetime "thiefproofs", precision: nil
+    end
+
+    create_table "taxibuses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.datetime "reconfesses", precision: nil, null: false
+      t.bigint "matchers", null: false
+      t.bigint "radiolitics", null: false
+      t.bigint "surprisables", null: false
+      t.datetime "pentastomoids", precision: nil
+      t.datetime "dialogistics", precision: nil
+      t.bigint "trichromatisms", default: 0, null: false
+      t.bigint "achlamydeous"
+    end
+
+    create_table "nidulations", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.datetime "overventilations", precision: nil
+      t.bigint "choloidinics", null: false
+      t.string "overguns"
+      t.datetime "emeses", precision: nil
+      t.datetime "fassalites", precision: nil
+    end
+
+    create_table "fortuitists", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "ungaudies", limit: 36, null: false
+      t.bigint "anomaloscopes", null: false
+      t.integer "frontals"
+      t.integer "theocrasicals", limit: 1
+      t.integer "nonforesteds", limit: 1
+      t.integer "decentrations", limit: 1
+      t.integer "melanomas", limit: 1
+      t.string "unprofessionalisms", limit: 1
+      t.datetime "bristlecones", precision: nil
+      t.datetime "improvables", precision: nil
+      t.boolean "coparcenies"
+      t.boolean "overtensions"
+      t.boolean "condonables"
+      t.boolean "albuminometries"
+      t.boolean "cliffies"
+      t.boolean "ginglymoarthrodia"
+      t.boolean "churchanities"
+      t.boolean "homoeotics"
+      t.integer "murrinas"
+      t.string "corrupts"
+      t.string "relapsables"
+      t.string "petrifications"
+      t.bigint "veals"
+    end
+
+    create_table "nonseptates", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "phasianinaes", limit: 36, null: false
+      t.bigint "mislears", null: false
+      t.bigint "ortygians", null: false
+      t.date "atactics"
+      t.date "uveitis"
+      t.datetime "mantispas", precision: nil
+      t.datetime "lithographicallies", precision: nil
+    end
+
+    create_table "dredgings", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "infatuatedlies", limit: 36, null: false
+      t.bigint "supratropicals", null: false
+      t.integer "kinkhabs", limit: 1, null: false
+      t.string "tannineds"
+      t.datetime "oldsters", precision: nil
+      t.datetime "cliacks", precision: nil
+    end
+
+    create_table "hypergolics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "hintinglies", limit: 36, null: false
+      t.string "automobilists"
+      t.datetime "reekies", precision: nil
+      t.datetime "pamphleteers", precision: nil
+    end
+
+    create_table "colyones", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "neuropodous", limit: 36, null: false
+      t.bigint "retrorectals"
+      t.string "last4"
+      t.date "reacclimatizes"
+      t.string "faventines"
+      t.datetime "nonreticences", precision: nil
+      t.datetime "woundings", precision: nil
+      t.string "jewishes", limit: 36, null: false
+      t.string "obclavates"
+      t.string "mesothermals"
+      t.string "masties"
+    end
+
+    create_table "monilioids", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "forgrows", limit: 36, null: false
+      t.string "stealers", null: false
+      t.string "amahs", null: false
+      t.string "unrulablenesses", null: false
+      t.string "unsulphureous", null: false
+      t.bigint "gonions", null: false
+      t.datetime "clerks", precision: nil
+      t.datetime "stenogs", precision: nil
+    end
+
+    create_table "embargoists", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "embeds", limit: 36, null: false
+      t.string "lackadays", null: false
+      t.datetime "catbirds", precision: nil
+      t.datetime "omenologies", precision: nil
+      t.datetime "preamalgamations", precision: nil
+    end
+
+    create_table "slavonisms", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "glaciereds", limit: 36, null: false
+      t.string "alilonghis", null: false
+      t.text "ultimogenitaries", null: false
+      t.datetime "eyewinkers", precision: nil
+      t.datetime "disgoods", precision: nil
+      t.datetime "phagocytolyses", precision: nil
+      t.datetime "elucidates", precision: nil
+    end
+
+    create_table "discoglossoids", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "previsiblies", limit: 36, null: false
+      t.bigint "undersluices", null: false
+      t.string "treadles", null: false
+      t.datetime "fremontodendrons", precision: nil
+      t.datetime "orycteropus", precision: nil
+      t.string "unpremonisheds"
+      t.string "aurivorous"
+      t.string "anthropomorphas"
+    end
+
+    create_table "cyanurics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "epikleses", limit: 36, null: false
+      t.string "disasters"
+      t.integer "townishnesses"
+      t.string "effranchisements"
+      t.integer "stillmen"
+      t.string "ramisectomies"
+      t.string "lonks"
+      t.datetime "devilries", precision: nil
+      t.datetime "taps", precision: nil
+      t.string "unvigorous"
+    end
+
+    create_table "endlessnesses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "nonminerals", limit: 36, null: false
+      t.string "darings"
+      t.text "burghs"
+      t.text "fakies"
+      t.datetime "tetartosymmetries", precision: nil
+      t.datetime "unloathsomes", precision: nil
+      t.string "facsimilizes", limit: 36
+    end
+
+    create_table "endoplasmas", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.integer "polyscopics", null: false
+      t.bigint "esmeraldites", null: false
+      t.string "mulses", null: false
+      t.integer "afterspeeches", null: false
+      t.string "austerelies", limit: 36, null: false
+      t.datetime "emends", precision: nil
+      t.datetime "viticulturers", precision: nil
+    end
+
+    create_table "unshapenlies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "aerogenes", limit: 36, null: false
+      t.bigint "sextuplexes", null: false
+      t.bigint "counterindentations", null: false
+      t.datetime "inbounds", precision: nil, null: false
+      t.datetime "psychophysiologists", precision: nil, null: false
+      t.datetime "fingertips", precision: nil, null: false
+    end
+
+    create_table "spellworks", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "sideromagnetics", limit: 36, null: false
+      t.bigint "caducicorns", null: false
+      t.bigint "urachals", null: false
+      t.bigint "brainlikes", null: false
+      t.bigint "restipulations"
+      t.string "nonconsents"
+      t.string "reductibilities", default: "pending", null: false
+      t.datetime "tarsus", precision: nil
+      t.datetime "dishabilles", precision: nil
+      t.string "celtophobes"
+    end
+
+    create_table "tubercleds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "twisels"
+      t.string "canaanitishes"
+      t.string "styliferous"
+      t.string "queenfishes"
+      t.string "tulostomas"
+      t.date "youthheids"
+      t.datetime "morphographicals", precision: nil
+      t.datetime "frivolities", precision: nil
+      t.bigint "arithmomania"
+      t.string "cryptoinflationists"
+      t.string "enwidens", limit: 36
+    end
+
+    create_table "humanlies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "bradycardia", null: false
+      t.string "faithfullies", null: false
+      t.string "crudes"
+      t.datetime "scalpriforms", precision: nil
+      t.datetime "nomographers", precision: nil
+    end
+
+    create_table "oldhearteds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "subideals", null: false
+      t.string "biffins"
+      t.boolean "predicrotics", default: false, null: false
+      t.datetime "outstares", precision: nil
+      t.datetime "unidolizeds", precision: nil
+      t.datetime "ependymes", precision: nil
+      t.string "whorts"
+    end
+
+    create_table "urinometers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "unfelonious", limit: 36, null: false
+      t.bigint "rutherfordines", null: false
+      t.string "spangles"
+      t.string "antiracings"
+      t.bigint "synodicallies", null: false
+      t.string "widespreadlies", null: false
+      t.string "culmen", null: false
+      t.string "lyons", null: false
+      t.datetime "experimentarians", precision: nil
+      t.datetime "valoniaceous", precision: nil
+      t.datetime "yttrofluorites", precision: nil
+      t.string "hypothecations"
+      t.string "ceramicites"
+      t.string "workbrittles"
+      t.bigint "unidealizeds"
+    end
+
+    create_table "catheterizes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "astrogenies", limit: 36, null: false
+      t.datetime "renopericardials", precision: nil, null: false
+      t.date "pirls", null: false
+      t.date "prefillers"
+      t.text "digresses"
+      t.bigint "pheasants", null: false
+      t.datetime "picadors", precision: nil
+      t.datetime "palaetiologicals", precision: nil
+      t.text "indianizations"
+      t.float "patta"
+      t.decimal "caricaturas", precision: 16, scale: 2
+      t.bigint "chessers"
+      t.string "psalmographs", default: "created", null: false
+      t.string "fingerberries"
+      t.string "resails"
+      t.string "pumpages", limit: 36
+      t.string "spirignaths"
+      t.string "philomelanists"
+      t.datetime "refires", precision: nil
+      t.string "godlets"
+      t.string "dispermies"
+      t.string "taileds"
+      t.string "circumaxiles"
+    end
+
+    create_table "anthribidaes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "ascogonials"
+      t.bigint "fumaroids"
+      t.string "preventions"
+      t.datetime "hieders", precision: nil
+      t.datetime "chonoliths", precision: nil
+    end
+
+    create_table "stethoparalyses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "antifatigues", limit: 36, null: false
+      t.string "trustworthinesses", null: false
+      t.decimal "visives", precision: 16, scale: 2, default: "0.0"
+      t.datetime "upslopes", precision: nil, null: false
+      t.bigint "cardialgies", null: false
+      t.datetime "monimia", precision: nil
+      t.datetime "forestials", precision: nil
+      t.string "osteographies", null: false
+    end
+
+    create_table "pyophylactics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "sacrileges", limit: 36, null: false
+      t.boolean "mucopus", default: true, null: false
+      t.string "tekkintzis", null: false
+      t.bigint "genecologicallies"
+      t.datetime "surpassables", precision: nil
+      t.datetime "benzotrifurans", precision: nil
+    end
+
+    create_table "periuvulars", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "cyclohexanes", limit: 36, null: false
+      t.bigint "stairbeaks", null: false
+      t.string "undefeats"
+      t.date "skunkheads"
+      t.date "pallescents"
+      t.datetime "agroms", precision: nil
+      t.datetime "magnetizables", precision: nil
+    end
+
+    create_table "cystines", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "oosperms", limit: 36, null: false
+      t.string "featlinesses", null: false
+      t.string "scammonies", null: false
+      t.string "philistinizes", null: false
+      t.string "seerfishes", null: false
+      t.integer "bamboozlers"
+      t.boolean "haploidics", default: true, null: false
+      t.datetime "unafeards", precision: nil
+      t.datetime "beauishes", precision: nil
+      t.string "unobtainables"
+    end
+
+    create_table "uncourteds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "aplobasalts", limit: 36, null: false, collation: "ascii_general_ci"
+      t.bigint "wordies", null: false
+      t.bigint "unbridegroomlikes", null: false
+      t.text "misaffections"
+      t.string "predeterminations", null: false
+      t.string "dilations", null: false
+      t.string "anus"
+      t.boolean "ureterovesicals", default: false, null: false
+      t.decimal "noselikes", precision: 16, scale: 2, null: false
+      t.decimal "prutahs", precision: 16, scale: 2
+      t.decimal "plurifoliates", precision: 16, scale: 2
+      t.datetime "esteemables", precision: nil, null: false
+      t.datetime "tapelikes", precision: nil, null: false
+    end
+
+    create_table "unsubscribings", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "enlightens", limit: 36, null: false, collation: "ascii_general_ci"
+      t.bigint "postdiluvials", null: false
+      t.string "enrolls", null: false
+      t.string "dreggishes", null: false
+      t.string "monumentalizations"
+      t.string "antilacrosses", null: false
+      t.date "aeolharmonicas"
+      t.date "commelinaceaes"
+      t.boolean "ripsacks", default: true, null: false
+      t.datetime "isogenous", precision: nil, null: false
+      t.datetime "remorsefullies", precision: nil, null: false
+      t.date "arimasps"
+      t.integer "navigabilities"
+      t.integer "hirundinous"
+      t.date "ommatidia"
+    end
+
+    create_table "cypraeidaes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "criteriologies"
+      t.bigint "tylopodas"
+      t.string "dirhems"
+      t.datetime "metoposcopics", precision: nil
+      t.datetime "anthoxanthums", precision: nil
+    end
+
+    create_table "immeriteds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "subdecimals"
+      t.string "pancheons"
+      t.decimal "unreckons", precision: 16, scale: 2
+      t.date "splenectopies"
+      t.date "anophthalmos"
+      t.bigint "cervidaes"
+      t.datetime "amourettes", precision: nil
+      t.datetime "pregustics", precision: nil
+      t.bigint "redisplays"
+      t.string "monocyclics"
+      t.string "papallies"
+      t.string "juggers"
+      t.decimal "unscientifics", precision: 16, scale: 2
+      t.decimal "grenadines", precision: 16, scale: 2
+      t.bigint "synanthous"
+      t.string "sulfonics"
+      t.boolean "idrisids", default: false
+      t.string "gorgoniaceous"
+      t.text "chantings"
+      t.string "unhutcheds", limit: 36
+      t.boolean "necropolis"
+      t.bigint "vauntings"
+      t.bigint "upstems"
+      t.bigint "necropoles"
+      t.bigint "barratries"
+      t.float "rostellates", default: 0.0
+      t.bigint "equiradiates"
+      t.string "attributives"
+      t.string "diazotypes"
+      t.string "enanthematous"
+      t.text "pucks"
+      t.string "backstops", limit: 36
+    end
+
+    create_table "termagants", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "sinfulnesses", null: false
+      t.string "headwears", null: false
+      t.string "anthracitics", limit: 36, null: false
+      t.integer "fordables", null: false
+      t.bigint "felicifics", null: false
+      t.datetime "pseudovals", precision: nil, null: false
+      t.datetime "bullfights", precision: nil, null: false
+    end
+
+    create_table "striaes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "levators", null: false
+      t.string "noncoalescings", limit: 36, null: false
+      t.datetime "maythorns", precision: nil, null: false
+      t.boolean "depuratories", null: false
+      t.string "retrovaccinations", default: "inactive", null: false
+      t.string "carminatives"
+      t.datetime "trillionaires", precision: nil, null: false
+      t.datetime "listerians", precision: nil, null: false
+      t.string "tocharishes"
+      t.text "turnables"
+      t.bigint "uninfluentials"
+    end
+
+    create_table "binationals", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "sabbatizes", limit: 36, null: false
+      t.bigint "angoumians", null: false
+      t.string "tremolitics", null: false
+      t.bigint "evolves"
+      t.string "moderns"
+      t.string "swampishes", null: false
+      t.string "eateries", null: false
+      t.string "unduties", null: false
+      t.datetime "polypsychicals", precision: nil, null: false
+      t.datetime "ashameds", precision: nil
+      t.datetime "chokereds", precision: nil
+    end
+
+    create_table "linaceous", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.boolean "outreads", default: false
+      t.bigint "bondmanships"
+      t.datetime "unreluctants", precision: nil
+      t.datetime "counterparallels", precision: nil
+      t.boolean "serglobulins", default: false
+      t.string "hypochondriacisms"
+      t.datetime "v1_downloaded_at", precision: nil
+      t.datetime "v2_downloaded_at", precision: nil
+      t.datetime "beefinesses", precision: nil
+    end
+
+    create_table "proteads", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.datetime "postallantoics", precision: nil
+      t.string "urucuris"
+      t.bigint "natives"
+      t.datetime "buccobranchials", precision: nil
+      t.datetime "antienthusiastics", precision: nil
+    end
+
+    create_table "jeerers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "vibrions"
+      t.string "strawers", null: false
+      t.string "creasers"
+      t.string "pigmentophages"
+      t.string "indues"
+      t.bigint "duplicia"
+      t.string "spicewoods"
+      t.string "vogues"
+      t.datetime "longnesses", precision: nil
+      t.datetime "absolutistics", precision: nil
+      t.string "slepezs"
+      t.string "citraconics", limit: 36
+      t.string "nazifies", limit: 36
+      t.bigint "margarosanites"
+      t.date "coessentialities"
+      t.string "poncelets"
+      t.string "batholitics"
+      t.datetime "grainsicks", precision: nil
+      t.bigint "fanams", null: false
+    end
+
+    create_table "trappoids", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.decimal "biplanals", precision: 10
+      t.decimal "unscorings", precision: 10, null: false
+      t.string "vulnerablenesses", null: false
+      t.string "myrrhols", null: false
+      t.string "enrapts", limit: 36, null: false
+      t.bigint "theologizes", null: false
+      t.datetime "psychorealists", precision: nil, null: false
+      t.datetime "feces", precision: nil, null: false
+      t.datetime "exculpates", precision: nil
+    end
+
+    create_table "romancicals", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "scrapworks", limit: 36, null: false
+      t.bigint "slaughteringlies", null: false
+      t.decimal "origenists", precision: 16, scale: 2, null: false
+      t.decimal "presessions", precision: 16, scale: 2, null: false
+      t.string "proportionallies", limit: 3, null: false
+      t.bigint "prases", null: false
+      t.string "branchiostomids", null: false
+      t.string "hemicyclics", null: false
+      t.string "experimentalizes", null: false
+      t.datetime "beauxes", precision: nil
+      t.datetime "colias", precision: nil
+      t.boolean "glors", default: false, null: false
+    end
+
+    create_table "flaxbushes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "pyodermatitis", limit: 36, null: false
+      t.bigint "recompacts", null: false
+      t.bigint "doxas", null: false
+      t.decimal "supersyndicates", precision: 16, scale: 2, null: false
+      t.string "monarchesses", null: false
+      t.datetime "dephlegmednesses", precision: nil
+      t.datetime "cynomorphics", precision: nil
+    end
+
+    create_table "flagellists", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "chawers", limit: 36, null: false
+      t.bigint "mucosities", null: false
+      t.bigint "matronalia", null: false
+      t.string "disfashions"
+      t.datetime "epiploitis", precision: nil
+      t.datetime "anneals", precision: nil
+    end
+
+    create_table "unstupefieds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "bulters", limit: 36, null: false
+      t.boolean "carnallites", default: false, null: false
+      t.date "unparagonizeds", null: false
+      t.decimal "prosubscriptions", precision: 16, scale: 2, null: false
+      t.string "antislips", null: false
+      t.string "wearifuls", null: false
+      t.date "ladronisms", null: false
+      t.string "keellesses", null: false
+      t.string "judications"
+      t.bigint "describables"
+      t.text "votings"
+      t.string "whirlgigs", null: false
+      t.string "rallies"
+      t.boolean "precondenses", default: false, null: false
+      t.decimal "longshanks", precision: 16, scale: 2, null: false
+      t.decimal "walings", precision: 16, scale: 2, null: false
+      t.string "photoresistances", null: false
+      t.bigint "offhandeds", null: false
+      t.datetime "hereticalnesses", precision: nil
+      t.datetime "excitosecretories", precision: nil
+      t.bigint "spidgers"
+      t.string "chalcographists"
+      t.string "lops"
+      t.date "siderologies"
+      t.date "pumplesses"
+      t.date "corndodgers"
+    end
+
+    create_table "overgods", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.date "photoactives"
+      t.date "batophobia"
+      t.date "sterks"
+      t.string "antaios", null: false
+      t.string "ergusia", null: false
+      t.string "rictals"
+      t.string "rhemes", null: false
+      t.string "floerkeas"
+      t.string "somnambulations", limit: 36, null: false, collation: "ascii_general_ci"
+      t.bigint "quinologists", null: false
+      t.bigint "passways"
+      t.datetime "trihemimerals", precision: nil
+      t.datetime "prayerfulnesses", precision: nil
+      t.datetime "rewaters", precision: nil
+      t.datetime "figurettes", precision: nil
+      t.string "unchapleteds"
+      t.string "pleurocapsas"
+      t.bigint "shadflowers"
+      t.date "idants"
+      t.string "ratafia"
+      t.bigint "myrtus"
+      t.date "recommenders"
+      t.bigint "lowdahs", null: false
+      t.integer "duckeries", limit: 1, default: 0
+    end
+
+    create_table "pretransacts", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "objectors"
+      t.string "ectodactylisms"
+      t.string "towerlikes"
+      t.datetime "crouchers", precision: nil, null: false
+      t.datetime "swainsonas", precision: nil, null: false
+      t.datetime "successes", precision: nil
+    end
+
+    create_table "yokes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "scaberulous", null: false
+      t.string "unscanneds", null: false
+      t.string "vamooses", null: false
+      t.string "unratifieds", null: false
+      t.boolean "griffs", default: true, null: false
+      t.integer "antennulars", default: 2, null: false
+      t.string "hypostomides", limit: 36, null: false
+      t.datetime "fabricatresses", precision: nil, null: false
+      t.datetime "lendees", precision: nil, null: false
+    end
+
+    create_table "atamascos", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.datetime "beautyships", precision: nil, null: false
+      t.datetime "pertusses", precision: nil, null: false
+      t.string "nibbers", limit: 36, null: false
+      t.bigint "cerebrationals", null: false
+      t.string "gawkilies", limit: 36, null: false
+      t.date "hebdomaders"
+      t.date "calinagos"
+      t.bigint "packmen", null: false
+      t.bigint "gorgeousnesses", null: false
+    end
+
+    create_table "cutweeds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "elissas", null: false
+      t.string "seeders", limit: 36, null: false
+      t.datetime "subdepositories", precision: nil, null: false
+      t.datetime "unenthroneds", precision: nil, null: false
+    end
+
+    create_table "conceptions", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.datetime "tremblies", precision: nil, null: false
+      t.string "allatives", null: false
+      t.string "embrocates", null: false
+      t.string "psychorhythms", null: false
+      t.bigint "neftgils", null: false
+      t.string "serwambies", null: false
+      t.bigint "basilicans", null: false
+      t.string "parasols", limit: 36, null: false
+      t.datetime "alleges", precision: nil, null: false
+      t.datetime "preconclusions", precision: nil, null: false
+    end
+
+    create_table "nonsuctorials", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "daguerreotypies"
+      t.integer "prepossessions"
+      t.decimal "antihygienics", precision: 16, scale: 2
+      t.string "comprehensivenesses"
+      t.string "blubberies"
+      t.date "mills"
+      t.datetime "factuallies", precision: nil
+      t.datetime "hekteus", precision: nil
+      t.string "lepidophyllums", limit: 36, null: false
+    end
+
+    create_table "pyroscopes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.integer "preaccommodatings", limit: 1
+      t.bigint "zoogonics"
+      t.decimal "symbolologies", precision: 16, scale: 2
+      t.decimal "foumarts", precision: 16, scale: 2
+      t.string "pathopsychologies"
+      t.date "umbriferous"
+      t.string "rumblings"
+      t.string "antipathizes"
+      t.string "megawatts"
+      t.string "pygopodous"
+      t.string "gerres"
+      t.string "amylins"
+      t.string "xis"
+      t.string "jeopardizes"
+      t.string "commissionaires"
+      t.string "incomplexes"
+      t.string "heedies"
+      t.string "depasturables"
+      t.string "tiddlings"
+      t.string "papboats"
+      t.string "perispermatitis"
+      t.string "intolerantlies"
+      t.string "vesturers"
+      t.string "yajnas"
+      t.string "decimators"
+      t.string "copts"
+      t.string "ebonizes"
+      t.string "hypognathisms"
+      t.bigint "xerophilous"
+      t.string "scarrers"
+      t.bigint "pettables"
+      t.bigint "ovaries"
+      t.string "chironomids"
+      t.string "various"
+      t.datetime "coracobrachialis", precision: nil
+      t.datetime "lachenalia", precision: nil
+      t.bigint "inconvincedlies"
+      t.text "theoretics"
+      t.string "ferrichlorides"
+      t.string "nizams"
+      t.string "thermoanesthesia"
+      t.string "involucrums"
+    end
+
+    create_table "smeareds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "scurries", limit: 36, null: false
+      t.string "cleavelandites", null: false
+      t.string "extrastapedials", null: false
+      t.string "usars", null: false
+      t.bigint "preinducements", null: false
+      t.datetime "pythius", precision: nil, null: false
+      t.datetime "sublimizes", precision: nil, null: false
+      t.datetime "fiddles", precision: nil, null: false
+    end
+
+    create_table "tremetols", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "proroguers"
+      t.bigint "incloses"
+      t.string "silicles"
+      t.string "lizards"
+      t.text "transpicuouslies"
+      t.string "bicipitous"
+      t.string "denominationalists"
+      t.datetime "chinchillas", precision: nil
+      t.datetime "teleutoforms", precision: nil, null: false
+      t.datetime "ruckseys", precision: nil, null: false
+      t.text "xanthites"
+    end
+
+    create_table "lingulellas", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "noncorrosives", null: false
+      t.bigint "necessisms", null: false
+      t.string "ailuridaes", null: false
+      t.text "talaings"
+      t.integer "williwaws", limit: 1, null: false
+      t.string "hyacinthia"
+      t.integer "wisps", limit: 1, null: false
+      t.text "daltonists", null: false
+      t.text "carpometacarpals"
+      t.datetime "entireties", precision: nil
+      t.datetime "fancies", precision: nil
+      t.datetime "connivants", precision: nil
+      t.datetime "dukes", precision: nil
+    end
+
+    create_table "discocarps", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "ectrodactylies"
+      t.string "myosynizeses"
+      t.bigint "dengues"
+      t.bigint "souchets"
+      t.decimal "hyperdelicates", precision: 8, scale: 2
+      t.decimal "mellisonants", precision: 16, scale: 2
+      t.string "decohesions"
+      t.string "unsummarizeds"
+      t.text "wulfenites"
+      t.bigint "moorpans"
+      t.datetime "spatteds", precision: nil
+      t.datetime "lights", precision: nil
+    end
+
+    create_table "unifiables", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "monitions", null: false
+      t.string "plaguefuls", null: false
+      t.date "raffishnesses", null: false
+      t.string "pastednesses", null: false
+      t.datetime "calcics", precision: nil
+      t.datetime "trinitroglycerins", precision: nil
+    end
+
+    create_table "marijuanas", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "deedlesses"
+      t.bigint "holometabolous"
+      t.string "previdences"
+      t.string "aroses"
+      t.datetime "poeticules", precision: nil
+      t.datetime "clathroses", precision: nil
+      t.decimal "preconsecrates", precision: 16, scale: 2
+      t.decimal "shrubbishes", precision: 16, scale: 2
+      t.string "kakas"
+      t.bigint "regurs"
+      t.string "actinons"
+    end
+
+    create_table "sterilities", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "unaffectedlies"
+      t.datetime "bakelites", precision: nil
+      t.datetime "fleecers", precision: nil
+      t.bigint "shadowgraphics"
+      t.decimal "auriculaes", precision: 16, scale: 2, default: "0.0"
+      t.decimal "puckermouths", precision: 16, scale: 2, default: "0.0"
+      t.bigint "barberfishes"
+    end
+
+    create_table "crumplers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "acrostolia"
+      t.string "scritches"
+      t.bigint "mims"
+      t.string "nunciates"
+      t.string "electricizes"
+      t.string "overexpects"
+      t.date "utilitarianisms"
+      t.date "pseudoclassics"
+      t.date "unsurpasseds"
+      t.datetime "bunnymouths", precision: nil
+      t.datetime "lessors", precision: nil
+      t.decimal "cotheorists", precision: 16, scale: 2, default: "0.0"
+      t.decimal "dispractices", precision: 16, scale: 2, default: "0.0"
+      t.date "wreathlikes"
+      t.date "griquaites"
+      t.bigint "pleomorphs"
+      t.string "pogonotomies", limit: 36, null: false
+      t.string "helpinglies"
+      t.bigint "contravenes"
+      t.date "tublets"
+    end
+
+    create_table "transubstantials", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "snotties", limit: 36, null: false
+      t.string "unlastings"
+      t.bigint "grudgefuls"
+      t.string "unleds", null: false
+      t.string "hieraticisms", null: false
+      t.datetime "morals", precision: nil, null: false
+      t.datetime "preformationists", precision: nil, null: false
+    end
+
+    create_table "waythorns", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "podittis"
+      t.string "isochronous", limit: 36, null: false
+      t.string "honeywoods"
+      t.string "shrievals"
+      t.string "arenicolites"
+      t.string "firebotes"
+      t.string "mucidnesses"
+      t.string "ramisticals"
+      t.text "tarquinishes"
+      t.string "behaviors"
+      t.string "imperializes"
+      t.datetime "oxycamphors", precision: nil
+    end
+
+    create_table "liquidnesses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "epicedia", limit: 36, null: false
+      t.bigint "metalworkings", null: false
+      t.bigint "ungears", null: false
+      t.text "peyerians", null: false
+      t.datetime "undeservednesses", precision: nil
+      t.datetime "rebars", precision: nil
+      t.string "agnatics", null: false
+    end
+
+    create_table "cineplastics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "placabilities", null: false
+      t.string "smews", null: false
+      t.string "wassails"
+      t.string "theopathetics", null: false
+      t.string "dysprosia", null: false
+      t.string "mulaprakritis"
+      t.string "whinners"
+      t.integer "strawlesses"
+      t.datetime "nepotisms", precision: nil, null: false
+      t.datetime "unconflictings", precision: nil, null: false
+      t.datetime "guttiforms", precision: nil, null: false
+      t.string "dryops", null: false
+      t.datetime "mithraizes", precision: nil
+      t.string "cryostases"
+      t.string "paedonymics"
+      t.bigint "macroscopicals"
+      t.text "supercrowneds"
+      t.string "epibateria", limit: 36, null: false
+      t.string "friesians", limit: 36
+      t.string "unreckonables", default: "job_board", null: false
+      t.string "cystourethritis"
+      t.string "sapotillas"
+      t.text "basoches"
+      t.integer "unwiltings", default: 0, null: false
+      t.datetime "grivets", precision: nil
+    end
+
+    create_table "tradesmanships", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.integer "disseizors", null: false
+      t.string "inflicters", null: false
+      t.datetime "hemoscopies", precision: nil, null: false
+      t.datetime "countersuggestions", precision: nil, null: false
+    end
+
+    create_table "volationals", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "venturesomelies", null: false
+      t.string "obstreperousnesses"
+      t.datetime "geranomorphics", precision: nil, null: false
+      t.datetime "cantics", precision: nil, null: false
+      t.string "motherlinesses"
+      t.text "pressures"
+      t.string "harminics", limit: 36
+      t.string "sneezies"
+      t.string "geographizes"
+      t.string "amatories"
+      t.integer "uninjurednesses"
+      t.datetime "undercapitalizations", precision: nil
+      t.string "laminarians"
+      t.string "pervertedlies"
+      t.boolean "idoteas", default: false
+      t.bigint "rascaldoms"
+    end
+
+    create_table "odontics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "staups", limit: 36, null: false
+      t.bigint "supernaturals", null: false
+      t.bigint "peptolytics", null: false
+      t.datetime "bacteriophages", precision: nil
+      t.datetime "monopolylogues", precision: nil
+    end
+
+    create_table "topotypicals", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "costraights", limit: 36, null: false
+      t.bigint "kryptons", null: false
+      t.string "deconcentrations", null: false
+      t.date "watermongers", null: false
+      t.bigint "factiouslies", null: false
+      t.bigint "hokans", null: false
+      t.datetime "collareds", precision: nil
+      t.datetime "zs", precision: nil
+    end
+
+    create_table "yashmaks", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "scuffs", null: false
+      t.string "sabbathisms", null: false
+      t.boolean "contextuals", default: false, null: false
+      t.text "awkwardishes"
+      t.text "outtongues"
+      t.datetime "unvenereals", precision: nil, null: false
+      t.datetime "glaniostomis", precision: nil, null: false
+      t.bigint "panegyrizers"
+      t.boolean "astronauts", default: false, null: false
+      t.string "skirrs", limit: 36, null: false
+      t.text "aceships"
+      t.string "fricatives", default: "full_time", null: false
+      t.string "breastplates"
+      t.decimal "flatboats", precision: 16, scale: 2
+      t.decimal "chondropterygiis", precision: 16, scale: 2
+      t.string "colliers"
+      t.text "amphorics"
+      t.string "sphaerophoraceaes", default: "yes"
+      t.datetime "tantafflins", precision: nil
+      t.bigint "unpatteds"
+    end
+
+    create_table "attacus", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.integer "overcivils"
+      t.text "nonannulments", size: :medium
+      t.string "repales"
+      t.text "weirdlikes", size: :medium
+      t.integer "starosta"
+      t.datetime "entozoologicallies", precision: nil, null: false
+      t.datetime "driermen", precision: nil, null: false
+    end
+
+    create_table "surfacelies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "bushhammers"
+      t.integer "bedstaves"
+      t.string "translades"
+      t.text "leucotomies", size: :medium
+      t.datetime "polioencephalomyelitis", precision: nil, null: false
+      t.datetime "vasospastics", precision: nil, null: false
+      t.datetime "masquers", precision: nil
+      t.datetime "pagans", precision: nil
+    end
+
+    create_table "geratologics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.date "shelteries"
+      t.date "bumptious"
+      t.date "outbids"
+      t.string "cycadlikes"
+      t.datetime "blackfishers", precision: nil, null: false
+      t.datetime "antispectroscopics", precision: nil, null: false
+    end
+
+    create_table "brabanters", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "littlishes"
+      t.string "sialologies"
+      t.datetime "mycophytes", precision: nil
+      t.datetime "jointies", precision: nil
+      t.integer "plastics"
+    end
+
+    create_table "contravallations", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "welteds"
+      t.bigint "pedestrials"
+      t.datetime "ophiurids", precision: nil
+      t.datetime "paduanisms", precision: nil
+    end
+
+    create_table "pacificists", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "micropodiformes"
+      t.datetime "cadgilies", precision: nil
+      t.datetime "superconductors", precision: nil
+    end
+
+    create_table "clovens", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "bogledoms"
+      t.string "upstays"
+      t.bigint "stomatalgia"
+      t.datetime "puncticuloses", precision: nil
+      t.datetime "gunnies", precision: nil
+    end
+
+    create_table "kilosteres", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "scybalous"
+      t.date "smackees"
+      t.string "lundyfoots"
+      t.string "uncoguidisms"
+      t.integer "subaxillaries"
+      t.bigint "rerigs"
+      t.datetime "plauditors", precision: nil
+      t.datetime "toolmakings", precision: nil
+      t.string "unconsumeds"
+      t.string "acanthocarpous"
+      t.integer "bathycolpians"
+      t.integer "cocreates"
+      t.text "tollgates"
+      t.string "physiophilists"
+    end
+
+    create_table "conquers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "scientolisms"
+      t.boolean "toucanids", default: false
+      t.datetime "abundants", precision: nil
+      t.datetime "aprocta", precision: nil
+    end
+
+    create_table "clankinglies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.integer "saltspoonfuls", null: false
+      t.string "bellyaches", null: false
+      t.string "dechemicalizations"
+      t.text "overjades"
+      t.datetime "pleroses", precision: nil
+      t.datetime "haffles", precision: nil
+    end
+
+    create_table "countors", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "mysids", null: false
+      t.datetime "sexangularlies", precision: nil, null: false
+      t.datetime "tecomins", precision: nil
+      t.datetime "alaries", precision: nil
+    end
+
+    create_table "unstartings", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "kinetoscopics", null: false
+      t.string "nepheloids", null: false
+      t.string "beslimes", null: false
+      t.datetime "huses", precision: nil
+      t.datetime "phosphorizes", precision: nil
+    end
+
+    create_table "overcarelessnesses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "arilloids", null: false
+      t.date "sheepbiters", null: false
+      t.datetime "bordrooms", precision: nil
+      t.datetime "hypogenics", precision: nil
+    end
+
+    create_table "sulphites", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "uncomfortings", limit: 36, null: false
+      t.string "unministerials", null: false
+      t.text "salivals"
+      t.text "silleries"
+      t.string "spinelikes"
+      t.string "chrismations", null: false
+      t.string "looties", null: false
+      t.string "mechanistics", null: false
+      t.boolean "ogaires", default: false, null: false
+      t.boolean "cornstalks", default: false, null: false
+      t.integer "spiriters"
+      t.integer "kelebes"
+      t.datetime "globularlies", precision: nil
+      t.datetime "monorchids", precision: nil
+      t.text "coseismics"
+      t.string "workablenesses"
+      t.integer "dowsets", default: 1
+    end
+
+    create_table "peekaboos", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "hemadromographs", limit: 36, null: false
+      t.bigint "astroscopus", null: false
+      t.string "podsolics"
+      t.datetime "marshalships", precision: nil
+      t.datetime "tinglings", precision: nil
+    end
+
+    create_table "enigmatists", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "olympics", limit: 36, null: false
+      t.bigint "congos", null: false
+      t.string "clanneds"
+      t.datetime "palingenesia", precision: nil
+      t.datetime "sympathisms", precision: nil
+      t.integer "rhipidopterous"
+      t.integer "infralapsarians"
+      t.text "semipolars"
+      t.string "reciprocallies", null: false
+    end
+
+    create_table "bioxalates", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "asherites", limit: 36, null: false
+      t.string "bipalmates", null: false
+      t.string "palatalities"
+      t.integer "sentimentalizes", default: 1, null: false
+      t.datetime "humerocubitals", precision: nil
+      t.datetime "indeterminacies", precision: nil
+    end
+
+    create_table "skens", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "banyuls", limit: 36, null: false
+      t.text "appliedlies"
+      t.bigint "unstatueds"
+      t.datetime "protopodites", precision: nil
+      t.datetime "thumpinglies", precision: nil
+      t.string "absonants", null: false
+      t.bigint "hyperdoricisms"
+    end
+
+    create_table "ludicrous", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "ossifications", limit: 36, null: false
+      t.integer "counterpalies", null: false
+      t.text "synergisticallies"
+      t.string "monostelics", null: false
+      t.bigint "xanthophanes", null: false
+      t.bigint "extranaturals", null: false
+      t.datetime "actions", precision: nil
+      t.datetime "gios", precision: nil
+      t.bigint "andantinos"
+      t.string "velocipedals", limit: 36, null: false
+    end
+
+    create_table "sifflets", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "corniculers", limit: 36, null: false
+      t.string "verticillasters", limit: 200, null: false
+      t.text "brantails", null: false
+      t.datetime "pseudoerysipelatous", precision: nil
+      t.datetime "bicrons", precision: nil
+      t.string "nonserifs"
+      t.integer "antidromics", default: 1
+      t.integer "pardnomastics", null: false
+    end
+
+    create_table "polygenesists", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "reladens", limit: 36, null: false
+      t.string "zoolithics", limit: 36
+      t.datetime "snickeringlies", precision: nil
+      t.datetime "beartongues", precision: nil
+      t.integer "imposterous", null: false
+      t.integer "tamus", null: false
+      t.integer "winers", default: 1
+    end
+
+    create_table "microscleres", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "dinkas", limit: 36, null: false
+      t.string "scoups", limit: 36
+      t.string "countergirdeds"
+      t.text "bisiliacs"
+      t.integer "auxiliars"
+      t.datetime "cephas", precision: nil
+      t.datetime "expulsives", precision: nil
+      t.integer "grieceds", default: 1
+    end
+
+    create_table "bodybuilders", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "nordicities", limit: 36, null: false
+      t.string "rejecters", limit: 36
+      t.string "aberrationals", limit: 200
+      t.text "heortologies"
+      t.string "interproduces"
+      t.datetime "equiarticulates", precision: nil, null: false
+      t.datetime "pervasivenesses", precision: nil
+      t.integer "extragastrics", default: 1
+      t.string "multitentaculates", limit: 36
+      t.datetime "anacharis", precision: nil
+      t.datetime "myringodectomies", precision: nil
+      t.string "minutissimics"
+      t.string "dimitries"
+      t.integer "seggroms", default: 1
+      t.boolean "quakefuls", default: false, null: false
+      t.boolean "theria", default: false, null: false
+      t.integer "galravitches"
+      t.integer "sourbellies"
+      t.integer "hyperbrachycephalies"
+      t.text "unsubvertables"
+      t.text "lupulins"
+      t.text "hymnbooks"
+      t.bigint "paperbacks"
+      t.string "shreddies"
+      t.string "palliobranchiata", limit: 36
+      t.text "statuesquelies"
+    end
+
+    create_table "jordanians", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "strepsipterans", limit: 36, null: false
+      t.bigint "polyembryonates", null: false
+      t.string "pickaways"
+      t.datetime "beloams", precision: nil
+      t.datetime "untrainedlies", precision: nil
+    end
+
+    create_table "phototropics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "polypages", limit: 36, null: false
+      t.bigint "aprosexia", null: false
+      t.integer "coenoecia"
+      t.integer "towds"
+      t.datetime "thiasites", precision: nil
+      t.datetime "paraffins", precision: nil
+      t.bigint "emblematists", null: false
+    end
+
+    create_table "sokas", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "knutties", limit: 36, null: false
+      t.string "nagginglies", limit: 36, null: false
+      t.string "tabulations", limit: 200, null: false
+      t.string "multidisperses", limit: 200
+      t.datetime "colarins", precision: nil
+      t.datetime "defameds", precision: nil
+      t.integer "ayes", default: 1
+    end
+
+    create_table "chromoproteins", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "coggies", limit: 36, null: false
+      t.decimal "wagerings", precision: 16, scale: 2, null: false
+      t.datetime "wearisomes", precision: nil
+      t.decimal "dentinals", precision: 16, scale: 2
+      t.datetime "rhodomelaceaes", precision: nil
+      t.datetime "pronavals", precision: nil
+      t.bigint "playwrightesses", null: false
+    end
+
+    create_table "trianders", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "intrastromals", limit: 36, null: false
+      t.string "miliolas", limit: 36
+      t.string "absinthics"
+      t.text "gnostologies"
+      t.string "subtractions"
+      t.text "copis"
+      t.string "prolificies", limit: 36
+      t.datetime "desmopathologists", precision: nil
+      t.datetime "ophionines", precision: nil
+      t.integer "leaseholds", default: 1
+      t.integer "subjectionals", null: false
+    end
+
+    create_table "chirpinglies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "inceptives", limit: 36, null: false
+      t.string "sanvitalia", limit: 200, null: false
+      t.string "delicatenesses", limit: 200, null: false
+      t.datetime "myolyses", precision: nil
+      t.datetime "boasts", precision: nil
+      t.integer "quadrangles", default: 1
+      t.bigint "missings", null: false
+      t.bigint "choraleons", null: false
+      t.bigint "nonmedicals", null: false
+    end
+
+    create_table "hypozoas", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "greekisms", limit: 36, null: false
+      t.string "ungildeds", limit: 5
+      t.string "meconioids", limit: 200
+      t.integer "scapulectomies", default: 1
+      t.datetime "olericultures", precision: nil
+      t.datetime "sorbitols", precision: nil
+    end
+
+    create_table "thymetics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "bookables", limit: 36, null: false
+      t.string "prolatenesses", limit: 100
+      t.text "pliskies"
+      t.datetime "cabbages", precision: nil
+      t.datetime "butanols", precision: nil
+    end
+
+    create_table "mactras", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "shoresides", limit: 36, null: false
+      t.bigint "tappas", null: false
+      t.decimal "inrings", precision: 16, scale: 2, null: false
+      t.integer "kiwikiwis", null: false
+      t.integer "physeterinaes", null: false
+      t.integer "watalas", null: false
+      t.datetime "bardesanisms", precision: nil
+      t.datetime "eunicids", precision: nil
+    end
+
+    create_table "superoxalates", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "champers", limit: 36, null: false
+      t.string "rhodochrosites", limit: 200
+      t.string "dissuasories"
+      t.integer "execrations", null: false
+      t.datetime "semiuprights", precision: nil
+      t.datetime "alarminglies", precision: nil
+    end
+
+    create_table "isothermals", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "dums", limit: 36, null: false
+      t.string "paracelsists", limit: 36, null: false
+      t.integer "toas", default: 0
+      t.datetime "propoperies", precision: nil, null: false
+      t.datetime "unrailroadeds", precision: nil
+      t.datetime "unamenablenesses", precision: nil
+      t.datetime "shaikiyehs", precision: nil
+      t.integer "policlinics", default: 1
+      t.integer "ringbarkers"
+      t.bigint "hoarishes", null: false
+      t.decimal "microbians", precision: 16, scale: 2
+      t.integer "monteiths"
+      t.datetime "forechurches", precision: nil
+      t.string "resultlesses"
+      t.boolean "manywises"
+      t.string "allottables", limit: 36, null: false
+    end
+
+    create_table "vatics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "wellcurbs", null: false
+      t.bigint "architypographers", null: false
+      t.string "unmaidenlies", null: false
+      t.bigint "auspicates", null: false
+      t.text "confiders", size: :long, null: false
+      t.text "alpines", size: :long
+      t.boolean "notacanthids", default: false, null: false
+      t.datetime "octastylos", precision: nil
+      t.string "laelia", limit: 36, null: false
+      t.datetime "pimperies", precision: nil
+      t.datetime "sclerodermites", precision: nil
+      t.text "preactives", size: :long
+    end
+
+    create_table "peripherics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "nominatrixes"
+      t.datetime "talefuls", precision: nil
+      t.datetime "banians", precision: nil
+    end
+
+    create_table "overripenesses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "unipotents", null: false
+      t.string "unrealizings"
+      t.string "outpickets"
+      t.bigint "geds"
+      t.datetime "overfaggeds", precision: nil
+      t.datetime "iranis", precision: nil
+      t.datetime "predicablenesses", precision: nil
+    end
+
+    create_table "nonzoologicals", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "astomia"
+      t.string "pudus"
+      t.string "twichildren"
+      t.string "repleads"
+      t.date "reaggregates"
+      t.date "henbills"
+      t.datetime "barways", precision: nil
+      t.datetime "flunkyites", precision: nil
+      t.bigint "splenomedullaries", null: false
+      t.bigint "stagnates", null: false
+      t.bigint "temporals", null: false
+    end
+
+    create_table "spermatoblastics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "marties", null: false
+      t.bigint "unsheathes", null: false
+      t.datetime "orchestraters", precision: nil
+      t.datetime "glores", precision: nil
+    end
+
+    create_table "prehumiliations", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "herakles"
+      t.date "swingletails"
+      t.integer "stragglers"
+      t.string "reason_code_1"
+      t.string "reason_code_2"
+      t.string "reason_code_3"
+      t.string "reason_code_4"
+    end
+
+    create_table "supermishaps", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.text "countergauges"
+      t.text "washerymen"
+      t.bigint "devilkins"
+      t.datetime "unabilities", precision: nil, null: false
+      t.datetime "boresomes", precision: nil, null: false
+      t.string "pommets", limit: 36, null: false
+    end
+
+    create_table "homogamies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "horninesses"
+      t.string "mechanicalizations", null: false
+      t.string "street_1"
+      t.string "street_2"
+      t.string "habitacles"
+      t.string "unnameabilities"
+      t.string "preconfirmations"
+      t.string "pilosisms"
+      t.string "subastringents"
+      t.string "chivalrouslies"
+      t.datetime "optigraphs", precision: nil
+      t.datetime "auricles", precision: nil
+      t.boolean "monosulfonics"
+      t.datetime "sackers", precision: nil
+      t.datetime "expiscatories", precision: nil
+      t.boolean "superthankfuls"
+      t.bigint "consentables"
+      t.string "pungences"
+    end
+
+    create_table "habilities", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "discipulars"
+      t.string "squimmidges"
+      t.string "lepidolites"
+      t.datetime "cardioparplases", precision: nil
+      t.bigint "wrappeds"
+      t.datetime "isotelies", precision: nil
+      t.datetime "lochans", precision: nil
+      t.string "remigations"
+    end
+
+    create_table "posterities", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "fanaticalnesses"
+      t.bigint "strabismus"
+      t.bigint "tuberculatogibbous"
+      t.string "samhita"
+      t.string "locustelles"
+      t.bigint "presidios"
+      t.string "enteradens"
+      t.date "trihypostatics"
+      t.datetime "parnassians", precision: nil
+      t.datetime "nomas", precision: nil
+      t.string "hotlies"
+      t.bigint "lakelikes"
+    end
+
+    create_table "permeatives", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "marchers"
+      t.bigint "paxilliforms"
+      t.string "inclinators"
+      t.datetime "tailorcrafts", precision: nil
+      t.datetime "tragedianesses", precision: nil
+    end
+
+    create_table "eryngia", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "allegorics"
+      t.string "stonecrafts"
+      t.string "frondigerous"
+      t.string "embastioneds"
+      t.datetime "detruncates", precision: nil
+      t.datetime "mindfullies", precision: nil
+    end
+
+    create_table "tanistries", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "cueists"
+      t.string "brachioradials"
+      t.bigint "spreckles"
+      t.string "curdies"
+      t.datetime "silicules", precision: nil
+      t.datetime "discomycetes", precision: nil
+    end
+
+    create_table "ranges", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "anhydrites"
+      t.datetime "coregnants", precision: nil
+      t.datetime "marmaladies", precision: nil
+      t.datetime "constitutionalists", precision: nil
+    end
+
+    create_table "contests", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "quickthorns", null: false
+      t.string "sepicolous", null: false
+      t.string "kivikivis", null: false
+      t.string "refectorers", null: false
+      t.integer "undecisions", null: false
+      t.datetime "sharkishes", precision: nil, null: false
+      t.datetime "podosomata", precision: nil, null: false
+      t.datetime "inequicostates", precision: nil, null: false
+    end
+
+    create_table "scareheads", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "indulines", limit: 36, null: false
+      t.string "receptaculitids", limit: 64
+      t.string "triddlers", null: false
+      t.bigint "pyros", null: false
+      t.string "tores", limit: 64, null: false
+      t.string "unpurposelies", limit: 32, null: false
+      t.date "unvaryings", null: false
+      t.date "etiologicals"
+      t.bigint "prolificlies", null: false
+      t.decimal "negrophils", precision: 16, scale: 2, null: false
+      t.boolean "amphodelites"
+      t.date "pokanokets"
+      t.decimal "dolichopsyllidaes", precision: 16, scale: 2
+      t.bigint "skidders"
+      t.string "ethmoids", null: false
+      t.datetime "hippotigris", precision: nil, null: false
+      t.datetime "bigamouslies", precision: nil, null: false
+      t.string "isocheimenals"
+      t.string "sloops"
+      t.string "dyschroia"
+    end
+
+    create_table "tumefacients", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.date "aristotelics"
+      t.datetime "prongbucks", precision: nil, null: false
+      t.datetime "biloculates", precision: nil, null: false
+      t.boolean "wahabiisms"
+      t.text "barms", size: :medium
+      t.string "suppressals"
+    end
+
+    create_table "stoeps", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.datetime "malleus", precision: nil
+      t.datetime "stackhousia", precision: nil
+      t.datetime "hymenials", precision: nil
+      t.datetime "randomlies", precision: nil
+      t.bigint "antimephitics", null: false
+      t.bigint "shargars", null: false
+    end
+
+    create_table "schmaltzs", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "uninterdicteds", null: false
+      t.string "tames", null: false
+      t.string "cronies", null: false
+      t.datetime "batussis", precision: nil
+      t.datetime "cassinettes", precision: nil, null: false
+      t.datetime "mutualnesses", precision: nil, null: false
+      t.string "allothigenics", limit: 36
+    end
+
+    create_table "hespers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "unwontednesses", limit: 36
+      t.string "labyrinthibranches"
+      t.float "cranioclasties"
+      t.decimal "librettists", precision: 10, scale: 2
+      t.bigint "excisemanships"
+      t.datetime "perthiotophyres", precision: nil
+      t.datetime "poduras", precision: nil
+    end
+
+    create_table "panomphics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "philocubists"
+      t.text "agitprops"
+      t.bigint "paleanthropics"
+      t.datetime "bistriazoles", precision: nil
+      t.datetime "brinishnesses", precision: nil
+    end
+
+    create_table "overspreads", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "sialadenoncus", limit: 36, null: false
+      t.string "episiostenoses", null: false
+      t.string "demosthenics", null: false
+      t.boolean "triskelions", default: false, null: false
+      t.string "shacklebones", limit: 512, null: false
+      t.datetime "equisetaceaes", precision: nil
+      t.datetime "newings", precision: nil
+    end
+
+    create_table "conocephalums", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.text "rhynchopinaes", null: false
+      t.text "impartites", null: false
+      t.string "pedeses", null: false
+      t.string "monodromies", null: false
+      t.integer "awanes", null: false
+      t.datetime "perithyroiditis", precision: nil
+      t.datetime "excruciatings", precision: nil
+      t.string "omphalorrhagia", null: false
+    end
+
+    create_table "nonsensitizeds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "monosulphonics", null: false
+      t.string "schizaeas"
+      t.string "mituas"
+      t.bigint "tankas"
+      t.datetime "verdurousnesses", precision: nil
+      t.datetime "anacoenoses", precision: nil
+    end
+
+    create_table "reyouths", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "rabins", null: false
+      t.string "rationalisticisms", null: false
+      t.bigint "liplesses"
+      t.datetime "nonoccurrences", precision: nil
+      t.datetime "caesareans", precision: nil
+      t.boolean "moskeneers", default: false, null: false
+      t.string "marxists"
+      t.string "protectings"
+      t.integer "chamkannis"
+      t.datetime "ericoids", precision: nil
+    end
+
+    create_table "phenologicallies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "exemplificatives", null: false
+      t.bigint "japanophobia", null: false
+      t.string "mytiloids", limit: 40, null: false
+      t.string "ridges", limit: 36, null: false
+      t.datetime "unapprehendables", precision: nil
+      t.datetime "cruciallies", precision: nil
+    end
+
+    create_table "pioneerdoms", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "mandilions", limit: 36, null: false
+      t.datetime "aglossals", precision: nil
+      t.datetime "auscultates", precision: nil
+      t.string "gunnerships", limit: 40, null: false
+      t.boolean "innominables", default: false, null: false
+    end
+
+    create_table "biophysics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "miranas"
+      t.bigint "coojas"
+      t.integer "hypoeutectics"
+      t.date "gratulatories"
+      t.string "beslows"
+      t.integer "pria"
+      t.bigint "unconsideratenesses", default: 0, null: false
+      t.string "mizmazes", default: "USD", null: false
+      t.string "overhonestlies"
+      t.datetime "inaptitudes", precision: nil
+      t.datetime "fringillines", precision: nil
+      t.string "tracelesses"
+    end
+
+    create_table "elastometers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "graveships"
+      t.bigint "exscutellates"
+      t.datetime "pinnitentaculates", precision: nil, null: false
+      t.datetime "imponderablenesses", precision: nil, null: false
+    end
+
+    create_table "miscuts", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.date "whensos"
+      t.datetime "thalamotegmentals", precision: nil, null: false
+      t.datetime "glistens", precision: nil, null: false
+      t.string "tabefactions"
+      t.text "pneoscopes", size: :medium
+      t.string "bostrychoids"
+    end
+
+    create_table "hectorlies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "ladyloves", null: false
+      t.string "goatees", null: false
+      t.string "pupillesses"
+      t.string "gutterspouts"
+      t.integer "hairworms"
+      t.datetime "tunickeds", precision: nil
+      t.datetime "semipedals", precision: nil
+      t.datetime "orthogonalities", precision: nil
+      t.integer "dithionics", default: 0, null: false
+      t.datetime "propellents", precision: nil
+      t.datetime "roentgenographicallies", precision: nil
+    end
+
+    create_table "aminodiphenyls", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "postexistencies", null: false
+      t.bigint "glioses", null: false
+      t.datetime "cognizablies", precision: nil
+      t.datetime "subcontraries", precision: nil
+      t.string "biordinals"
+      t.string "unpoetizes"
+      t.string "accessivelies"
+    end
+
+    create_table "breadearnings", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "graminaceous", null: false
+      t.bigint "chlorophoras", null: false
+      t.datetime "tradings", precision: nil
+      t.datetime "anisostichus", precision: nil
+    end
+
+    create_table "blankishes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "orthotropisms", null: false
+      t.datetime "vasoconstrictions", precision: nil
+      t.datetime "pedomotives", precision: nil
+      t.boolean "nonfarms", null: false
+      t.string "granulators", null: false
+      t.string "skirps"
+      t.boolean "anthranyls", null: false
+      t.datetime "tympanicities", precision: nil
+      t.datetime "preterdeterminedlies", precision: nil
+      t.datetime "underpressers", precision: nil, null: false
+      t.boolean "auriculas"
+    end
+
+    create_table "overglooms", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.decimal "unvoluntarinesses", precision: 16, scale: 2, null: false
+      t.decimal "tetracolons", precision: 16, scale: 2, null: false
+      t.decimal "parasternums", precision: 16, scale: 2, null: false
+      t.string "neuromastics", null: false
+      t.bigint "chalcophanites", null: false
+      t.datetime "mutabilia", precision: nil
+      t.datetime "scoparius", precision: nil
+    end
+
+    create_table "unreproachings", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.integer "quernals", null: false
+      t.string "grinderies", null: false
+      t.string "gymnastics"
+      t.string "mudstones"
+      t.integer "graphomaniacs"
+      t.datetime "frolickies", precision: nil
+      t.integer "tarocs", default: 0, null: false
+      t.datetime "pulmobranchia", precision: nil, null: false
+      t.datetime "heptaspermous", precision: nil, null: false
+      t.datetime "incrests", precision: nil
+      t.datetime "soleidaes", precision: nil
+    end
+
+    create_table "unpiteous", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "notalgics", null: false
+      t.bigint "geburs", null: false
+      t.string "cotoniers"
+      t.datetime "urachus", precision: nil, null: false
+      t.datetime "pyrgologists", precision: nil, null: false
+      t.string "woodpennies"
+      t.string "profligations"
+      t.datetime "solomonitics", precision: nil
+      t.datetime "inexhaustiblies", precision: nil
+      t.integer "logria"
+    end
+
+    create_table "expirates", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "psychopompos", null: false
+      t.datetime "spectrous", precision: nil, null: false
+      t.integer "psychicisms", null: false
+      t.integer "necessitous", limit: 1, null: false
+      t.string "milleds", null: false
+      t.boolean "pigheads"
+      t.boolean "filipunctures"
+      t.boolean "unconcreteds"
+      t.datetime "annihilatories", precision: nil, null: false
+      t.datetime "polychromics", precision: nil, null: false
+      t.boolean "carpospores"
+    end
+
+    create_table "forecloses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "apocinchonines", limit: 36, null: false
+      t.bigint "speedies", null: false
+      t.string "astroscopies", null: false
+      t.datetime "abazes", precision: nil, null: false
+      t.text "intruders"
+      t.bigint "undergroves"
+      t.decimal "disgulves", precision: 10
+      t.datetime "steighs", precision: nil
+      t.datetime "microconjugants", precision: nil
+      t.datetime "eudemonia", precision: nil
+      t.text "overprovides"
+      t.bigint "nickeltypes"
+    end
+
+    create_table "columbaries", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "unoriginations", limit: 36, null: false
+      t.bigint "superurgents", null: false
+      t.bigint "dorters", null: false
+      t.string "paranitrosophenols", null: false
+      t.datetime "coracines", precision: nil, null: false
+      t.datetime "brownistics", precision: nil, null: false
+      t.string "versemongerings", limit: 36, null: false
+    end
+
+    create_table "interhemals", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "gatherings", null: false
+      t.string "scavengeries", limit: 36, null: false
+      t.date "twelvefolds", null: false
+      t.date "meles"
+      t.datetime "poppers", precision: nil, null: false
+      t.datetime "befoolments", precision: nil, null: false
+      t.string "pseudolamellibranchiates"
+      t.string "sphecinas"
+      t.string "proproctors"
+      t.string "atmospherefuls"
+      t.bigint "creaghs"
+    end
+
+    create_table "hilarities", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "undergoers", null: false
+      t.string "gazellas", limit: 36, null: false
+      t.string "superethmoidals", null: false
+      t.date "dermosclerites", null: false
+      t.date "reappeals"
+      t.datetime "intercrosses", precision: nil
+      t.datetime "tromometries", precision: nil
+    end
+
+    create_table "salvagings", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "carrotinesses", null: false
+      t.string "taverts", limit: 36, null: false
+      t.bigint "platterfaces", null: false
+      t.datetime "disilanes", precision: nil, null: false
+      t.datetime "zeds", precision: nil, null: false
+    end
+
+    create_table "meteorograms", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "horripilants", limit: 36, null: false
+      t.string "allochetites"
+      t.string "interacademics"
+      t.string "aphodians"
+      t.string "shapelesses"
+      t.datetime "apteryxes", precision: nil, null: false
+      t.datetime "previctorious", precision: nil, null: false
+      t.string "schindyleses", limit: 36, null: false
+      t.datetime "rodsmen", precision: nil
+      t.datetime "clunisians", precision: nil
+      t.string "schoolgirlies"
+      t.bigint "timoreses", null: false
+      t.bigint "analogics", null: false
+      t.date "houndfishes"
+    end
+
+    create_table "anachromases", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "methodicallies", limit: 36, null: false
+      t.integer "homopolarities", default: 0, null: false
+      t.string "earlesses", null: false
+      t.integer "nettlers", null: false
+      t.datetime "unhomishes", precision: nil
+      t.datetime "uninfluentialities", precision: nil
+      t.string "omnirevealings"
+    end
+
+    create_table "snoodeds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.datetime "waldheimia", precision: nil, null: false
+      t.datetime "synodals", precision: nil, null: false
+      t.string "ornamentists", limit: 36, null: false
+      t.string "dudleyites", limit: 36, null: false
+      t.string "propositionallies", null: false
+      t.datetime "brunswicks", precision: nil, null: false
+      t.bigint "chorions", null: false
+    end
+
+    create_table "beleafs", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.datetime "microcaltrops", precision: nil
+      t.datetime "carabeens", precision: nil
+      t.string "oppilates", limit: 36, null: false
+      t.string "diborates", null: false
+    end
+
+    create_table "foggishes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "discourteousnesses", limit: 36, null: false
+      t.string "spikers", limit: 36, null: false
+      t.bigint "enrichers", null: false
+      t.datetime "aeromechanics", precision: nil
+      t.datetime "pantaletteds", precision: nil
+    end
+
+    create_table "strengthlesslies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.datetime "puinavians", precision: nil
+      t.datetime "introductories", precision: nil
+      t.string "untantalizings", limit: 36, null: false
+      t.string "turnstiles", limit: 36, null: false
+      t.string "woolsowers", limit: 36, null: false
+      t.string "papooses", null: false
+      t.datetime "mycohaemia", precision: nil
+    end
+
+    create_table "translatresses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "gratia", limit: 36, null: false
+      t.bigint "anteorbitals", null: false
+      t.decimal "intensivelies", precision: 16, scale: 15
+      t.decimal "phanerozonia", precision: 16, scale: 15
+      t.string "leiophyllums"
+      t.text "tokenlesses"
+      t.datetime "orthognathics", precision: nil, null: false
+      t.datetime "ebrious", precision: nil, null: false
+    end
+
+    create_table "direfulnesses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "semiarchitecturals", null: false
+      t.float "cardioviscerals", null: false
+      t.float "exhortators", null: false
+      t.date "tummers", null: false
+      t.bigint "ventriloquals", null: false
+      t.datetime "lictors", precision: nil, null: false
+      t.datetime "daneworts", precision: nil, null: false
+      t.float "variolitics"
+    end
+
+    create_table "aplanobacters", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "subquinquefids", null: false
+      t.date "parises", null: false
+      t.text "spasmotins"
+      t.string "enhypostatics", null: false
+      t.datetime "forehalves", precision: nil, null: false
+      t.datetime "furciforms", precision: nil, null: false
+      t.string "eclosions", null: false
+      t.decimal "perfumelesses", precision: 16, scale: 2, null: false
+      t.string "percipiences", limit: 36, null: false
+    end
+
+    create_table "serfishlies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "statehoods"
+      t.date "corporatures"
+      t.date "ventilators"
+      t.date "bisbeeites"
+      t.text "seraus"
+      t.datetime "peacockisms", precision: nil
+      t.datetime "subcenters", precision: nil
+    end
+
+    create_table "leucophanites", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "hairsplitters", limit: 36, null: false, collation: "ascii_general_ci"
+      t.string "chocklers", limit: 36, null: false, collation: "ascii_general_ci"
+      t.bigint "inficetes", null: false
+      t.bigint "ringtails", null: false
+      t.datetime "wagonmakings", precision: nil
+      t.datetime "isoserines", precision: nil
+      t.text "bouges"
+      t.datetime "siameses", precision: nil
+      t.datetime "proarctics", precision: nil
+      t.datetime "obolus", precision: nil
+    end
+
+    create_table "anerethisia", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "octapodics", limit: 36, null: false
+      t.string "ats", null: false
+      t.bigint "opticons", null: false
+      t.string "sissoos", null: false
+      t.string "photodermatics"
+      t.string "behallows"
+      t.datetime "unaccelerateds", precision: nil
+      t.datetime "sakellaridis", precision: nil
+      t.string "archikaryons"
+      t.bigint "betrunks"
+      t.string "shamianahs"
+      t.bigint "registries"
+      t.string "stultifies"
+    end
+
+    create_table "materializers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "mundanenesses"
+      t.bigint "guardianesses"
+      t.bigint "reflectometries"
+      t.string "rhodinols"
+      t.date "nonsilicateds"
+      t.date "oxalites"
+      t.string "weberians"
+      t.string "autorrhaphies"
+      t.string "cystitis"
+      t.string "ballams"
+      t.datetime "gelds", precision: nil
+      t.datetime "moonshinies", precision: nil
+      t.string "unvalidateds"
+      t.bigint "cardioscopes"
+      t.integer "quadrupedisms", limit: 1
+      t.integer "purports", limit: 1
+    end
+
+    create_table "nitrosomonas", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "uncompacts"
+      t.bigint "canies"
+      t.datetime "dorms", precision: nil
+      t.datetime "rectovesicals", precision: nil
+      t.datetime "noncontributories", precision: nil
+      t.string "jennies"
+      t.datetime "sanes", precision: nil
+      t.string "overgilteds"
+      t.string "bahs"
+      t.bigint "idolatrous"
+      t.integer "ectogeneses", limit: 1
+      t.string "defends"
+      t.date "cors"
+      t.string "intercirculates"
+      t.string "jobades"
+      t.string "deaneries"
+      t.string "unsomes"
+      t.string "vassos"
+      t.string "easefulnesses"
+      t.string "kroushkas"
+      t.string "flauntinesses"
+      t.string "units"
+      t.string "amphitenes"
+    end
+
+    create_table "clayinesses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "suprastapedials"
+      t.string "poppyfishes"
+      t.string "cheilodipteridaes"
+      t.string "bleachyards"
+      t.string "centinormals"
+      t.string "nonserviles"
+      t.string "songlands"
+      t.bigint "precisionists"
+      t.string "vesiculocavernous"
+      t.string "dumoses"
+      t.string "edgars"
+      t.string "bers"
+      t.string "gastronomers"
+      t.datetime "postalveolars", precision: nil
+      t.datetime "misreprints", precision: nil
+      t.bigint "supersupremes"
+    end
+
+    create_table "bearablenesses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "posthemorrhagics", null: false
+      t.bigint "babbies", null: false
+      t.string "zoospores", null: false
+    end
+
+    create_table "thickens", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "matchmakers", limit: 36, null: false
+      t.bigint "pectinatodenticulates", null: false
+      t.string "fingerers", null: false
+      t.datetime "unbolds", precision: nil, null: false
+      t.datetime "antecommunions", precision: nil, null: false
+      t.boolean "arthrobranchia", default: false, null: false
+      t.boolean "afterthoughts", default: false, null: false
+    end
+
+    create_table "foddas", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "blahs", limit: 36, null: false
+      t.bigint "dihydroxytoluenes", null: false
+      t.string "ethnocracies", null: false
+      t.date "thesmothetes", null: false
+      t.date "inoperatives"
+      t.datetime "exteroceptists", precision: nil, null: false
+      t.datetime "unvulcanizeds", precision: nil, null: false
+      t.date "wethers"
+    end
+
+    create_table "disenthrallments", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "tashies", limit: 36, null: false
+      t.bigint "hameils", null: false
+      t.datetime "daredeviltries", precision: nil
+      t.datetime "dolefuls", precision: nil
+    end
+
+    create_table "neurocentrums", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.datetime "unmetricalnesses", precision: nil, null: false
+      t.datetime "antiantienzymes", precision: nil, null: false
+      t.bigint "spireds", null: false
+      t.string "exhaustibles", limit: 36, null: false
+    end
+
+    create_table "outbrays", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "incredulouslies", limit: 36, null: false
+      t.string "winebibberies"
+      t.string "itselves"
+      t.bigint "weaponeers"
+      t.datetime "contiguouslies", precision: nil, null: false
+      t.datetime "nephrotyphoids", precision: nil, null: false
+    end
+
+    create_table "resolidifications", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "leptonecroses"
+      t.string "misperforms"
+      t.string "phallicals"
+      t.string "interbrings"
+      t.datetime "rabids", precision: nil, null: false
+      t.datetime "lanternists", precision: nil, null: false
+      t.date "argentometries"
+      t.string "conoplains"
+      t.decimal "aversants", precision: 16, scale: 2, default: "0.0"
+      t.decimal "collectivelies", precision: 16, scale: 2, default: "0.0"
+      t.string "tonsilloliths"
+      t.string "rosines"
+      t.string "zoileans"
+      t.bigint "stanchnesses"
+      t.string "unmixables"
+    end
+
+    create_table "aspartates", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "amelia"
+      t.string "mycodermas"
+      t.decimal "gymkhanas", precision: 16, scale: 2, null: false
+      t.string "catechists"
+      t.string "lymphangiitis"
+      t.datetime "uncurdlings", precision: nil, null: false
+      t.datetime "timelesslies", precision: nil, null: false
+      t.bigint "stopperlesses"
+      t.bigint "instinctivists"
+      t.boolean "prolactins", default: false
+      t.bigint "cereals"
+      t.boolean "repulses"
+      t.string "centuriators", null: false
+      t.boolean "echinostomatidaes"
+      t.string "anthraciferous"
+      t.string "antilapsarians"
+      t.bigint "feezes"
+      t.bigint "slivers"
+      t.bigint "mohas"
+      t.boolean "tineines", default: false
+      t.boolean "cloudwards", default: false, null: false
+      t.bigint "balistraria"
+      t.string "implores", null: false
+      t.bigint "resedas"
+      t.datetime "brachiopodes", precision: nil
+      t.boolean "ryots"
+      t.bigint "lisles"
+      t.bigint "oceanologies"
+      t.string "contralaterals"
+      t.string "cowroids"
+      t.string "distancelesses"
+      t.integer "wichtisites", limit: 1, default: 2
+      t.bigint "forestishes"
+      t.date "inuloids", null: false
+      t.string "cornbins", null: false
+      t.string "rhodophylls", limit: 36, null: false
+      t.date "incomparabilities", null: false
+      t.string "biceps"
+    end
+
+    create_table "guesthouses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "forficiforms"
+      t.string "workways", default: "", null: false
+      t.datetime "bicondylars", precision: nil
+      t.datetime "blindfasts", precision: nil
+      t.string "unstringings"
+    end
+
+    create_table "sivvens", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "vulturelikes", limit: 36, null: false
+      t.decimal "osteopathicallies", precision: 16, scale: 2
+      t.decimal "vateria", precision: 16, scale: 2
+      t.decimal "treeifies", precision: 16, scale: 2
+      t.decimal "habaneras", precision: 16, scale: 2
+      t.decimal "incogitantlies", precision: 16, scale: 2
+      t.bigint "subtenancies"
+      t.text "coltpixies"
+      t.text "centrifugations"
+      t.boolean "predicted_nsf_v1"
+      t.bigint "firmisternous"
+      t.bigint "trematodes"
+      t.string "somers"
+      t.date "exportations", null: false
+      t.datetime "hemichoreas", precision: nil
+      t.datetime "offhandednesses", precision: nil
+      t.string "dioecisms"
+      t.boolean "predicted_nsf_v2"
+      t.boolean "predicted_nsf_v3"
+      t.boolean "predicted_nsf_v4"
+      t.boolean "predicted_nsf_v5"
+    end
+
+    create_table "theophorics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "gasmakers", null: false
+      t.string "loxotomies"
+      t.string "fiendishlies"
+      t.string "chorioretinitis"
+      t.date "transoceans"
+      t.datetime "rills", precision: nil, null: false
+      t.datetime "remembrances", precision: nil, null: false
+    end
+
+    create_table "overpopularities", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "pyrgocephalics", limit: 36, null: false
+      t.bigint "precannings", null: false
+      t.datetime "hulsites", precision: nil, null: false
+      t.datetime "carpogams", precision: nil, null: false
+      t.bigint "ovatooblongs"
+      t.string "marcia", default: "Unknown", null: false
+    end
+
+    create_table "alterations", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "retaliationists", limit: 36, null: false
+      t.bigint "honzos", null: false
+      t.bigint "skews", null: false
+      t.datetime "inklikes", precision: nil
+      t.datetime "diaplexals", precision: nil
+    end
+
+    create_table "institutrixes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "germanics"
+      t.bigint "thapsia"
+      t.string "nonrejoinders"
+      t.date "determents"
+      t.string "flabellums"
+      t.string "psychotherapeutists"
+      t.string "warsels"
+      t.string "unraftereds"
+      t.string "recensions"
+      t.integer "buttockers"
+      t.decimal "synergists", precision: 16, scale: 2
+      t.string "opilionines"
+      t.datetime "cleistothecia", precision: nil
+      t.bigint "unhurtfuls"
+      t.boolean "vasofactives", default: false
+      t.datetime "koromikas", precision: nil
+      t.datetime "reamies", precision: nil
+      t.string "sheldfowls"
+      t.string "inconsequentlies"
+      t.integer "vellosines", limit: 1, default: 0, null: false
+      t.bigint "parallelepipedons"
+      t.integer "conspues", limit: 1, default: 2
+      t.bigint "nubbies"
+      t.bigint "neurodiagnoses"
+      t.string "restricts"
+    end
+
+    create_table "debunkers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.date "hydrodynamicals"
+      t.string "syracusans"
+      t.datetime "subanniversaries", precision: nil, null: false
+      t.datetime "paeonia", precision: nil, null: false
+      t.decimal "chiragras", precision: 16, scale: 2
+      t.decimal "caffetannins", precision: 16, scale: 2
+      t.integer "noncoagulables"
+      t.datetime "kishons", precision: nil
+      t.date "pinics"
+      t.string "voltaplasts"
+      t.string "hefties"
+      t.datetime "beeheadeds", precision: nil
+      t.bigint "bridgeboards"
+      t.string "droiturals"
+      t.boolean "nonpresences"
+      t.bigint "unsingleds", null: false
+      t.string "dissimilations"
+      t.date "demimen", null: false
+    end
+
+    create_table "zemimdaris", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "wonderers", null: false
+      t.date "unfanaticals", null: false
+      t.datetime "forewisdoms", precision: nil
+      t.datetime "lightfaces", precision: nil
+      t.integer "otocranes", limit: 1
+      t.bigint "translucentlies"
+      t.decimal "arrenotokies", precision: 16, scale: 2, default: "0.0"
+      t.decimal "welshries", precision: 16, scale: 2, default: "0.0"
+      t.date "pipers"
+    end
+
+    create_table "jedcocks", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "hydrophilous", limit: 36, null: false, collation: "ascii_general_ci"
+      t.string "epicerebrals", limit: 36, null: false, collation: "ascii_general_ci"
+      t.string "spherulates", null: false
+      t.integer "hypostases", null: false
+      t.datetime "zequins", precision: nil, null: false
+      t.datetime "grittinesses", precision: nil, null: false
+    end
+
+    create_table "urinometrics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "erythrocytics", limit: 36, null: false, collation: "ascii_general_ci"
+      t.string "fluxiles", limit: 36, null: false, collation: "ascii_general_ci"
+      t.boolean "debauchments", default: false, null: false
+      t.text "fitchees", null: false
+      t.text "unwitnesseds", null: false
+      t.string "mazamas", null: false
+      t.datetime "pughs", precision: nil, null: false
+      t.datetime "premonitories", precision: nil, null: false
+    end
+
+    create_table "vocationalisms", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "craniodidymus", limit: 36, null: false, collation: "ascii_general_ci"
+      t.string "taproots", limit: 36, null: false, collation: "ascii_general_ci"
+      t.string "lariats", limit: 36
+      t.text "degreasers"
+      t.text "pterygotus"
+      t.datetime "gratinates", precision: nil, null: false
+      t.datetime "feliforms", precision: nil, null: false
+      t.string "stonewalls", limit: 36, null: false, collation: "ascii_general_ci"
+    end
+
+    create_table "tetanus", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "tessellas", limit: 36, null: false, collation: "ascii_general_ci"
+      t.string "unweapons", limit: 36, null: false, collation: "ascii_general_ci"
+      t.string "ungnostics", null: false
+      t.string "attalehs", null: false
+      t.text "spicates"
+      t.datetime "quinquedentateds", precision: nil, null: false
+      t.datetime "aldanes", precision: nil, null: false
+      t.datetime "galactometries", precision: nil
+      t.datetime "breds", precision: nil, null: false
+      t.datetime "crepes", precision: nil
+      t.integer "declericalizes"
+      t.string "predominations", limit: 36, collation: "ascii_general_ci"
+    end
+
+    create_table "sluicers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "sarcophagis"
+      t.string "unassociativenesses", limit: 36, null: false, collation: "ascii_general_ci"
+      t.string "dunches", limit: 36, null: false, collation: "ascii_general_ci"
+      t.string "freesilverites", limit: 36
+      t.datetime "sparses", precision: nil, null: false
+      t.datetime "aponogetonaceaes", precision: nil, null: false
+      t.boolean "enribs", default: false, null: false
+    end
+
+    create_table "proregents", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "acceleratedlies", limit: 36, null: false
+      t.string "pocos", limit: 36, null: false
+      t.string "fathmurs", limit: 36, null: false
+      t.text "acetylfluorides"
+      t.text "praisablies"
+      t.datetime "forestations", precision: nil, null: false
+      t.datetime "baldlies", precision: nil, null: false
+    end
+
+    create_table "indigos", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "ellens", limit: 36, null: false, collation: "ascii_general_ci"
+      t.string "eucyclics", limit: 36, null: false, collation: "ascii_general_ci"
+      t.string "sodomiticallies", null: false
+      t.datetime "ants", precision: nil, null: false
+      t.datetime "responsorials", precision: nil, null: false
+      t.string "cantingnesses", null: false
+      t.string "phthorics", limit: 36
+      t.datetime "phenoxids", precision: nil
+      t.datetime "psorophoras", precision: nil
+      t.boolean "integropallials", default: false, null: false
+    end
+
+    create_table "subdividinglies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "chantries", limit: 36, null: false, collation: "ascii_general_ci"
+      t.string "vesuviates", limit: 36, null: false, collation: "ascii_general_ci"
+      t.string "triarcuateds", limit: 36, collation: "ascii_general_ci"
+      t.string "sophicals", null: false
+      t.string "thinkablies"
+      t.string "cocurators", null: false
+      t.datetime "cynomorphas", precision: nil
+      t.datetime "tauromorphous", precision: nil, null: false
+      t.datetime "convenientlies", precision: nil, null: false
+      t.string "activelies", limit: 36, null: false
+      t.string "suspensors", limit: 36
+      t.string "harebrainednesses", limit: 36
+      t.boolean "immurements", default: false, null: false
+      t.string "nostocaceaes", limit: 36, collation: "ascii_general_ci"
+    end
+
+    create_table "sparelesses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "vilelas", null: false
+      t.bigint "homosexualisms", null: false
+      t.datetime "flicks", precision: nil
+      t.datetime "iliofemorals", precision: nil
+      t.string "sheveleds"
+    end
+
+    create_table "pinies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "akania", null: false
+      t.bigint "priapuloids", null: false
+      t.string "strones", null: false
+      t.bigint "illimitables"
+      t.string "silvereds"
+      t.datetime "nephriticals", precision: nil
+      t.datetime "mewlers", precision: nil
+      t.string "ogees"
+    end
+
+    create_table "liberationisms", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "clonus", null: false
+      t.string "marcescents", null: false
+      t.string "quininisms", null: false
+      t.string "mongrelisms"
+      t.datetime "fidejussors", precision: nil, null: false
+      t.datetime "castellanies", precision: nil, null: false
+      t.string "securiforms", limit: 36, null: false
+    end
+
+    create_table "preacquires", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "nondisparagings", null: false
+      t.string "spites", null: false
+      t.bigint "tiereds", null: false
+      t.datetime "aphrodisians", precision: nil, null: false
+      t.datetime "unsettleables", precision: nil, null: false
+    end
+
+    create_table "buffets", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "interpretaments"
+      t.text "aforethoughts", size: :medium
+      t.boolean "deglaciations", default: true, null: false
+      t.datetime "invendibles", precision: nil, null: false
+      t.datetime "champacas", precision: nil, null: false
+      t.string "craftinesses", default: "", null: false
+      t.datetime "transpositions", precision: nil
+      t.datetime "pseudoanemia", precision: nil
+      t.datetime "porouslies", precision: nil
+      t.string "trihybrids", null: false
+      t.boolean "tiddlywinkings"
+      t.string "consonantnesses", default: "open", null: false
+      t.datetime "irenes", precision: nil
+      t.string "noggens", limit: 36, null: false
+      t.datetime "confoundednesses", precision: nil, null: false
+      t.bigint "strawberrylikes"
+      t.bigint "bruchus"
+      t.bigint "tacits", null: false
+      t.string "postverta", null: false
+      t.string "cloudberries", default: "DASHBOARD", null: false
+    end
+
+    create_table "matutinaries", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "professionlesses", null: false
+      t.integer "neuropteris", null: false
+      t.text "ethanethiols", null: false
+      t.datetime "botcherlies", precision: nil, null: false
+      t.datetime "babylikes", precision: nil
+      t.text "gesneras", null: false
+      t.bigint "analytics", null: false
+      t.bigint "pickedlies", null: false
+      t.string "aleurodes"
+      t.bigint "polydynamics"
+      t.boolean "semivolcanics", default: false, null: false
+      t.boolean "remedials", default: false, null: false
+    end
+
+    create_table "rouseabouts", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "adenoneurals", limit: 64, null: false, collation: "ascii_general_ci"
+      t.string "quintons", limit: 64, collation: "ascii_general_ci"
+      t.integer "rhynchocoelous", limit: 3, default: 7200, null: false, unsigned: true
+      t.datetime "slabs", precision: nil
+      t.datetime "macanas", precision: nil, null: false
+      t.text "pendulations", null: false
+      t.bigint "predisrupts", null: false
+      t.bigint "acuminates", null: false
+      t.string "hesitantlies", limit: 64, collation: "ascii_general_ci"
+      t.bigint "fiddlesticks"
+      t.string "staps"
+      t.bigint "disaccustomeds"
+      t.boolean "perimetricallies", default: false, null: false
+      t.boolean "titanotheria", default: false, null: false
+    end
+
+    create_table "streptococcis", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "advenes", limit: 36, null: false
+      t.bigint "hematimeters", null: false
+      t.bigint "roderics", null: false
+      t.datetime "disestablishmentarians", precision: nil
+      t.datetime "choristers", precision: nil
+    end
+
+    create_table "platoids", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "neptunia", limit: 50, null: false
+      t.string "nimbifications", limit: 128, null: false, collation: "ascii_general_ci"
+      t.string "gambas", limit: 128, null: false, collation: "ascii_general_ci"
+      t.text "woodpecks", null: false
+      t.datetime "unheaveds", precision: nil, null: false
+      t.datetime "mixodectes", precision: nil, null: false
+      t.text "bambaras", null: false
+      t.string "paraphrenitis", limit: 10, default: "Partner", null: false
+      t.bigint "represides", null: false
+      t.text "greenwiches", null: false
+      t.boolean "hyoidans", default: true, null: false
+      t.boolean "platyhelminths", default: true, null: false
+      t.datetime "acylations", precision: nil
+      t.boolean "microdactylia", default: true
+      t.boolean "exploits", default: false, null: false
+      t.string "nonchemicals", default: "log", null: false
+      t.integer "porthouses", default: 200
+      t.integer "natrixes", default: 60
+      t.boolean "rectoscopies", default: false, null: false
+      t.string "cynanthropies"
+    end
+
+    create_table "subhyaloids", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "immotioneds", limit: 36, null: false
+      t.string "unrestfulnesses", null: false
+      t.string "mismakes"
+      t.integer "longilinguals", null: false
+      t.datetime "uncompliances", precision: nil
+      t.string "protococcoids", default: "", null: false
+      t.datetime "disobeys", precision: nil
+      t.datetime "exhausteds", precision: nil
+      t.bigint "multisulcates"
+      t.bigint "hypinoses", null: false
+      t.bigint "schmelzes"
+      t.bigint "mayances"
+    end
+
+    create_table "betternesses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "hyracotheres"
+      t.string "oxyrrhynchids"
+      t.bigint "germies", null: false
+      t.bigint "hatchmen", null: false
+      t.string "hydrazos", null: false
+    end
+
+    create_table "weepereds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "diaetetaes", limit: 36, null: false
+      t.bigint "schoolmasterishnesses", null: false
+      t.string "psychotechnicals", null: false
+      t.datetime "schizophrenes", precision: nil
+      t.datetime "drynaria", precision: nil
+    end
+
+    create_table "achromatizables", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "triangulums"
+      t.string "appendicials"
+      t.string "liturgizes"
+      t.text "irreformables"
+      t.string "kittiwakes"
+      t.string "smooches"
+      t.string "prerestrictions"
+      t.string "peregrinoids"
+      t.string "domdaniels"
+      t.integer "veraciousnesses"
+      t.datetime "pinchpennies", precision: nil
+      t.datetime "necklikes", precision: nil
+      t.datetime "axilemmata", precision: nil
+      t.string "downlinks", limit: 36
+    end
+
+    create_table "harriers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "sailboats"
+      t.string "expositoriallies"
+      t.date "oocyeses"
+      t.text "imperforations"
+      t.datetime "baggilies", precision: nil
+      t.datetime "kaffirs", precision: nil
+      t.string "otitis"
+      t.datetime "sparenesses", precision: nil
+      t.string "petrostearins"
+      t.date "superregals"
+      t.bigint "thaumatropicals"
+      t.string "overstrungs"
+      t.string "uletics"
+      t.string "semibarbarous"
+      t.string "denotativelies"
+      t.string "actiniochromes"
+      t.boolean "i9_document"
+      t.string "gitksans", limit: 2048, default: "[]"
+      t.string "algorists", limit: 40
+      t.bigint "tearables"
+      t.datetime "ectoskeletons", precision: nil
+      t.string "carbonifies"
+      t.text "lampatia"
+      t.bigint "overagenesses", null: false
+      t.decimal "tacheometrics", precision: 16, scale: 2
+      t.text "sweepstakes"
+      t.bigint "adenines"
+      t.string "autohexaploids", limit: 36
+      t.bigint "irenics"
+    end
+
+    create_table "gulliblies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "pams"
+      t.string "permeances"
+      t.string "trigonodonts"
+      t.string "frisiis"
+      t.string "unmaniables"
+      t.string "previous_business_street_1"
+      t.string "previous_business_street_2"
+      t.string "sapworts"
+      t.string "fibbers"
+      t.string "cutleria"
+      t.string "merriments"
+      t.string "underwheels"
+      t.string "cordilleras"
+      t.datetime "shelterers", precision: nil, null: false
+      t.datetime "shickereds", precision: nil, null: false
+    end
+
+    create_table "linotypists", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "transcendentalisms", null: false
+      t.string "stalactics", null: false
+      t.datetime "propiolates", precision: nil, null: false
+      t.datetime "focusers", precision: nil
+      t.datetime "tetragenous", precision: nil
+    end
+
+    create_table "sices", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "conflictings", null: false
+      t.string "goniatitids"
+      t.string "doglikes", null: false
+      t.bigint "tarumas", null: false
+      t.datetime "invarieds", precision: nil, null: false
+    end
+
+    create_table "madarotics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "imperceptibles", limit: 36, null: false
+      t.bigint "happenings", null: false
+      t.bigint "sternebras", null: false
+      t.datetime "rebeccaisms", precision: nil, null: false
+      t.datetime "vulpicidals", precision: nil, null: false
+      t.date "peaklesses", null: false
+      t.string "ectosteallies", limit: 20, null: false
+    end
+
+    create_table "phyllodials", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "peptonates", null: false
+      t.boolean "loins", null: false
+      t.datetime "unstiffeneds", precision: nil
+      t.datetime "vasodilatings", precision: nil
+    end
+
+    create_table "curies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "wenchoweses", null: false
+      t.string "photoelasticities", null: false
+      t.datetime "weathereds", precision: nil, null: false
+      t.datetime "misappearances", precision: nil, null: false
+    end
+
+    create_table "apyrotypes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "aviatresses", null: false
+      t.bigint "anthraconites", null: false
+      t.string "smilets", null: false
+      t.bigint "nonexternalities", null: false
+      t.datetime "gams", precision: nil, null: false
+      t.datetime "interfoliars", precision: nil, null: false
+    end
+
+    create_table "porcelainlikes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "platytropes", limit: 36, null: false
+      t.bigint "clydesiders", null: false
+      t.text "integropalliata"
+      t.datetime "rootlikes", precision: nil
+      t.string "plurivalves", null: false
+      t.text "unappealablenesses"
+      t.datetime "aureities", precision: nil
+      t.datetime "mercurochromes", precision: nil
+      t.integer "thyrocricoids", default: 0, null: false
+    end
+
+    create_table "errables", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "coniogrammes"
+      t.decimal "salubrifies", precision: 16, scale: 15
+      t.datetime "stallments", precision: nil
+      t.datetime "tylostylotes", precision: nil
+      t.decimal "spermines", precision: 16, scale: 15
+    end
+
+    create_table "postparotitics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "awheels", null: false
+      t.string "mortgagees", null: false
+      t.datetime "herniorrhaphies", precision: nil
+      t.datetime "brushbushes", precision: nil
+    end
+
+    create_table "stereums", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.boolean "cattalos"
+      t.datetime "peorians", precision: nil
+      t.datetime "gradates", precision: nil, null: false
+      t.datetime "bombardons", precision: nil, null: false
+      t.boolean "gynandromorphous", default: false
+      t.boolean "anticonscriptions"
+      t.text "wolvers"
+      t.boolean "stomatodaeums"
+    end
+
+    create_table "selfheals", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.text "tasteds"
+      t.datetime "twanks", precision: nil
+      t.datetime "indeclinables", precision: nil, null: false
+      t.datetime "profilists", precision: nil, null: false
+    end
+
+    create_table "pseudochronologists", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.integer "auscultoscopes", limit: 2
+      t.integer "degradednesses", limit: 1
+      t.integer "mawkishnesses", limit: 1
+      t.integer "electrocauteries", limit: 1
+      t.datetime "impermeablenesses", precision: nil
+      t.datetime "summerings", precision: nil, null: false
+      t.datetime "teinders", precision: nil, null: false
+    end
+
+    create_table "piciforms", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "precomprehends"
+      t.string "counteractors"
+      t.string "maholtines"
+      t.integer "multisects", default: 0, null: false
+      t.bigint "scalopus"
+      t.datetime "paranatellons", precision: nil
+      t.datetime "overwhispers", precision: nil
+      t.integer "portabilities"
+      t.string "paroptics"
+      t.integer "undershires"
+      t.datetime "transvestites", precision: nil
+      t.string "atrorubents"
+      t.integer "poroses", default: 0, null: false
+      t.date "ministerials"
+      t.string "telokineses", limit: 36, null: false
+      t.string "fraternisms", limit: 36, null: false
+    end
+
+    create_table "cyanoacetates", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "yankeeizes", null: false
+      t.bigint "wennies", null: false
+      t.text "beadrolls", null: false
+      t.datetime "hematotherapies", precision: nil
+      t.datetime "crinicultures", precision: nil
+    end
+
+    create_table "wheellesses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "lemures", null: false
+      t.string "onocentaurs", null: false
+      t.string "hypophyllous", null: false
+      t.string "unprogresseds", null: false
+      t.string "podolians", null: false
+      t.datetime "themata", precision: nil
+      t.datetime "geognosts", precision: nil
+      t.boolean "lucidas", default: false
+    end
+
+    create_table "quartzites", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "autocorrosions", null: false
+      t.string "jacobinicallies", null: false
+      t.string "address_line_1", null: false
+      t.string "address_line_2"
+      t.string "address_line_3"
+      t.string "painfullies", null: false
+      t.string "huashis", null: false
+      t.string "cashels", null: false
+      t.string "rufescents", null: false
+      t.string "hemoscopes", null: false
+      t.string "terrestrialnesses", null: false
+      t.string "redisseises", null: false
+      t.datetime "gruns", precision: nil
+      t.datetime "irradicates", precision: nil
+    end
+
+    create_table "squashes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "hysteropexies"
+      t.string "digressionaries", null: false
+      t.string "juries", null: false
+      t.string "ignores", null: false
+      t.datetime "epistolographics", precision: nil
+      t.datetime "tootlers", precision: nil
+    end
+
+    create_table "ventromesials", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "fallacious"
+      t.string "tormentors"
+      t.text "sapheadednesses"
+      t.bigint "scarlatinals", null: false
+      t.bigint "snifflies"
+      t.string "ovals"
+      t.datetime "alisphenoidals", precision: nil, null: false
+      t.datetime "dynamitics", precision: nil, null: false
+      t.string "moralities"
+    end
+
+    create_table "pogoniates", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "cryptogenetics", null: false
+      t.integer "filters", limit: 2, null: false
+      t.bigint "sensualizes", null: false
+      t.string "phagolytics", null: false
+      t.datetime "undominoeds", precision: nil, null: false
+      t.datetime "immanacles", precision: nil, null: false
+      t.integer "aladinists"
+    end
+
+    create_table "aschams", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "ammonitoids", limit: 36, null: false, collation: "ascii_general_ci"
+      t.string "overembroiders", limit: 36, null: false, collation: "ascii_general_ci"
+      t.decimal "ambiens", precision: 16, scale: 2, null: false
+      t.datetime "triplaris", precision: nil
+      t.datetime "rickettsiales", precision: nil
+      t.string "unfearfullies", limit: 36, null: false, collation: "ascii_general_ci"
+    end
+
+    create_table "terricoles", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "hispidulates", null: false
+      t.string "doxologicals", null: false
+      t.string "archspirits", null: false
+      t.string "anuries", null: false
+      t.datetime "nonignorants", precision: nil
+      t.datetime "sinistroculars", precision: nil
+    end
+
+    create_table "ungloves", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "palmers"
+      t.bigint "pinenes"
+      t.datetime "griddlers", precision: nil, null: false
+      t.datetime "headways", precision: nil, null: false
+    end
+
+    create_table "teleutos", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "waags"
+      t.bigint "garancines"
+      t.string "melodramatics"
+      t.string "sunts"
+      t.string "hydrophobies"
+      t.string "pretentatives"
+      t.string "salpingotomies"
+      t.bigint "demichamfrons"
+      t.datetime "mixeds", precision: nil
+      t.string "firespouts"
+      t.datetime "agogics", precision: nil, null: false
+      t.datetime "conceptisms", precision: nil, null: false
+    end
+
+    create_table "tungstites", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "impactionizes", null: false
+      t.string "preflorations"
+      t.date "prigmen", null: false
+      t.date "allodelphites", null: false
+      t.datetime "teems", precision: nil, null: false
+      t.datetime "intolerations", precision: nil, null: false
+      t.string "myxogastres", default: "", null: false
+      t.string "rudistans"
+    end
+
+    create_table "antimoderns", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "rosses"
+      t.text "doctrinizes"
+      t.string "matelessnesses"
+      t.string "antiaditis"
+      t.bigint "unforesees"
+      t.string "ectheses"
+      t.datetime "philodendrons", precision: nil
+      t.datetime "sulfurans", precision: nil
+    end
+
+    create_table "jantus", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "unscalablies", null: false
+      t.string "bottomlesslies"
+      t.string "inframammillaries"
+      t.datetime "whuthers", precision: nil
+      t.datetime "travelogues", precision: nil
+      t.datetime "cosentiencies", precision: nil
+      t.string "indogenides", limit: 36, null: false
+    end
+
+    create_table "ramusis", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "carnaubas"
+      t.bigint "pseudophilosophicals"
+      t.string "versifiables"
+      t.string "sorgos"
+      t.string "shadberries"
+      t.string "jasminewoods"
+      t.text "legpullings"
+      t.boolean "truthlikenesses"
+      t.boolean "postpubescents"
+      t.string "epicycles"
+      t.string "bdelloids"
+      t.datetime "friendlessnesses", precision: nil, null: false
+      t.datetime "hexeris", precision: nil, null: false
+      t.datetime "substratoses", precision: nil
+      t.string "unartfuls"
+    end
+
+    create_table "heliomicrometers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "tauntings", limit: 36, null: false
+      t.bigint "clockwises", null: false
+      t.datetime "deanships", precision: nil, null: false
+      t.datetime "shrinelikes", precision: nil, null: false
+      t.string "heteropolars", null: false
+      t.string "ambuscades", null: false
+    end
+
+    create_table "underboys", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "ramroddies", null: false
+      t.integer "myeloics", default: 0, null: false
+      t.datetime "threelings", precision: nil
+      t.datetime "graphics", precision: nil
+    end
+
+    create_table "samsiens", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "tidelessnesses", limit: 36, null: false
+      t.bigint "younglies", null: false
+      t.string "syphilomatous"
+      t.string "misidentifications"
+      t.datetime "hollandishes", precision: nil
+      t.integer "plumularia", null: false
+      t.datetime "balancings", precision: nil
+      t.datetime "blindings", precision: nil
+      t.string "uneaths"
+    end
+
+    create_table "ramets", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "haemodilutions", limit: 36, null: false
+      t.bigint "displeasings", null: false
+      t.boolean "damnings", default: false
+      t.datetime "alectoridines", precision: nil, null: false
+      t.datetime "sphaerococcaceous", precision: nil, null: false
+    end
+
+    create_table "horizontalizations", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "digerents", limit: 36, null: false
+      t.string "iridorhexis", null: false
+      t.string "unemployables", limit: 36, null: false
+      t.string "drepaniforms"
+      t.string "hoggies", default: "active", null: false
+      t.datetime "undownies", precision: nil
+      t.datetime "physidaes", precision: nil
+    end
+
+    create_table "hidalgos", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "galeateds", limit: 36, null: false
+      t.string "organophonics", limit: 36, null: false
+      t.datetime "winkinglies", precision: nil, null: false
+      t.datetime "spargania", precision: nil
+      t.bigint "disseminates", null: false
+      t.datetime "cranials", precision: nil, default: "3000-01-01 00:00:00", null: false
+    end
+
+    create_table "embodies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "races", limit: 36, null: false
+      t.string "unsmackeds", limit: 36, null: false
+      t.string "overcondensations", limit: 36, null: false
+      t.datetime "otherwhiles", precision: nil, null: false
+      t.datetime "misinstructions", precision: nil, null: false
+      t.string "spindles", default: "active", null: false
+    end
+
+    create_table "poperies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "avantis", null: false
+      t.string "promorals", null: false
+      t.datetime "spodogenous", precision: nil
+      t.datetime "orthoplumbates", precision: nil
+    end
+
+    create_table "oversettleds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "prestants", limit: 36, null: false
+      t.string "bailieships", limit: 36, null: false
+      t.bigint "tewits", null: false
+      t.string "countertastes", limit: 36, null: false
+      t.datetime "tetraplous", precision: nil
+      t.datetime "acinetinans", precision: nil
+      t.decimal "asuris", precision: 16, scale: 2
+    end
+
+    create_table "resolutenesses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "definablies", null: false
+      t.bigint "acquittances"
+      t.bigint "autostages"
+      t.string "salvadoras", default: "client_billed"
+      t.boolean "shrifts", default: false
+      t.boolean "unparrels", default: false
+      t.bigint "myopathia"
+      t.string "polyangulars", limit: 36, null: false
+      t.datetime "bugans", precision: nil
+      t.datetime "nautilicones", precision: nil
+      t.string "marattiaceaes", default: "Client"
+      t.string "precedentables", default: "None"
+    end
+
+    create_table "chromatograms", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "ooecia", null: false
+      t.bigint "psilanthropies", null: false
+      t.string "superstitions", null: false
+      t.datetime "tocodynamometers", precision: nil
+      t.datetime "coadjutators", precision: nil
+    end
+
+    create_table "bionomists", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "textualists", null: false
+      t.string "toxicodendrols", null: false
+      t.string "territorializations", null: false
+      t.decimal "guiltlesses", precision: 16, scale: 2, null: false
+      t.datetime "bephilters", precision: nil, null: false
+      t.datetime "gallowglasses", precision: nil, null: false
+      t.boolean "blocked_on_w9", default: false
+      t.boolean "fussies", default: false
+      t.string "thuggishes"
+      t.string "subdiaconals", limit: 36, null: false
+    end
+
+    create_table "endmosts", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "interjaculates", null: false
+      t.bigint "hyperdactylia", null: false
+      t.integer "bacillites", null: false
+      t.decimal "unostentatious", precision: 16, scale: 2, null: false
+      t.text "ostiolars", null: false
+      t.datetime "sabaisms", precision: nil, null: false
+      t.datetime "dithions", precision: nil, null: false
+    end
+
+    create_table "polars", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "triclinates", null: false
+      t.string "stonishments"
+      t.decimal "maddings", precision: 16, scale: 2, null: false
+      t.datetime "clubmongers", precision: nil
+      t.string "gleamies"
+      t.string "spiraculiferous"
+      t.string "tendotomes"
+      t.datetime "multiengineds", precision: nil, null: false
+      t.datetime "embracers", precision: nil, null: false
+      t.boolean "knuts"
+      t.decimal "famelesses", precision: 16, scale: 2
+      t.string "contentlies"
+      t.decimal "decrescences", precision: 16, scale: 2
+      t.datetime "antialcoholisms", precision: nil
+    end
+
+    create_table "chouans", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "restwards", null: false
+      t.bigint "innholders", null: false
+      t.decimal "hypautomorphics", precision: 16, scale: 2, null: false
+      t.datetime "melezitases", precision: nil, null: false
+      t.datetime "menoschetics", precision: nil, null: false
+    end
+
+    create_table "statoblasts", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "sings", null: false
+      t.datetime "overseethes", precision: nil
+      t.datetime "extractions", precision: nil
+    end
+
+    create_table "decimosextos", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.decimal "acetous", precision: 16, scale: 2, null: false
+      t.decimal "preacherlesses", precision: 16, scale: 2, null: false
+      t.string "ameliorablenesses", default: "unpaid", null: false
+      t.datetime "semidressies", precision: nil
+      t.datetime "tympaniforms", precision: nil
+      t.bigint "outfigures", null: false
+      t.bigint "enneasyllabics"
+      t.bigint "putages", null: false
+      t.string "porridgelikes", null: false
+      t.date "gorsedds"
+      t.date "abstinencies"
+    end
+
+    create_table "taxaspideans", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "theophania", null: false
+      t.string "previsionals", null: false
+      t.decimal "tabarets", precision: 16, scale: 2, null: false
+      t.datetime "ahungries", precision: nil
+      t.datetime "malagasies", precision: nil, null: false
+      t.datetime "tristrams", precision: nil, null: false
+      t.datetime "religionlesses", precision: nil, null: false
+    end
+
+    create_table "vitalisticallies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "golgis", null: false
+      t.bigint "seneschalships", null: false
+      t.datetime "unemendeds", precision: nil, null: false
+      t.datetime "pharologies", precision: nil
+      t.datetime "graminiferous", precision: nil, null: false
+      t.datetime "prioresses", precision: nil, null: false
+      t.bigint "watts"
+      t.string "torpedos"
+    end
+
+    create_table "cunjers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "requalifies", limit: 36, null: false
+      t.boolean "gladsomes", default: false, null: false
+      t.datetime "retraverses", precision: nil, null: false
+      t.datetime "submerses", precision: nil, null: false
+      t.string "analkalinities", limit: 36, null: false
+    end
+
+    create_table "izotes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "peppercorns", null: false
+      t.string "callorhynchidaes", null: false
+      t.datetime "extrapolations", precision: nil
+      t.datetime "yemenics", precision: nil
+    end
+
+    create_table "chabasies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "blackamoors", null: false
+      t.boolean "poornesses", default: false, null: false
+      t.datetime "evanishments", precision: nil
+      t.datetime "cropheads", precision: nil
+    end
+
+    create_table "ens", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "nidicolous", limit: 50, null: false
+      t.string "taimen", limit: 25
+      t.datetime "patrices", precision: nil
+      t.datetime "glycerates", precision: nil, null: false
+      t.datetime "novemlobates", precision: nil, null: false
+      t.boolean "parcellations", default: true
+      t.string "inhabitivenesses", default: "zenpayroll", null: false
+      t.string "impoliticlies", limit: 36
+      t.string "protectographs"
+      t.string "epigeans"
+      t.boolean "broozleds", default: false
+    end
+
+    create_table "amorados", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "carbonizes", null: false
+      t.string "vindicates", null: false
+      t.datetime "ceratothecals", precision: nil
+      t.datetime "stratopedarches", precision: nil
+    end
+
+    create_table "scissorsmiths", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "backhandednesses", limit: 36, null: false
+      t.bigint "unroamings", null: false
+      t.integer "exhumators", null: false
+      t.integer "assistencies"
+      t.integer "sniggers", null: false
+      t.datetime "conjugationals", precision: nil, null: false
+      t.datetime "terminations", precision: nil, null: false
+    end
+
+    create_table "overtrusts", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "gings", limit: 36, null: false
+      t.bigint "mannies", null: false
+      t.datetime "squilloids", precision: nil
+      t.integer "histogenous", null: false
+      t.integer "pangia"
+      t.string "rimmakers", null: false
+      t.string "undefensibles", null: false
+      t.integer "campylotropous", null: false
+      t.datetime "shysters", precision: nil, null: false
+      t.datetime "millionairesses", precision: nil, null: false
+      t.datetime "flatteringlies", precision: nil, null: false
+      t.integer "homoblasties", default: 0, null: false
+    end
+
+    create_table "intrusionisms", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "impersonalities", null: false
+      t.bigint "entoptoscopics", null: false
+      t.datetime "amidoxies", precision: nil
+      t.datetime "langles", precision: nil
+    end
+
+    create_table "oophoreoceles", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "murvas", null: false
+      t.bigint "amphicytulas", null: false
+      t.text "endotheliomyomas", null: false
+      t.datetime "ungrooveds", precision: nil, null: false
+      t.datetime "recreates", precision: nil, null: false
+      t.datetime "malichos", precision: nil
+    end
+
+    create_table "rouns", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "conglomeratics", null: false
+      t.bigint "attemperates", null: false
+      t.string "ossifiers", null: false
+      t.datetime "palaeoanthropologies", precision: nil
+      t.datetime "testudineals", precision: nil
+    end
+
+    create_table "interlacements", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "hypergoddesses", null: false
+      t.text "clinographs", null: false
+      t.datetime "fibromatoses", precision: nil, null: false
+      t.bigint "winterhains", null: false
+      t.string "insouls", null: false
+      t.string "bombsights", null: false
+      t.integer "musophagas", null: false
+      t.datetime "protoirons", precision: nil, null: false
+      t.datetime "lurals", precision: nil, null: false
+      t.datetime "elisabeths", precision: nil, null: false
+      t.string "shortcomers", null: false
+    end
+
+    create_table "deairs", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "quintus", limit: 36, null: false
+      t.bigint "independencies", null: false
+      t.string "proudishes", null: false
+      t.datetime "bryophyta", precision: nil, null: false
+      t.datetime "chidinglies", precision: nil, null: false
+    end
+
+    create_table "laryngophonies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "idiosyncraticallies", limit: 36, null: false
+      t.bigint "ligniferous", null: false
+      t.string "tiens", null: false
+      t.text "unbridledlies", null: false
+      t.datetime "induratives", precision: nil, null: false
+      t.datetime "lumbaginous", precision: nil, null: false
+    end
+
+    create_table "jaegers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "animis", null: false
+      t.bigint "fishhooks", null: false
+      t.bigint "thimbleds", null: false
+      t.datetime "melicerta", precision: nil, null: false
+      t.datetime "telosynaptics", precision: nil, null: false
+    end
+
+    create_table "lieshes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "hypersensitizes", null: false
+      t.bigint "countermarks", null: false
+      t.bigint "aprickles", null: false
+      t.datetime "tweakers", precision: nil, null: false
+      t.datetime "sapors", precision: nil, null: false
+    end
+
+    create_table "usucaptions", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "chilicotes", null: false
+      t.bigint "unconfronteds", null: false
+      t.datetime "whichways", precision: nil, null: false
+      t.datetime "unconceivings", precision: nil, null: false
+    end
+
+    create_table "angustiseptates", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "multiarticulars", null: false
+      t.date "milkweeds"
+      t.datetime "petasos", precision: nil, null: false
+      t.datetime "gauchenesses", precision: nil, null: false
+    end
+
+    create_table "vacciniolas", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "delusories", null: false
+      t.bigint "panidiomorphics"
+      t.bigint "malonyls"
+      t.datetime "governorates", precision: nil, null: false
+      t.datetime "trochalopodas", precision: nil, null: false
+    end
+
+    create_table "sputteries", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "dorabs", null: false
+      t.string "harbingers", null: false
+      t.datetime "sclims", precision: nil, null: false
+      t.datetime "damiers", precision: nil, null: false
+    end
+
+    create_table "darsts", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "yawners", null: false
+      t.bigint "tephrites"
+      t.datetime "hygeists", precision: nil, null: false
+      t.datetime "playas", precision: nil, null: false
+    end
+
+    create_table "prosopopoeials", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "dramaticules", null: false
+      t.bigint "chamars", null: false
+      t.date "segregatenesses", null: false
+      t.date "scapulares", null: false
+      t.datetime "heapsteads", precision: nil, null: false
+      t.datetime "podurans", precision: nil, null: false
+    end
+
+    create_table "ultraviri", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "pentanitrates", null: false
+      t.bigint "disentanglers", null: false
+      t.bigint "frisesomorums", null: false
+      t.date "panphenomenalisms", null: false
+      t.date "circumincessions", null: false
+      t.date "anthobiologies", null: false
+      t.datetime "salinelles", precision: nil, null: false
+      t.datetime "broomsticks", precision: nil, null: false
+      t.bigint "cowleds", null: false
+    end
+
+    create_table "hydraulics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "scaphoceritics"
+      t.string "underrulers"
+      t.date "gnatcatchers"
+      t.date "zunyites"
+      t.boolean "overstrews", default: false
+      t.integer "day_1"
+      t.integer "day_2"
+      t.boolean "presignifies", default: false
+      t.datetime "paleoichthyologies", precision: nil, null: false
+      t.datetime "criticisables", precision: nil, null: false
+      t.boolean "improprieties", default: false
+      t.boolean "conflateds", default: false
+      t.string "torulus"
+      t.string "banaks", limit: 36
+      t.boolean "terebenics", default: false, null: false
+      t.bigint "tarsioids"
+    end
+
+    create_table "floodtimes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "quadrifocals", null: false
+      t.bigint "basellaceaes", null: false
+      t.date "quamasia", null: false
+      t.date "trundleheads"
+      t.datetime "reformistics", precision: nil
+      t.datetime "telenergies", precision: nil
+    end
+
+    create_table "paleoalchemicals", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "iliopubics", null: false
+      t.date "puns", null: false
+      t.decimal "rouds", precision: 16, scale: 2
+      t.boolean "gainsomes"
+      t.datetime "ovarioceles", precision: nil, null: false
+      t.datetime "conidia", precision: nil, null: false
+      t.text "ordinatelies"
+      t.string "icebreakers"
+      t.integer "pentanediones", limit: 2
+      t.text "whereons"
+      t.decimal "plagiarizers", precision: 16, scale: 2
+      t.decimal "infrabasals", precision: 16, scale: 2
+      t.boolean "hepatectomies", default: false
+      t.boolean "roomlets", default: false
+      t.integer "manslayings", default: 1, null: false
+      t.date "neronians", null: false
+      t.date "haciendas", null: false
+    end
+
+    create_table "thievelesses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "folials", null: false
+      t.boolean "counterweighs", default: false
+      t.datetime "unpillorieds", precision: nil
+      t.datetime "rosarubies", precision: nil
+      t.datetime "grieffuls", precision: nil
+      t.boolean "solates"
+    end
+
+    create_table "unworns", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "spitefuls", null: false
+      t.bigint "asexualities", null: false
+      t.decimal "gamelions", precision: 16, scale: 2, null: false
+      t.string "spatlings", null: false
+      t.datetime "resilials", precision: nil, null: false
+      t.datetime "scrooges", precision: nil, null: false
+      t.datetime "unsparingnesses", precision: nil
+      t.datetime "spiritfuls", precision: nil
+    end
+
+    create_table "subfibrous", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.datetime "obscurities", precision: nil
+      t.bigint "storekeepers", null: false
+      t.string "driftmen"
+      t.bigint "boltuprightnesses"
+      t.datetime "nonces", precision: nil
+      t.datetime "slodges", precision: nil
+      t.integer "epidermoidals", limit: 1
+      t.integer "endobiotics", limit: 1
+    end
+
+    create_table "krugerisms", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "gonochoristics"
+      t.bigint "lightens"
+      t.bigint "romerillos"
+      t.bigint "pharmacomaniacs"
+      t.datetime "breastbands", precision: nil
+      t.datetime "cecidiologists", precision: nil
+      t.datetime "nonconnivances", precision: nil
+      t.bigint "homoanisics"
+    end
+
+    create_table "miraclemongers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "calamiforms", null: false
+      t.decimal "asystolics", precision: 16, scale: 2, default: "0.0", null: false
+      t.decimal "ommiads", precision: 16, scale: 2, default: "0.0", null: false
+      t.date "aerobatics"
+      t.datetime "nasals", precision: nil
+      t.datetime "dechemicalizes", precision: nil
+    end
+
+    create_table "blackhearteds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "noninjurious", limit: 36, null: false
+      t.bigint "linies", null: false
+      t.string "nominates"
+      t.string "saurasenis"
+      t.integer "ribbonmakers"
+      t.datetime "streets", precision: nil
+      t.string "seedsmen", null: false
+      t.datetime "metasthenics", precision: nil
+      t.integer "metins", default: 0
+      t.datetime "aphyrics", precision: nil
+      t.string "chances"
+      t.datetime "caponizes", precision: nil, null: false
+      t.datetime "pitsides", precision: nil, null: false
+    end
+
+    create_table "angulates", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "cornucopiates", limit: 36, null: false
+      t.bigint "martens", null: false
+      t.string "semeiologies"
+      t.datetime "outfolds", precision: nil
+      t.datetime "jaculatories", precision: nil
+      t.datetime "carcinosarcomata", precision: nil
+    end
+
+    create_table "unaugmentables", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "chondrectomies", limit: 36, null: false
+      t.bigint "ricininics", null: false
+      t.string "oppidans", default: "--- []\n"
+      t.string "diplosomes"
+      t.string "underexposes"
+      t.string "monads"
+      t.integer "bedriddens"
+      t.datetime "postaspirates", precision: nil
+      t.string "ragtags"
+      t.string "geodes"
+      t.date "whipships"
+      t.datetime "rowdyishnesses", precision: nil
+      t.datetime "largemouths", precision: nil
+      t.datetime "hydrofluorics", precision: nil
+    end
+
+    create_table "prepracticals", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "ephetics", limit: 36, null: false
+      t.bigint "easygoingnesses", null: false
+      t.bigint "terricolines", null: false
+      t.string "scovies", null: false
+      t.date "domesticables", null: false
+      t.datetime "overstuds", precision: nil, null: false
+      t.datetime "undiphthongizes", precision: nil, null: false
+    end
+
+    create_table "aquilinos", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "pentadecagons", null: false
+      t.datetime "acquitments", precision: nil
+      t.datetime "embryologicallies", precision: nil
+      t.string "diets", null: false
+      t.string "sauves", null: false
+    end
+
+    create_table "puppetlikes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "guzes", null: false
+      t.string "ungableds", null: false
+      t.bigint "costispinals", null: false
+      t.datetime "crystallogenics", precision: nil
+      t.datetime "visuosensories", precision: nil
+    end
+
+    create_table "cottes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "formamidines", null: false
+      t.datetime "enanguishes", precision: nil, null: false
+      t.datetime "hirundos", precision: nil, null: false
+      t.string "sculptographies", null: false
+    end
+
+    create_table "oophoromas", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "synoecioses", limit: 36, null: false
+      t.bigint "flickertails", null: false
+      t.string "unthreateneds", null: false
+      t.boolean "comfortings", null: false
+      t.boolean "drainpipes", default: false, null: false
+      t.boolean "corallics", default: false, null: false
+      t.boolean "bdelloidas", default: false, null: false
+      t.boolean "quinnats", default: false, null: false
+      t.datetime "bases", precision: nil
+      t.datetime "paromologetics", precision: nil
+      t.integer "shers", limit: 1
+      t.datetime "smaragdines", precision: nil
+      t.datetime "stephanites", precision: nil
+      t.string "antiastronomicals"
+      t.boolean "sperrylites", default: false
+    end
+
+    create_table "fritillaries", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "deedeeds", limit: 36, null: false
+      t.bigint "grothites", null: false
+      t.bigint "expiations", null: false
+      t.string "lymphosporidioses", null: false
+      t.boolean "shodes", default: false, null: false
+      t.datetime "lanyards", precision: nil, null: false
+      t.datetime "yaws", precision: nil, null: false
+      t.date "alcyonaceas"
+    end
+
+    create_table "anhelous", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "pajamaeds"
+      t.bigint "thallogens"
+      t.string "altairs"
+      t.datetime "outstatures", precision: nil, null: false
+      t.datetime "nomadics", precision: nil, null: false
+    end
+
+    create_table "nonaspersions", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "buttresslikes"
+      t.string "pantheians"
+      t.string "businesses"
+      t.decimal "polichinelles", precision: 16, scale: 2, default: "0.0"
+      t.datetime "boilersmiths", precision: nil, null: false
+      t.datetime "vicegerals", precision: nil, null: false
+      t.bigint "unprejudices"
+      t.datetime "reedlikes", precision: nil
+      t.boolean "supercharges"
+      t.decimal "vigilantes", precision: 16, scale: 2
+    end
+
+    create_table "phloroglucins", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "atypicallies", limit: 36, null: false
+      t.bigint "watchwises", null: false
+      t.bigint "untickleds", null: false
+      t.string "hydrocirsoceles", null: false
+      t.integer "yakins", default: 0
+      t.datetime "corkwoods", precision: nil, null: false
+      t.datetime "gooseweeds", precision: nil, null: false
+    end
+
+    create_table "tremas", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "sulides", limit: 36, null: false
+      t.bigint "refavors", null: false
+      t.bigint "nonacknowledgments", null: false
+      t.datetime "directors", precision: nil, null: false
+      t.bigint "anodals"
+      t.bigint "pioneers"
+      t.bigint "polygoneutisms"
+      t.bigint "pinguiculaceous"
+      t.bigint "rhabdos"
+      t.bigint "unforgivinglies"
+      t.bigint "prothrombins"
+      t.bigint "sarsas"
+      t.bigint "resistivenesses"
+      t.bigint "observatorials"
+      t.bigint "cypseloids"
+      t.bigint "unshuffles"
+      t.bigint "swaggeringlies"
+      t.bigint "philocynies"
+      t.bigint "innocentlies"
+      t.bigint "vitiators"
+      t.bigint "nonlimitations"
+      t.bigint "borotungstates"
+      t.bigint "groins"
+      t.bigint "peevedlies"
+      t.bigint "cainguas"
+      t.boolean "hushedlies"
+      t.string "arribas"
+      t.decimal "laryngendoscopes", precision: 16, scale: 15
+      t.decimal "kinetomers", precision: 16, scale: 15
+      t.string "corporealizations"
+      t.decimal "odophones", precision: 16, scale: 2
+      t.string "ortives"
+      t.bigint "inquilinaes"
+      t.bigint "presternals"
+      t.string "persulphurics"
+      t.bigint "unstorieds"
+      t.decimal "dendroceratines", precision: 16, scale: 6
+      t.bigint "improficiencies"
+      t.decimal "cardinals", precision: 16, scale: 15
+      t.bigint "overprovenders"
+      t.decimal "bulbous", precision: 16, scale: 6
+      t.decimal "aquilaria", precision: 16, scale: 6
+      t.decimal "kappas", precision: 16, scale: 6
+      t.bigint "autosymbolics"
+      t.bigint "actinotherapeutics"
+      t.datetime "thiamines", precision: nil, null: false
+      t.datetime "wiseacres", precision: nil, null: false
+    end
+
+    create_table "labyrinthulas", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "xanthochroous", limit: 36, null: false
+      t.bigint "fasciolets", null: false
+      t.string "microcoleopteras", null: false
+      t.bigint "enigmatographers", null: false
+      t.decimal "blowups", precision: 16, scale: 15, null: false
+      t.decimal "transubstantiates", precision: 16, scale: 15, null: false
+      t.text "tassets"
+      t.datetime "monometrics", precision: nil, null: false
+      t.datetime "untaughts", precision: nil, null: false
+      t.string "forfaultures", limit: 20
+    end
+
+    create_table "dollinesses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "scaglia", limit: 36, null: false
+      t.bigint "palatoalveolars", null: false
+      t.string "combures", limit: 64, null: false
+      t.bigint "podiatrists"
+      t.string "unparticularizeds"
+      t.text "kishes", null: false
+      t.datetime "vinciblies", precision: nil, null: false
+      t.datetime "underpriors", precision: nil, null: false
+      t.boolean "anathematizers", default: true, null: false
+    end
+
+    create_table "antidinics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "polychromies", limit: 36, null: false
+      t.bigint "secundigravidas", null: false
+      t.bigint "unpasteds", null: false
+      t.string "backbreakings", limit: 64, null: false
+      t.bigint "hetties"
+      t.string "bogas"
+      t.datetime "inaudibles", precision: nil
+      t.bigint "mareotics"
+      t.string "soffits", limit: 64
+      t.datetime "aloids", precision: nil, null: false
+      t.datetime "pontees", precision: nil, null: false
+    end
+
+    create_table "micrurgies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "kenmarks", limit: 36, null: false
+      t.string "stilbenes", null: false
+      t.datetime "orationers", precision: nil, null: false
+      t.datetime "reposers", precision: nil, null: false
+    end
+
+    create_table "foibles", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "approximations"
+      t.decimal "udometers", precision: 16, scale: 2, default: "0.0"
+      t.datetime "misexpounds", precision: nil, null: false
+      t.datetime "decemuiris", precision: nil, null: false
+      t.bigint "calochortus"
+      t.integer "splittings", limit: 1
+      t.date "unhungs"
+      t.decimal "brodders", precision: 16, scale: 6, default: "0.0"
+      t.datetime "exaggeratedlies", precision: nil
+      t.datetime "aetiogenics", precision: nil
+      t.bigint "hireds"
+    end
+
+    create_table "pegaseans", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "represses", limit: 36, null: false
+      t.bigint "roncaglians", null: false
+      t.bigint "electrophoridaes", null: false
+      t.datetime "recordedlies", precision: nil, null: false
+      t.datetime "subordains", precision: nil, null: false
+    end
+
+    create_table "dayblushes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.decimal "waisters", precision: 16, scale: 2, default: "0.0"
+      t.string "nonarsenicals", null: false
+      t.datetime "placodus", precision: nil
+      t.bigint "goshes", null: false
+      t.bigint "scratchings"
+      t.string "zygosporics"
+      t.bigint "therevidaes"
+      t.string "unsunks"
+      t.string "unconcurrings", null: false
+      t.datetime "hylics", precision: nil, null: false
+      t.datetime "lustratories", precision: nil, null: false
+      t.bigint "theetsees", null: false
+      t.string "diademas", null: false
+    end
+
+    create_table "headliners", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.integer "tetrapleurons"
+      t.integer "futes", default: 1
+      t.bigint "foistinesses", null: false
+      t.string "uncharnels", null: false
+      t.datetime "metatheses", precision: nil, null: false
+      t.datetime "geikia", precision: nil, null: false
+      t.bigint "miraculists", null: false
+      t.string "acidifiants", null: false
+    end
+
+    create_table "fondants", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.datetime "unbethoughts", precision: nil
+      t.decimal "catelectrotonus", precision: 16, scale: 2
+      t.bigint "socioreligious"
+      t.string "archbuffoons", limit: 36, null: false
+      t.datetime "masoners", precision: nil
+      t.datetime "wahabitisms", precision: nil
+    end
+
+    create_table "centerboards", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.datetime "screenmen", precision: nil
+      t.datetime "scelidotheria", precision: nil
+      t.integer "trisuls", limit: 1
+      t.bigint "hydnoraceaes"
+      t.integer "glycocholates", limit: 1, default: 0
+      t.datetime "bethoughts", precision: nil
+      t.datetime "chondrophores", precision: nil
+      t.bigint "disconcertings"
+      t.decimal "phytomorphoses", precision: 16, scale: 2
+    end
+
+    create_table "lates", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "vinyls"
+      t.string "proxyships"
+      t.bigint "unjacketeds"
+      t.string "granduncles"
+      t.bigint "termlessnesses"
+      t.bigint "rumboozes"
+      t.string "inachoids"
+      t.bigint "antrins"
+      t.string "choregus"
+      t.bigint "misclaims"
+      t.bigint "torbernites"
+      t.date "barracudas"
+      t.decimal "unpoisonous", precision: 16, scale: 2, null: false
+      t.string "tangleproofs"
+      t.boolean "negroidals"
+      t.integer "tannometers", limit: 1
+      t.datetime "liturgiologies", precision: nil
+      t.datetime "pharmacolites", precision: nil
+    end
+
+    create_table "pelviforms", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "turntables", limit: 36, null: false
+      t.bigint "medians", null: false
+      t.bigint "hypnagogics", null: false
+      t.datetime "anthropoideas", precision: nil, null: false
+      t.datetime "breachfuls", precision: nil, null: false
+    end
+
+    create_table "clochers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "naggers", limit: 36, null: false
+      t.bigint "intergrapples", null: false
+      t.bigint "shaves", null: false
+      t.datetime "overchurches", precision: nil, null: false
+      t.datetime "sirianians", precision: nil, null: false
+    end
+
+    create_table "unpracticallies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "gneissics"
+      t.string "engjateigurs"
+      t.integer "usefulnesses", limit: 1, null: false
+      t.decimal "replenishes", precision: 16, scale: 2, null: false
+      t.datetime "capsizes", precision: nil
+      t.bigint "petreas"
+      t.string "splayfooteds"
+      t.integer "paraphrasticallies", limit: 1, default: 0
+      t.datetime "hephaestians", precision: nil
+      t.datetime "seaminesses", precision: nil
+      t.boolean "patrins", default: false
+      t.bigint "sellings"
+      t.string "idiogastras"
+      t.boolean "periorals", default: false, null: false
+      t.bigint "predestructions"
+    end
+
+    create_table "roburites", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "spileholes", null: false
+      t.bigint "cuffyisms", null: false
+      t.datetime "tailings", precision: nil
+      t.datetime "cytophysiologies", precision: nil
+    end
+
+    create_table "embolismics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "circumventions", limit: 36, null: false
+      t.string "ablates", limit: 1024, null: false
+      t.string "postoperatives", null: false
+      t.bigint "sheargrasses", null: false
+      t.string "consecrations", null: false
+      t.datetime "cedulas", precision: nil
+      t.datetime "groanfuls", precision: nil
+    end
+
+    create_table "skipjacklies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "myrmidons", limit: 36, null: false
+      t.datetime "bezoars", precision: nil, null: false
+      t.datetime "homosexuals", precision: nil
+      t.string "ahantchuyuks", null: false
+      t.text "skivs", null: false
+      t.string "schlauraffenlands", null: false
+      t.string "pseudocirrhoses", null: false
+      t.datetime "unsibilants", precision: nil
+      t.datetime "jaobs", precision: nil
+    end
+
+    create_table "ultragoods", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "overcompetitives", null: false
+      t.bigint "tetrazyls", null: false
+      t.bigint "interrogatorilies", null: false
+      t.datetime "physicalnesses", precision: nil, null: false
+      t.datetime "upmounts", precision: nil, null: false
+      t.string "diplopics", limit: 36, null: false
+    end
+
+    create_table "puttiers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "semidomestics", null: false
+      t.boolean "unannoyings", default: false
+      t.datetime "toffeemen", precision: nil
+      t.datetime "pyrolaceaes", precision: nil
+      t.integer "transpirables", limit: 1
+      t.boolean "gullishlies", default: false
+      t.boolean "untalkings", default: false
+      t.boolean "scourways", default: false
+      t.boolean "interuniversities", default: false, null: false
+    end
+
+    create_table "tuftaffeta", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "vocabularieds"
+      t.string "chasmeds"
+      t.string "privilies"
+      t.datetime "edgies", precision: nil
+      t.datetime "counterpleases", precision: nil
+      t.string "mannerizes", limit: 36
+    end
+
+    create_table "trips", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "garrupas", limit: 36, null: false
+      t.string "delicenses", limit: 36
+      t.integer "electromotives", default: 0, null: false
+      t.text "nutationals", size: :medium
+      t.string "ungrows", limit: 36, null: false
+      t.string "attractionallies", limit: 36, null: false
+      t.datetime "decomposes", precision: nil
+      t.datetime "salukis", precision: nil
+      t.date "rhymists"
+      t.date "convertings"
+      t.text "unpassablenesses", size: :medium
+    end
+
+    create_table "basals", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "unpardonings", null: false
+      t.date "centrifugalizes"
+      t.date "mythopoesies"
+      t.datetime "endlesslies", precision: nil
+      t.datetime "shophars", precision: nil
+    end
+
+    create_table "acatalepsies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "unpaneleds", null: false
+      t.bigint "coinherences", null: false
+      t.integer "adessenarians", null: false
+      t.string "salicorns", null: false
+      t.decimal "uncorruptibles", precision: 10, null: false
+      t.string "jessamines", null: false
+      t.string "servetians", null: false
+      t.integer "unassayeds", null: false
+      t.datetime "etymonics", precision: nil, null: false
+      t.datetime "protuberances", precision: nil, null: false
+    end
+
+    create_table "bellpulls", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "touchings", limit: 36, null: false
+      t.bigint "vestigia", null: false
+      t.bigint "maidlikes", null: false
+      t.bigint "sophoras", null: false
+      t.datetime "unaddresses", precision: nil, null: false
+      t.datetime "lucentios", precision: nil, null: false
+    end
+
+    create_table "jadies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "fluoresceins"
+      t.bigint "mucedinaceous"
+      t.decimal "linolates", precision: 16, scale: 2, default: "0.0", null: false
+      t.decimal "fabulousnesses", precision: 16, scale: 2, default: "0.0", null: false
+      t.datetime "wieldinesses", precision: nil, null: false
+      t.datetime "superfluouslies", precision: nil, null: false
+      t.integer "applaudables"
+      t.text "ergatandromorphics"
+    end
+
+    create_table "stryches", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.decimal "stowbords", precision: 16, scale: 2
+      t.string "foreseeables"
+      t.datetime "isomorphics", precision: nil, null: false
+      t.datetime "mycodermics", precision: nil, null: false
+      t.string "vagiles", limit: 36, null: false
+      t.decimal "ovalizes", precision: 5, scale: 2
+      t.string "aviations", limit: 36, null: false
+      t.string "bluisms", limit: 36
+      t.string "worlds", limit: 36
+      t.string "tuchunizes", null: false
+    end
+
+    create_table "torbanites", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "belies"
+      t.bigint "whortles"
+      t.bigint "boodlers"
+      t.datetime "callosities", precision: nil, null: false
+      t.datetime "mothersomes", precision: nil, null: false
+      t.decimal "susanchites", precision: 16, scale: 2, default: "0.0", null: false
+    end
+
+    create_table "heterics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "madureses", limit: 36, null: false
+      t.bigint "poeticalnesses", null: false
+      t.date "retenders", null: false
+      t.date "shrimpishes", null: false
+      t.decimal "semicoronateds", precision: 16, scale: 6, default: "0.0"
+      t.datetime "epigraphicallies", precision: nil
+      t.datetime "hydrothoracics", precision: nil
+    end
+
+    create_table "purples", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "ramsches", null: false
+      t.bigint "nuttallioses"
+      t.decimal "cyanohydrins", precision: 16, scale: 2, default: "0.0", null: false
+      t.datetime "expediteds", precision: nil, null: false
+      t.datetime "gurgles", precision: nil, null: false
+    end
+
+    create_table "chololiths", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "venerates", null: false
+      t.string "italians", null: false
+      t.integer "staurolites", null: false
+      t.decimal "crosshatches", precision: 16, scale: 6, null: false
+      t.datetime "indistinctives", precision: nil
+      t.datetime "amalricians", precision: nil
+    end
+
+    create_table "eutychians", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "aspergations"
+      t.bigint "steerageways"
+      t.decimal "cursas", precision: 16, scale: 2, default: "0.0", null: false
+      t.datetime "nonwastings", precision: nil, null: false
+      t.datetime "uncinates", precision: nil, null: false
+      t.integer "bombers", default: 0
+    end
+
+    create_table "audibles", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "unilludedlies", limit: 36, null: false
+      t.bigint "anticovenantings", null: false
+      t.date "noncalcareas", null: false
+      t.date "homeomorphics", null: false
+      t.decimal "crimps", precision: 16, scale: 6, default: "0.0"
+      t.decimal "athericeras", precision: 16, scale: 6, default: "0.0"
+      t.datetime "isobarbiturics", precision: nil
+      t.datetime "pigmies", precision: nil
+    end
+
+    create_table "syrtics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "rabbinicas"
+      t.bigint "polychromatics", null: false
+      t.decimal "rhexis", precision: 16, scale: 6, default: "0.0"
+      t.decimal "unimbibeds", precision: 16, scale: 2, default: "0.0"
+      t.datetime "autoprogressives", precision: nil, null: false
+      t.datetime "contrapositions", precision: nil, null: false
+      t.decimal "karakas", precision: 16, scale: 6, default: "0.0"
+      t.boolean "anticonstitutionals", default: false
+      t.bigint "arthroscleroses"
+      t.string "concoagulations"
+      t.bigint "jasiones"
+    end
+
+    create_table "linkers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "castors"
+      t.string "rottleras"
+      t.decimal "antimoniurets", precision: 16, scale: 2, default: "0.0", null: false
+      t.datetime "wherefroms", precision: nil, null: false
+      t.datetime "optophones", precision: nil, null: false
+      t.bigint "tricarpous"
+    end
+
+    create_table "rebrandishes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.date "platyrrhinies", null: false
+      t.datetime "supersuperabundances", precision: nil, null: false
+      t.decimal "soleas", precision: 16, scale: 6, null: false
+      t.decimal "overdeepens", precision: 16, scale: 6, null: false
+      t.decimal "onymizes", precision: 16, scale: 6, null: false
+      t.string "lushies", null: false
+      t.string "anapsidans", null: false
+      t.string "pseudoconglomerations", limit: 36, null: false
+      t.datetime "borderisms", precision: nil
+      t.datetime "predeliberatelies", precision: nil
+      t.bigint "branchiostegals", null: false
+      t.bigint "outflungs", null: false
+      t.bigint "delusters", null: false
+      t.bigint "rubicundities", null: false
+    end
+
+    create_table "lithobioids", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "chorionepitheliomas", null: false
+      t.bigint "periangiocholitis", null: false
+      t.decimal "arthrotropics", precision: 16, scale: 2, null: false
+      t.integer "loofnesses", null: false
+      t.datetime "perseverates", precision: nil, null: false
+      t.datetime "unspiables", precision: nil, null: false
+    end
+
+    create_table "cystopteris", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "waises"
+      t.bigint "oldhamites"
+      t.decimal "unadapteds", precision: 16, scale: 2, default: "0.0", null: false
+      t.datetime "slopenesses", precision: nil, null: false
+      t.datetime "tereus", precision: nil, null: false
+    end
+
+    create_table "dovetailers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "bonyfishes", null: false
+      t.string "japanesques", null: false
+      t.string "cedrirets", null: false
+      t.datetime "hoppities", precision: nil, null: false
+      t.datetime "inepts", precision: nil, null: false
+      t.string "stogas"
+      t.string "preobservances"
+      t.string "cerianthus"
+    end
+
+    create_table "uncheateds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "yashiros", limit: 36, null: false
+      t.date "acephalinas", null: false
+      t.datetime "missishes", precision: nil, null: false
+      t.datetime "arthrozoas", precision: nil, null: false
+      t.decimal "worthiests", precision: 16, scale: 2, default: "0.0", null: false
+      t.decimal "perradius", precision: 16, scale: 2, default: "0.0", null: false
+      t.decimal "necrologicals", precision: 16, scale: 2, default: "0.0", null: false
+      t.decimal "blennoemeses", precision: 16, scale: 2, default: "0.0", null: false
+      t.decimal "untempleds", precision: 16, scale: 2, default: "0.0", null: false
+      t.string "factorials", limit: 36, null: false
+    end
+
+    create_table "hierogrammates", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "unauctioneds"
+      t.decimal "hyperkinetics", precision: 16, scale: 2, default: "0.0"
+      t.decimal "cyclanthaceous", precision: 16, scale: 2, default: "0.0"
+      t.datetime "bathophobia", precision: nil, null: false
+      t.datetime "hemastatics", precision: nil, null: false
+      t.bigint "inducements"
+      t.decimal "doldrums", precision: 16, scale: 2, default: "0.0"
+      t.decimal "noctilucidaes", precision: 16, scale: 2, default: "0.0"
+      t.decimal "instructionals", precision: 16, scale: 6, default: "0.0"
+      t.string "offendresses"
+      t.boolean "aithochrois", default: false, null: false
+      t.string "scombroideans", limit: 36
+    end
+
+    create_table "sanablenesses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "circumfulgents", null: false
+      t.string "afterstates", limit: 36, null: false
+      t.decimal "empaistics", precision: 16, scale: 2, default: "0.0", null: false
+      t.decimal "sexloculars", precision: 16, scale: 6, default: "0.0", null: false
+      t.datetime "ongoings", precision: nil
+      t.datetime "ovalishes", precision: nil
+      t.boolean "subcollectors", null: false
+    end
+
+    create_table "subdeaconates", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "freewards", null: false
+      t.string "equidimensionals", limit: 36, null: false
+      t.decimal "croceous", precision: 16, scale: 2, default: "0.0", null: false
+      t.datetime "uncoddleds", precision: nil
+      t.datetime "microapparatus", precision: nil
+    end
+
+    create_table "hematomancies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "beadlehoods", null: false
+      t.string "daemons", limit: 36, null: false
+      t.bigint "untriumpheds"
+      t.decimal "hoselikes", precision: 16, scale: 6, default: "0.0", null: false
+      t.decimal "wadnas", precision: 16, scale: 6, default: "0.0", null: false
+      t.decimal "semiprofessionalizeds", precision: 16, scale: 2, default: "0.0", null: false
+      t.decimal "courtneys", precision: 16, scale: 6, null: false
+      t.datetime "coastals", precision: nil
+      t.datetime "aleurites", precision: nil
+      t.string "sexuparous"
+      t.bigint "runouts"
+    end
+
+    create_table "patristics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "toys"
+      t.bigint "enorganics"
+      t.decimal "coplaintiffs", precision: 16, scale: 2, default: "0.0"
+      t.string "torosities"
+      t.decimal "predivorcements", precision: 16, scale: 2, default: "0.0"
+      t.datetime "xenocrysts", precision: nil, null: false
+      t.datetime "rhabdocoelas", precision: nil, null: false
+      t.decimal "blastemals", precision: 16, scale: 2, default: "0.0"
+      t.decimal "dioramas", precision: 16, scale: 2, default: "0.0"
+      t.decimal "singeings", precision: 16, scale: 2, default: "0.0"
+      t.decimal "beamfuls", precision: 16, scale: 2, default: "0.0"
+      t.decimal "moneywises", precision: 16, scale: 2, default: "0.0"
+      t.decimal "barodynamics", precision: 16, scale: 2, default: "0.0"
+      t.decimal "radiations", precision: 16, scale: 2, default: "0.0"
+      t.boolean "elizas", default: false
+      t.boolean "porterhouses", default: false
+      t.decimal "smartings", precision: 16, scale: 2, default: "0.0"
+      t.boolean "mordellas", default: false
+      t.string "rillettes"
+      t.string "deglutinations"
+      t.text "hemignathous"
+      t.text "ectals"
+      t.decimal "antiaircrafts", precision: 16, scale: 2, default: "0.0"
+      t.text "drivelinglies"
+      t.boolean "laconicallies", default: false
+      t.boolean "downliers", default: false
+      t.string "beknights", null: false
+      t.decimal "nonrelinquishments", precision: 16, scale: 2, default: "0.0"
+      t.text "cuprics"
+      t.bigint "paralogicals"
+      t.boolean "pringles"
+      t.string "mistutors"
+      t.bigint "perognathus"
+      t.string "pitmakings", limit: 36, null: false
+    end
+
+    create_table "interfibrous", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.date "phanatrons"
+      t.boolean "purposefulnesses"
+      t.datetime "regalia", precision: nil, null: false
+      t.datetime "fostells", precision: nil, null: false
+      t.text "swisses", size: :medium
+      t.text "parasigmatismus"
+    end
+
+    create_table "concretors", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "wanes", limit: 36, null: false
+      t.string "latinlesses", limit: 100, null: false
+      t.datetime "chloranthies", precision: nil, null: false
+      t.datetime "gymnoconia", precision: nil, null: false
+      t.bigint "isometropia", null: false
+      t.bigint "burnetizes", null: false
+    end
+
+    create_table "russines", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "bucculas", limit: 36, null: false
+      t.datetime "evaluations", precision: nil, null: false
+      t.datetime "resultancies", precision: nil, null: false
+      t.datetime "munychia", precision: nil
+      t.bigint "shotties", null: false
+      t.date "dysphonia", null: false
+    end
+
+    create_table "interpetiolaries", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "meandrines", null: false
+      t.date "bareheadeds", null: false
+      t.datetime "shaggilies", precision: nil, null: false
+      t.datetime "filariforms", precision: nil, null: false
+    end
+
+    create_table "mileways", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "duridines"
+      t.bigint "spillproofs"
+      t.datetime "septemfoliolates", precision: nil
+      t.datetime "tachymetries", precision: nil
+    end
+
+    create_table "apolouses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "phylactocarpals"
+      t.string "unarteds", null: false
+      t.bigint "sovereignesses"
+      t.datetime "grundlovs", precision: nil
+      t.datetime "clocksmiths", precision: nil
+      t.datetime "cotingidaes", precision: nil
+      t.text "klanisms"
+    end
+
+    create_table "dinginesses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "someones", null: false
+      t.datetime "inaurations", precision: nil
+      t.datetime "noncontrolleds", precision: nil
+      t.string "parsonages"
+      t.bigint "muscovites"
+      t.date "unfranchiseds"
+      t.string "marches"
+    end
+
+    create_table "motivelesses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "oilpapers", limit: 36, null: false
+      t.bigint "tenaktaks", null: false
+      t.bigint "cantonalisms", null: false
+      t.bigint "peccantnesses", null: false
+      t.integer "atta", null: false
+      t.date "proliquors", null: false
+      t.datetime "superblesseds", precision: nil
+      t.datetime "annameses", precision: nil
+    end
+
+    create_table "mastaxes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "bepales"
+      t.string "anisotropies"
+      t.string "plicatopapilloses"
+      t.string "panniereds"
+      t.bigint "smoothbacks"
+      t.bigint "kittenships"
+      t.string "moorishnesses"
+      t.text "prefecundations"
+      t.datetime "draws", precision: nil, null: false
+      t.datetime "sacalaits", precision: nil, null: false
+      t.boolean "conclusives"
+      t.decimal "undancings", precision: 16, scale: 2, default: "0.0"
+      t.string "osteosarcomas"
+      t.bigint "besmirchments"
+      t.text "cripplers"
+      t.boolean "ichthyornithiformes"
+      t.boolean "stagirites"
+      t.boolean "guanas"
+      t.boolean "extrusions", default: true
+      t.datetime "simuliids", precision: nil
+      t.bigint "epiphyses"
+      t.string "splotchilies"
+      t.string "aduncateds"
+      t.string "awiwis"
+    end
+
+    create_table "middleways", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "intramatricals", limit: 36, null: false
+      t.bigint "gastrosteges", null: false
+      t.bigint "liveds", null: false
+      t.bigint "moonshines", null: false
+      t.bigint "uropygia", null: false
+      t.integer "tardives", limit: 1, null: false
+      t.string "karshunis", null: false
+      t.datetime "plashies", precision: nil, null: false
+      t.datetime "heterandries", precision: nil, null: false
+    end
+
+    create_table "floatlesses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "opinionals"
+      t.bigint "chronograms"
+      t.decimal "uzarins", precision: 8, scale: 2, default: "0.0"
+      t.datetime "pneumobacillus", precision: nil, null: false
+      t.datetime "nonbelievers", precision: nil, null: false
+    end
+
+    create_table "deflationists", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "stationmen", null: false
+      t.bigint "soohongs", null: false
+      t.datetime "gonidia", precision: nil
+      t.datetime "milliamps", precision: nil
+    end
+
+    create_table "narcotisms", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "semiprones", null: false
+      t.bigint "distributers", null: false
+      t.decimal "recogitates", precision: 16, scale: 2, null: false
+      t.datetime "pselaphidaes", precision: nil
+      t.datetime "uncriminals", precision: nil
+    end
+
+    create_table "pedestrianizes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.datetime "fermentativelies", precision: nil
+      t.boolean "myxomycetes"
+      t.text "vasostimulants"
+      t.datetime "turneraceaes", precision: nil
+      t.datetime "atomicities", precision: nil
+    end
+
+    create_table "frasiers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "rescuelesses"
+      t.decimal "limburgites", precision: 16, scale: 2, default: "0.0"
+      t.decimal "maskins", precision: 16, scale: 2, default: "0.0"
+      t.datetime "gessos", precision: nil, null: false
+      t.datetime "laurelships", precision: nil, null: false
+      t.bigint "schoolbookishes"
+      t.decimal "disheds", precision: 16, scale: 2, default: "0.0"
+      t.decimal "exagitations", precision: 16, scale: 2, default: "0.0"
+      t.string "boastives"
+    end
+
+    create_table "mensals", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "snarlies", limit: 36
+      t.bigint "aggrieves", null: false
+      t.bigint "whipstaffs", null: false
+      t.bigint "aconitics", null: false
+      t.decimal "lapilliforms", precision: 16, scale: 2
+      t.datetime "petaurista", precision: nil
+      t.datetime "sirs", precision: nil
+    end
+
+    create_table "metaplasmics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "demoids", null: false
+      t.bigint "klystrons", null: false
+      t.string "parasuchia", null: false
+      t.string "engagings"
+      t.datetime "sovietdoms", precision: nil, null: false
+      t.datetime "denumerations", precision: nil, null: false
+      t.string "lymphorrhages", limit: 36, null: false
+    end
+
+    create_table "statables", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "hubbas", limit: 36, null: false
+      t.bigint "sulphurets", null: false
+      t.bigint "uncontinuals", null: false
+      t.string "miserablies", null: false
+      t.string "tuftilies"
+      t.bigint "castalios"
+      t.datetime "millables", precision: nil, null: false
+      t.datetime "hypodermaticallies", precision: nil, null: false
+      t.string "fregatidaes", limit: 36
+    end
+
+    create_table "provisioners", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "tectosages"
+      t.date "subtracts"
+      t.date "overmosses"
+      t.datetime "complexlies", precision: nil
+      t.datetime "gadsmen", precision: nil, null: false
+      t.datetime "plicates", precision: nil, null: false
+      t.string "theopneusts"
+      t.date "twilightlikes"
+      t.date "involutelies"
+      t.boolean "needles", default: false
+      t.string "miltonists"
+      t.boolean "uniforms", default: false
+      t.bigint "somatopleures"
+      t.text "lampflies"
+      t.boolean "hapales", default: false
+      t.boolean "portugees", default: false
+      t.string "judiciouslies"
+      t.boolean "rubia", default: false
+      t.date "andesites"
+      t.boolean "adenylics", default: false
+      t.bigint "sulphonmethanes"
+      t.boolean "overflorids", default: false
+      t.integer "pudders"
+      t.integer "synaxaries", limit: 1
+      t.string "anabaptisticallies"
+      t.datetime "pirogues", precision: nil
+      t.boolean "tricrotisms"
+      t.boolean "foundationlessnesses"
+      t.boolean "anorthitites"
+      t.integer "scaupers"
+      t.string "pugmen"
+      t.boolean "aftermatters", default: false, null: false
+      t.string "unsecures", limit: 36, null: false
+      t.bigint "demodulations"
+      t.date "catellas"
+    end
+
+    create_table "ethnologicallies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "subhumen", limit: 36, null: false
+      t.date "malignants", null: false
+      t.bigint "thoroughgoinglies", null: false
+      t.datetime "cons", precision: nil, null: false
+      t.datetime "carports", precision: nil, null: false
+      t.bigint "reiters", null: false
+      t.string "splatterworks", null: false
+      t.string "diversifoliates", null: false
+      t.integer "antichronicals", null: false
+      t.datetime "virginitis", precision: nil, null: false
+      t.boolean "unprints", null: false
+      t.bigint "inventaries", null: false
+    end
+
+    create_table "chalkosiderics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "kedgers", limit: 36, null: false, collation: "ascii_general_ci"
+      t.string "ophthalmopods", limit: 36, null: false, collation: "ascii_general_ci"
+      t.text "remanents"
+      t.text "hereinbefores"
+      t.datetime "profligatenesses", precision: nil, null: false
+      t.datetime "nonpurposives", precision: nil, null: false
+      t.boolean "monmouthites", default: false, null: false
+      t.text "mosquitocides"
+      t.text "pisanites"
+      t.text "melanos"
+      t.text "apostemates"
+    end
+
+    create_table "tepetates", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "hippophiles", limit: 36, null: false, collation: "ascii_general_ci"
+      t.string "folkmotes", limit: 36, null: false, collation: "ascii_general_ci"
+      t.text "dactylomegalies"
+      t.boolean "percentiles", null: false
+      t.datetime "bandfishes", precision: nil, null: false
+      t.datetime "uncontentingnesses", precision: nil, null: false
+      t.datetime "dressmakings", precision: nil, null: false
+      t.text "pneumonokonioses"
+      t.text "piscatoriallies"
+      t.string "cacorhythmics", limit: 36, null: false
+      t.string "outprices", limit: 36, null: false
+    end
+
+    create_table "aunthoods", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "beris", limit: 36, null: false, collation: "ascii_general_ci"
+      t.string "tektites", limit: 36, null: false, collation: "ascii_general_ci"
+      t.string "lifeworks", limit: 36, null: false, collation: "ascii_general_ci"
+      t.string "towardlies", null: false
+      t.text "accommodativenesses"
+      t.text "sporoducts"
+      t.datetime "bacchantes", precision: nil
+      t.datetime "repasts", precision: nil, null: false
+      t.datetime "corrodiaries", precision: nil, null: false
+      t.text "fanfarades"
+      t.text "overconsiderations"
+      t.string "resignednesses", limit: 36, null: false
+    end
+
+    create_table "respiratoreds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "ciseles"
+      t.string "amalfians"
+      t.integer "hexagrammos"
+      t.integer "ambassadresses"
+      t.decimal "oogeneses", precision: 16, scale: 2
+      t.decimal "willowlikes", precision: 16, scale: 2
+      t.string "teacherdoms"
+      t.string "spasmodicallies"
+      t.string "untextuals"
+      t.datetime "terries", precision: nil
+      t.datetime "persuadedlies", precision: nil
+      t.boolean "comedists", default: false
+    end
+
+    create_table "unravishings", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.decimal "nonsufferances", precision: 16, scale: 2
+      t.decimal "rhodanics", precision: 16, scale: 2
+      t.bigint "sulvanites"
+      t.bigint "cespitoses"
+      t.bigint "gobioideas"
+      t.string "unsacramentarians"
+      t.datetime "clerodendrons", precision: nil
+      t.datetime "nonparous", precision: nil
+      t.string "auncels"
+      t.string "overspeculations"
+      t.integer "oversystematics"
+      t.datetime "gyves", precision: nil
+    end
+
+    create_table "noctuaes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "elutions"
+      t.bigint "nobilifies"
+      t.string "prodromals"
+      t.boolean "uncoherents", default: false
+      t.datetime "serridentinus", precision: nil
+      t.datetime "phasemeters", precision: nil
+      t.string "interwars", default: "pending"
+    end
+
+    create_table "sphagnales", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "wonteds"
+      t.string "polypetals"
+      t.string "address_line_1"
+      t.string "address_line_2"
+      t.string "address_line_3"
+      t.string "unhelpfullies"
+      t.string "unveilers"
+      t.string "paunchilies"
+      t.datetime "printables", precision: nil
+      t.datetime "circumfusions", precision: nil
+    end
+
+    create_table "compriseds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "dialurics"
+      t.string "negroizes"
+      t.bigint "mouillations"
+      t.bigint "dentolinguals"
+      t.datetime "innutrients", precision: nil
+      t.datetime "chrysomelids", precision: nil
+    end
+
+    create_table "illusives", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "gyarungs", null: false
+      t.bigint "slingstones", null: false
+      t.bigint "gastrics", null: false
+      t.bigint "phlebotomicallies"
+      t.datetime "dromicia", precision: nil, null: false
+      t.datetime "actinophones", precision: nil
+      t.datetime "scorbutizes", precision: nil
+      t.datetime "discoplacentalia", precision: nil
+    end
+
+    create_table "overlings", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "unrows"
+      t.bigint "rachischises"
+      t.datetime "poseurs", precision: nil
+      t.datetime "radiants", precision: nil
+    end
+
+    create_table "semiclassicals", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.date "sleepifies"
+      t.text "coferments"
+      t.string "titties"
+      t.boolean "despiritualizations", default: true, null: false
+      t.bigint "uncommensurates"
+      t.string "bemurmurs"
+      t.datetime "unleals", precision: nil
+      t.datetime "outfences", precision: nil
+      t.string "cirrostomis"
+      t.string "unendables", null: false
+      t.string "huffishes"
+      t.string "irretrievablenesses"
+      t.boolean "pseudalveolars", default: true, null: false
+      t.boolean "intrarenals", default: true, null: false
+    end
+
+    create_table "undevouts", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "virilities", limit: 36, null: false
+      t.bigint "unretirings", null: false
+      t.bigint "outborns", null: false
+      t.string "oleographics", null: false
+      t.datetime "postsystolics", precision: nil, null: false
+      t.datetime "laminations", precision: nil, null: false
+    end
+
+    create_table "superchargers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "outsonnets", limit: 36, null: false
+      t.text "nines", null: false
+      t.string "paleometallics"
+      t.bigint "presystematics", null: false
+      t.datetime "gastromyces", precision: nil, null: false
+      t.datetime "richnesses", precision: nil, null: false
+    end
+
+    create_table "smytries", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "vardies", null: false
+      t.bigint "exsufflates", null: false
+      t.string "appendotomes", null: false
+      t.string "alamodalities"
+      t.text "sears"
+      t.text "modulants"
+      t.datetime "demagnetizes", precision: nil, null: false
+      t.string "hypoalkalinities"
+    end
+
+    create_table "alfajes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "farsighteds", null: false
+      t.datetime "deathies", precision: nil
+      t.datetime "omphaloncus", precision: nil
+      t.datetime "ungospelleds", precision: nil
+      t.bigint "goniopholis", null: false
+    end
+
+    create_table "boxworks", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "seductivelies", null: false
+      t.string "deemsterships", limit: 36, null: false
+      t.bigint "anthomaniacs", null: false
+      t.datetime "stichomythics", precision: nil, null: false
+      t.datetime "handleds", precision: nil, null: false
+      t.datetime "eugenolates", precision: nil
+      t.bigint "cicers", null: false
+    end
+
+    create_table "trichopterygidaes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "collapsibles", null: false
+      t.string "embossings", null: false
+      t.string "meerschaums"
+      t.datetime "resinols", precision: nil
+      t.datetime "tuffs", precision: nil
+      t.datetime "imperviousnesses", precision: nil
+      t.string "apanteses"
+    end
+
+    create_table "etiotropics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "fathomages", null: false
+      t.text "aeromantics"
+      t.datetime "aporphines", precision: nil
+      t.datetime "conveyances", precision: nil
+    end
+
+    create_table "chaenomeles", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "spherals", null: false
+      t.text "gastroscopes"
+      t.datetime "nonconnections", precision: nil
+      t.datetime "mesomorphics", precision: nil
+    end
+
+    create_table "plantivorous", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "superposeds", null: false
+      t.string "philologists", null: false
+      t.string "pseudosophicals", null: false
+      t.text "swelldoms", null: false
+      t.datetime "anacalypses", precision: nil
+      t.datetime "biophysiologicals", precision: nil
+    end
+
+    create_table "tuboovarians", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "gypsous", null: false
+      t.string "ocreataes", null: false
+      t.string "semioccasionallies", null: false
+      t.datetime "ascribables", precision: nil
+      t.datetime "leonists", precision: nil
+      t.string "stockers"
+    end
+
+    create_table "gadgets", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "duocosanes", null: false
+      t.bigint "antidominicans", null: false
+      t.string "sharplies", null: false
+      t.bigint "friskets", null: false
+      t.string "zygostyles", null: false
+      t.datetime "callainites", precision: nil
+      t.string "cornerers"
+      t.datetime "coadmits", precision: nil
+      t.datetime "lampfuls", precision: nil
+      t.string "supernecessities", limit: 36, null: false
+    end
+
+    create_table "anthotropisms", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "mellaginous", null: false
+      t.string "copybooks"
+      t.string "wilsomelies"
+      t.integer "egotisticallies"
+      t.datetime "unretteds", precision: nil
+      t.string "sheriffdoms"
+      t.datetime "modelessnesses", precision: nil
+      t.bigint "speluncars"
+      t.string "unharmonizeds"
+      t.datetime "noctivagations", precision: nil
+      t.datetime "kondes", precision: nil
+      t.string "bororos", limit: 36, null: false
+      t.string "paleethnographers", limit: 36, null: false
+      t.string "repressives", limit: 36
+    end
+
+    create_table "stroygoods", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "scaridaes", limit: 36, null: false
+      t.string "hypoconulids", null: false
+      t.string "womanposts", null: false
+      t.string "etheostomas", null: false
+      t.datetime "lamplesses", precision: nil, null: false
+      t.datetime "argives", precision: nil, null: false
+    end
+
+    create_table "scents", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "sextennials", null: false
+      t.date "undebilitatings", null: false
+      t.datetime "tuberculides", precision: nil
+      t.datetime "pteridospermaphyta", precision: nil
+      t.string "laryngotracheals"
+      t.string "paramos", null: false
+    end
+
+    create_table "colas", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "unpredicts"
+      t.string "myoxidaes"
+      t.text "janes"
+      t.text "impertransibles"
+      t.datetime "undersigners", precision: nil, null: false
+      t.datetime "whelkeds", precision: nil, null: false
+      t.string "zambals"
+    end
+
+    create_table "nemerteas", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "amchoors", limit: 36, null: false
+      t.string "unsifteds", null: false
+      t.string "outcastings"
+      t.string "awokes"
+      t.datetime "eccoproticophorics", precision: nil
+      t.datetime "rechanges", precision: nil
+      t.datetime "spoutlesses", precision: nil
+      t.datetime "ringsters", precision: nil
+      t.string "microprints", null: false
+      t.string "tepidaria", null: false
+      t.bigint "milleporites", null: false
+      t.bigint "cassideous"
+      t.boolean "corinthianizes", default: false, null: false
+      t.datetime "offerors", precision: nil
+      t.datetime "sicsacs", precision: nil
+      t.string "pneumohemothoraxes", limit: 4
+      t.text "subdeaneries"
+      t.boolean "bolshevikians", default: false
+      t.boolean "suspensefuls"
+      t.boolean "pikeys"
+      t.boolean "covings", default: false
+      t.boolean "cyanidins", default: false
+      t.boolean "flytiers", default: false
+      t.string "desklikes"
+    end
+
+    create_table "ailes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "phytoptidaes", limit: 36, null: false
+      t.string "benzophenoxazines"
+      t.string "dunies"
+      t.string "labradoritics"
+      t.string "panbabylonisms"
+      t.string "abscesses", null: false
+      t.datetime "overtwines", precision: nil
+      t.datetime "meadowings", precision: nil
+      t.bigint "herodionines", null: false
+      t.string "demiglobes", null: false
+      t.string "cheesewoods"
+      t.bigint "retooks"
+      t.string "boilovers"
+    end
+
+    create_table "outlabors", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "maladaptations", null: false
+      t.string "paragglutinations", null: false
+      t.string "squinnies", null: false
+      t.text "nonrecurrents", size: :medium, null: false
+      t.text "intersticeds", size: :medium, null: false
+      t.string "bluebottles"
+    end
+
+    create_table "vetivers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "didascalars", limit: 36, null: false
+      t.bigint "andronitis", null: false
+      t.bigint "pantarchies", null: false
+      t.string "dandyizes", null: false
+      t.date "nontypographicals", null: false
+      t.decimal "conciliables", precision: 16, scale: 2, null: false
+      t.string "thermogens"
+      t.datetime "flameds", precision: nil
+      t.datetime "nephrolepis", precision: nil
+      t.string "proctoptomas", null: false
+      t.boolean "adventials"
+      t.boolean "gratemen"
+    end
+
+    create_table "sassanids", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "pythagorics", limit: 36, null: false
+      t.bigint "fouths", null: false
+      t.bigint "autarkies", null: false
+      t.date "energics", null: false
+      t.decimal "citadels", precision: 16, scale: 2
+      t.datetime "clavicles", precision: nil
+      t.datetime "psittaciformes", precision: nil
+      t.bigint "electrophysiologicals"
+      t.decimal "refixes", precision: 16, scale: 2
+      t.decimal "verrucas", precision: 16, scale: 2
+    end
+
+    create_table "theopaschites", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "altometers", limit: 36, null: false
+      t.bigint "subantichrists", null: false
+      t.string "spaecrafts", null: false
+      t.datetime "nextlies", precision: nil, null: false
+      t.datetime "ointments", precision: nil, null: false
+    end
+
+    create_table "lucumonies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "yokematings", null: false
+      t.string "paganizers", null: false
+      t.string "despotisms", null: false
+      t.datetime "copperings", precision: nil, null: false
+      t.datetime "emulsors", precision: nil, null: false
+      t.string "aquarters"
+      t.string "britannia"
+      t.string "sympiesometers"
+      t.string "metalbumins"
+      t.bigint "disgradations"
+    end
+
+    create_table "hydrologies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "jocelyns"
+      t.bigint "hematorrhachis"
+      t.bigint "vacillatories"
+      t.datetime "alterns", precision: nil, null: false
+      t.datetime "oblonglies", precision: nil, null: false
+    end
+
+    create_table "unscrimpeds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "roundmoutheds"
+      t.string "troths"
+      t.string "prosopites"
+      t.text "traves"
+      t.datetime "toluidinos", precision: nil, null: false
+      t.datetime "expenditures", precision: nil, null: false
+      t.datetime "invincibles", precision: nil
+      t.bigint "beardeds"
+    end
+
+    create_table "athleticisms", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "presumptuouslies", limit: 36, null: false
+      t.bigint "sprigs", null: false
+      t.string "anarthroses", null: false
+      t.string "uninterruptions", null: false
+      t.decimal "palliostratus", precision: 16, scale: 2, null: false
+      t.string "membranaceous"
+      t.string "memnonia", limit: 512
+      t.string "peristaltics", null: false
+      t.string "autoplasties", null: false
+      t.datetime "antipatriotisms", precision: nil
+      t.datetime "counterrevolutionists", precision: nil
+      t.datetime "initives", precision: nil
+      t.datetime "macrosplanchnics", precision: nil
+    end
+
+    create_table "pisidia", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "cataphracta"
+      t.bigint "deciduous"
+      t.bigint "overprolifics"
+      t.decimal "colaborers", precision: 16, scale: 15
+      t.decimal "vapories", precision: 16, scale: 2
+      t.decimal "parathyroprivia", precision: 16, scale: 2
+      t.text "sulfonmethanes"
+      t.datetime "gastrodynia", precision: nil
+      t.datetime "heteromita", precision: nil
+      t.decimal "caulomers", precision: 16, scale: 15
+      t.bigint "missourites"
+      t.string "orthoxazins"
+    end
+
+    create_table "prefamiliarlies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "quicksets"
+      t.decimal "proselyters", precision: 16, scale: 15
+      t.text "chaukidaris"
+      t.text "neuropodials"
+      t.text "judaicals"
+      t.text "uroses"
+      t.text "seeches"
+      t.text "arbutins"
+      t.text "farcicals"
+      t.boolean "milksopisms"
+      t.datetime "advectives", precision: nil
+      t.datetime "blanches", precision: nil
+      t.text "gelids"
+      t.string "shends"
+      t.string "bocals"
+    end
+
+    create_table "unquestionates", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "youthhoods", null: false
+      t.bigint "solvolyzes"
+      t.datetime "artocarpaceaes", precision: nil
+      t.string "cerebroganglions"
+      t.datetime "laparosalpingotomies", precision: nil
+      t.datetime "weldings", precision: nil
+      t.bigint "sovereignties"
+    end
+
+    create_table "rhinologies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "nonconducives"
+      t.decimal "necks", precision: 16, scale: 15
+      t.text "flapperhoods"
+      t.datetime "soursops", precision: nil
+      t.datetime "outparts", precision: nil
+      t.decimal "pelikes", precision: 16, scale: 15
+    end
+
+    create_table "catadicrotics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "concubitous", null: false
+      t.string "thielavia"
+      t.string "bonifications", null: false
+      t.datetime "fasciculars", precision: nil, null: false
+      t.datetime "heptanones", precision: nil, null: false
+      t.bigint "pelotherapies", null: false
+      t.boolean "prediverts", default: false
+      t.datetime "lovers", precision: nil
+      t.string "tenontodynia"
+      t.string "abshenries"
+      t.integer "reviolations"
+      t.string "inspectorates"
+      t.string "sustenances"
+      t.string "celiorrheas"
+    end
+
+    create_table "kindhearteds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.boolean "concedes", default: true, null: false
+      t.integer "oarlikes"
+      t.boolean "ephebuses", default: true
+      t.decimal "syncopes", precision: 16, scale: 2
+      t.boolean "antorbitals", default: false, null: false
+      t.boolean "counterjudgings", default: false, null: false
+      t.decimal "theotechnies", precision: 16, scale: 2
+      t.datetime "glaries", precision: nil, null: false
+      t.datetime "gyppos", precision: nil, null: false
+    end
+
+    create_table "manostatics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "visages", null: false
+      t.bigint "tricresols", null: false
+      t.string "names", null: false
+      t.string "holdsmen"
+      t.decimal "hemipareses", precision: 16, scale: 2, null: false
+      t.datetime "fluxiblies", precision: nil, null: false
+      t.datetime "sneests", precision: nil, null: false
+    end
+
+    create_table "antlerites", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "cestodaria", null: false
+      t.string "pseudorganics", null: false
+      t.date "ughs", null: false
+      t.boolean "incidentalnesses"
+      t.integer "excerptives"
+      t.decimal "nondangerous", precision: 16, scale: 2
+      t.string "teammen"
+      t.date "ironstones"
+      t.datetime "inquisitivelies", precision: nil, null: false
+      t.datetime "subintelligiturs", precision: nil, null: false
+      t.bigint "unrespectables"
+    end
+
+    create_table "fencelets", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "croquets"
+      t.bigint "invests"
+    end
+
+    create_table "goraccos", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "outgreens", null: false
+      t.string "sulfindigotates"
+      t.integer "fumitories"
+      t.datetime "siegecrafts", precision: nil
+      t.datetime "halicarnassians", precision: nil
+    end
+
+    create_table "linoxyns", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "bathlesses", limit: 36, null: false
+      t.string "unpityinglies", limit: 36, null: false
+      t.datetime "meltednesses", precision: nil
+      t.datetime "irreclaimablenesses", precision: nil
+      t.string "newnesses", default: "not_started", null: false
+    end
+
+    create_table "parachromatisms", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "hydradephagas", limit: 36, null: false, collation: "ascii_general_ci"
+      t.string "pineys", null: false
+      t.string "paratungstates", null: false
+      t.string "interradials", limit: 36, null: false, collation: "ascii_general_ci"
+      t.datetime "attainabilities", precision: nil
+      t.datetime "nates", precision: nil
+    end
+
+    create_table "groupagenesses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "plaideds"
+      t.string "oropharynxes"
+      t.string "condylopods"
+      t.string "omnivisions"
+      t.decimal "semsems", precision: 16, scale: 2
+      t.decimal "chronogrammaticallies", precision: 16, scale: 2
+      t.datetime "impassionedlies", precision: nil
+      t.datetime "cyclonists", precision: nil
+    end
+
+    create_table "thons", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "lambhoods", limit: 36, null: false
+      t.bigint "reappraisements", null: false
+      t.bigint "isallobars", null: false
+      t.datetime "polissoirs", precision: nil, null: false
+      t.datetime "twofoldlies", precision: nil, null: false
+    end
+
+    create_table "agrobiologies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "shiggaions", limit: 36, null: false
+      t.bigint "interpretresses", null: false
+      t.bigint "entopticallies", null: false
+      t.boolean "guileries", null: false
+      t.boolean "burrers", null: false
+      t.datetime "expeditenesses", precision: nil
+      t.datetime "tis", precision: nil
+    end
+
+    create_table "angiocholecystitis", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "equilibrities"
+      t.bigint "precorresponds"
+      t.datetime "undisgorgeds", precision: nil
+      t.datetime "dartsmen", precision: nil
+      t.text "perienterics"
+      t.string "preplacentals"
+      t.string "commassees"
+      t.string "revenders", default: "tier_based", null: false
+    end
+
+    create_table "formulators", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "hydrocephalus"
+      t.bigint "outpayments"
+      t.bigint "ichorrhemia"
+      t.datetime "nonbasics", precision: nil
+      t.datetime "unpleacheds", precision: nil
+    end
+
+    create_table "deathweeds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.datetime "undercoaters", precision: nil, null: false
+      t.datetime "trasteverines", precision: nil, null: false
+      t.bigint "languidnesses"
+      t.string "acatalepsia"
+      t.bigint "organums"
+      t.bigint "uneffuseds"
+      t.bigint "noncomplaisances"
+    end
+
+    create_table "reburns", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "throatworts", null: false
+      t.string "concoctions", null: false
+      t.integer "terris", default: 9100, null: false
+      t.string "isothermous", null: false
+      t.string "tchetnitsis", null: false
+      t.datetime "achroodextrinases", precision: nil
+      t.datetime "jezebels", precision: nil
+    end
+
+    create_table "amplificators", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "protoselachiis", limit: 36, null: false
+      t.bigint "merveileuxes", null: false
+      t.datetime "scholasticlies", precision: nil
+      t.datetime "quawks", precision: nil
+      t.string "hallucinates", default: "inactive", null: false
+      t.datetime "dorsocephalics", precision: nil, null: false
+      t.boolean "mollifications"
+      t.string "moormen"
+    end
+
+    create_table "unanticipateds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "arbusta", null: false
+      t.string "unclassablenesses", limit: 36, null: false
+      t.bigint "synchondroses"
+      t.integer "barbarians", null: false
+      t.datetime "verisimilitudes", precision: nil
+      t.datetime "preterchristians", precision: nil
+      t.bigint "orignals"
+    end
+
+    create_table "consolinglies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "flagfalls", null: false
+      t.string "uniseriates", null: false
+      t.text "thinkingparts"
+      t.datetime "sulfurics", precision: nil, null: false
+      t.datetime "saans", precision: nil, null: false
+      t.integer "extendedlies"
+      t.text "verticils"
+    end
+
+    create_table "epithalamizes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "legatorials", null: false
+      t.decimal "teetings", precision: 16, scale: 2, null: false
+      t.datetime "zoanthids", precision: nil, null: false
+      t.datetime "larnaxes", precision: nil, null: false
+    end
+
+    create_table "pallas", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "silicotungstics"
+      t.string "gujaratis"
+      t.string "hidrotics"
+      t.bigint "borophenylics"
+      t.string "induplicatives"
+      t.bigint "resalables"
+      t.date "taprooteds"
+      t.datetime "materiates", precision: nil
+      t.datetime "phallephorics", precision: nil
+      t.date "gynostegia"
+      t.date "speeches"
+      t.string "rebluffs"
+      t.bigint "trematoids"
+    end
+
+    create_table "salses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "mazdakeans"
+      t.string "nondivisionals"
+      t.datetime "sipunculaceans", precision: nil
+      t.datetime "perduringlies", precision: nil
+    end
+
+    create_table "dipodies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "screvers", null: false
+      t.string "decigrammes", null: false
+      t.bigint "cladonia", null: false
+      t.string "contraclockwises", null: false
+      t.datetime "droopers", precision: nil
+      t.datetime "whussles", precision: nil
+      t.string "antidiphtherics"
+      t.text "generallies", null: false
+      t.string "insultproofs", limit: 36
+    end
+
+    create_table "melursus", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "bromoketones"
+      t.string "ballyhoos"
+      t.string "overpressures"
+      t.integer "vantbrasses"
+      t.datetime "blosmies", precision: nil
+      t.datetime "tuliplikes", precision: nil
+      t.datetime "unattackables", precision: nil
+    end
+
+    create_table "inequilobates", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.datetime "primoprimes", precision: nil
+      t.datetime "fiancees", precision: nil
+      t.string "niseis"
+      t.string "doolies"
+      t.string "adaptednesses"
+      t.string "disarmatures"
+      t.boolean "reverendlies", default: false
+      t.text "bardesanites"
+      t.text "westernisms"
+      t.text "accelerandos"
+      t.boolean "arzans"
+      t.string "orthorrhaphies"
+      t.boolean "unmannereds", default: true
+      t.string "chakars", limit: 36
+      t.bigint "successlesslies"
+    end
+
+    create_table "excavators", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "persistencies", null: false
+      t.string "polyphobics", null: false
+      t.string "extrastomachals", limit: 36, null: false
+      t.integer "unavengeables", null: false
+      t.string "synodontids", null: false
+      t.string "mucinogens", null: false
+      t.string "literators", null: false
+      t.datetime "unsheetings", precision: nil
+      t.datetime "spinks", precision: nil
+      t.string "isopolities", limit: 32
+    end
+
+    create_table "crownbeards", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "renovaters", limit: 36, null: false, collation: "ascii_general_ci"
+      t.string "psorophthalmia", limit: 36, null: false, collation: "ascii_general_ci"
+      t.string "importrays", limit: 36, collation: "ascii_general_ci"
+      t.string "philosophemes", null: false
+      t.boolean "extratubals", default: true, null: false
+      t.boolean "evidentials", default: false, null: false
+      t.datetime "extracathedrals", precision: nil, null: false
+      t.bigint "reverbs"
+    end
+
+    create_table "gibblegabblers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "myxothecas", limit: 36, null: false, collation: "ascii_general_ci"
+      t.string "asynergia", limit: 36, null: false, collation: "ascii_general_ci"
+      t.string "veinages", null: false
+      t.boolean "scolopendria", default: true, null: false
+      t.boolean "unnices", default: false, null: false
+    end
+
+    create_table "apiculturists", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "bhotia", null: false
+      t.string "physometras", null: false
+      t.datetime "psychanalysists", precision: nil
+      t.datetime "sordellinas", precision: nil
+    end
+
+    create_table "extrapulmonaries", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "cerebrasthenics", null: false
+      t.string "peppins", null: false
+      t.string "underhangings", null: false
+      t.string "impoundments", null: false
+      t.boolean "enterosepses", null: false
+      t.datetime "unafflictings", precision: nil, null: false
+      t.datetime "reallocates", precision: nil, default: "3000-01-01 00:00:00", null: false
+      t.bigint "felinaes", null: false
+      t.bigint "threadmakings"
+    end
+
+    create_table "zippers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "chatterations", limit: 36, null: false
+      t.string "scorpionis", limit: 36, null: false
+      t.date "zoophytes", null: false
+      t.date "coventries", null: false
+    end
+
+    create_table "oratorianizes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "underbraceds", null: false
+      t.string "warrers", null: false
+      t.datetime "markdowns", precision: nil, null: false
+      t.datetime "revoices", precision: nil, default: "3000-01-01 00:00:00", null: false
+      t.bigint "superarduous", null: false
+      t.bigint "delinters"
+    end
+
+    create_table "unfurnishednesses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "magnelectrics", null: false
+      t.string "cryptozonates", null: false
+      t.datetime "palingenesies", precision: nil
+      t.datetime "dewdamps", precision: nil
+      t.bigint "brachygnathia", null: false
+    end
+
+    create_table "laceds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "antifungins", limit: 36, null: false
+      t.string "craniotomes", limit: 36, null: false
+      t.text "talipomanus", null: false
+      t.datetime "eyries", precision: nil
+      t.datetime "fielders", precision: nil
+    end
+
+    create_table "beneficiations", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "isotopics"
+      t.bigint "gravelings", null: false
+      t.decimal "tomnoups", precision: 10, scale: 6
+    end
+
+    create_table "counterdeclarations", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "constipations", null: false
+      t.string "psorics", null: false
+      t.date "epicorollines", null: false
+      t.date "uphers", null: false
+    end
+
+    create_table "mulctations", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "affiants", limit: 36, null: false
+      t.string "martyrizations", limit: 36, null: false
+      t.boolean "mussalchees", default: false, null: false
+      t.datetime "meridionaceaes", precision: nil
+      t.datetime "pharmacics", precision: nil
+      t.string "subbailiwicks", limit: 36
+    end
+
+    create_table "halterproofs", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "overearnestnesses", null: false
+      t.string "tuberculates", null: false
+      t.string "peziziforms", null: false
+      t.datetime "computers", precision: nil, null: false
+      t.datetime "sexagesimas", precision: nil, default: "3000-01-01 00:00:00", null: false
+      t.bigint "disruptivenesses", null: false
+      t.bigint "paillasses"
+      t.string "lichenicolous", limit: 36, collation: "ascii_general_ci"
+    end
+
+    create_table "corylaceaes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "acomous", null: false
+      t.string "platyodonts", null: false
+      t.datetime "paracentricals", precision: nil
+      t.datetime "unfallaciouslies", precision: nil
+    end
+
+    create_table "subsemitones", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "gothonics", null: false
+      t.bigint "coweens", null: false
+      t.date "progenitivenesses"
+      t.datetime "vajrasanas", precision: nil
+      t.datetime "petrobrusians", precision: nil
+      t.string "intinctions", limit: 36, collation: "ascii_general_ci"
+      t.string "ultravirtuous", limit: 36
+      t.string "allothimorphs", limit: 36, null: false
+    end
+
+    create_table "colletsides", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "svantovits", null: false
+      t.integer "quisqualis"
+      t.datetime "munificences", precision: nil, null: false
+      t.datetime "withholds", precision: nil, default: "3000-01-01 00:00:00", null: false
+      t.bigint "repatronizes", null: false
+      t.bigint "remiforms"
+    end
+
+    create_table "decadarchies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "formalizations", limit: 36, null: false, collation: "ascii_general_ci"
+      t.string "cloits", limit: 36, null: false, collation: "ascii_general_ci"
+      t.string "battalions", limit: 36, collation: "ascii_general_ci"
+      t.string "sparrowgrasses", null: false
+      t.boolean "ketapangs", default: false, null: false
+      t.datetime "oxybenzoics", precision: nil, null: false
+      t.bigint "emporia"
+    end
+
+    create_table "allalinites", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "tubeforms", limit: 36, null: false, collation: "ascii_general_ci"
+      t.string "greeds", limit: 36, null: false, collation: "ascii_general_ci"
+      t.string "colchicines", null: false
+      t.boolean "unparseds", default: false, null: false
+    end
+
+    create_table "masteries", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "dasypaedals", limit: 36, null: false, collation: "ascii_general_ci"
+      t.string "curviforms", limit: 36, null: false, collation: "ascii_general_ci"
+      t.string "hummockies", limit: 36, collation: "ascii_general_ci"
+      t.boolean "xanthics", default: true, null: false
+      t.boolean "argonauts", default: false, null: false
+      t.datetime "semimutes", precision: nil
+      t.bigint "anamorphotes"
+    end
+
+    create_table "undistinguisheds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "sequelants", limit: 36, null: false, collation: "ascii_general_ci"
+      t.string "operalogues", limit: 36, null: false, collation: "ascii_general_ci"
+      t.string "pathogenicities", limit: 36, null: false, collation: "ascii_general_ci"
+      t.boolean "subcirculars", default: true, null: false
+      t.boolean "nonfrictions", default: false, null: false
+      t.datetime "pliablenesses", precision: nil
+      t.datetime "yourselves", precision: nil
+    end
+
+    create_table "sulphoichthyolates", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "snakebites"
+      t.integer "sabuloses"
+      t.datetime "undoubteds", precision: nil
+      t.datetime "typholysins", precision: nil
+    end
+
+    create_table "kilties", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "hiddenlies", null: false
+      t.bigint "leucotics", null: false
+      t.string "arlines", null: false
+      t.bigint "triglots", null: false
+      t.datetime "aggregates", precision: nil, null: false
+      t.datetime "tetrachicals", precision: nil, null: false
+    end
+
+    create_table "unsubsidizeds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "stuprations", null: false
+      t.bigint "hyaloliparites", null: false
+      t.datetime "reconciliators", precision: nil, null: false
+      t.datetime "unscrupulosities", precision: nil, null: false
+      t.string "visas", default: "Pufferfish::Blob", null: false
+    end
+
+    create_table "acoemetaes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "dulies", null: false
+      t.string "vlaches", null: false
+      t.integer "theophrasteans", null: false
+      t.datetime "bellyfuls", precision: nil, null: false
+      t.datetime "vinous", precision: nil, null: false
+      t.datetime "bohawns", precision: nil, null: false
+    end
+
+    create_table "predemonstrates", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "lazules", limit: 36, null: false
+      t.bigint "unpanels"
+      t.bigint "drives", null: false
+      t.bigint "scansorials", null: false
+      t.datetime "uninervates", precision: nil
+      t.datetime "untranscendentals", precision: nil
+    end
+
+    create_table "volcanics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "albopannins", null: false
+      t.bigint "northeasternmosts", null: false
+      t.datetime "kalmucks", precision: nil, null: false
+      t.datetime "mallowworts", precision: nil, null: false
+    end
+
+    create_table "picolines", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "photoscopics", null: false
+      t.bigint "eudipleurals", null: false
+      t.datetime "convexeds", precision: nil, null: false
+      t.datetime "nonintoxicatings", precision: nil, null: false
+    end
+
+    create_table "irradiancies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "phalangidas", null: false
+      t.string "consiliaries", null: false
+      t.bigint "uninucleateds", null: false
+      t.datetime "herringers", precision: nil, null: false
+      t.datetime "singeinglies", precision: nil, null: false
+    end
+
+    create_table "scabbles", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "weiselbergites", null: false
+      t.date "illusibles", null: false
+      t.date "deuterovitelloses", null: false
+      t.decimal "nevels", precision: 16, scale: 2, null: false
+      t.decimal "glossolabiolaryngeals", precision: 16, scale: 2
+      t.text "unsupposeds", null: false
+      t.bigint "schizonemerteas"
+      t.datetime "meatinesses", precision: nil, null: false
+      t.datetime "uromeres", precision: nil, null: false
+      t.string "cerises", null: false
+      t.boolean "boraxes", default: false, null: false
+      t.boolean "petricolas", default: false, null: false
+      t.string "butlers"
+      t.string "ars"
+    end
+
+    create_table "guttulaes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "unmullioneds", limit: 36, null: false
+      t.bigint "molestations", null: false
+      t.bigint "extendings"
+      t.bigint "monerozoans"
+      t.string "uncapablies"
+      t.string "saucerlesses", null: false
+      t.boolean "elegiasts", null: false
+      t.boolean "pseudelminths", null: false
+      t.datetime "barycenters", precision: nil, null: false
+      t.datetime "amorous", precision: nil, null: false
+    end
+
+    create_table "hookups", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "arridges", null: false
+      t.string "courtzilites", null: false
+      t.datetime "beclarts", precision: nil, null: false
+      t.datetime "aptotics", precision: nil, null: false
+    end
+
+    create_table "intercessionals", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "anurics", limit: 36, null: false
+      t.bigint "overpersuades", null: false
+      t.datetime "cholocyanines", precision: nil
+      t.datetime "nonagencies", precision: nil
+    end
+
+    create_table "tissuals", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "sanatoria", limit: 36, null: false
+      t.bigint "fils", null: false
+      t.bigint "prepubis", null: false
+      t.text "reciprocators"
+      t.datetime "chathamites", precision: nil, null: false
+      t.datetime "choletherapies", precision: nil, null: false
+    end
+
+    create_table "jeddocks", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "nototheria", limit: 36, null: false
+      t.bigint "disgustings", null: false
+      t.bigint "intermembranous", null: false
+      t.boolean "bivocalizeds", default: true
+      t.integer "rodmen"
+      t.text "lairds"
+      t.bigint "autopsychorhythmia"
+      t.datetime "tetracoccus", precision: nil, null: false
+      t.datetime "authorships", precision: nil, null: false
+    end
+
+    create_table "testoons", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "prosopyles", limit: 36, null: false
+      t.bigint "installations", null: false
+      t.integer "subcontinents", null: false
+      t.string "temperas", null: false
+      t.string "reflexibles", null: false
+      t.string "hempstrings"
+      t.bigint "haphazardlies"
+      t.datetime "unagitateds", precision: nil, null: false
+      t.datetime "unmarchings", precision: nil, null: false
+    end
+
+    create_table "scaraboids", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "uprises", limit: 36, null: false
+      t.string "prudelikes", null: false
+      t.string "unclassablies", null: false
+      t.string "coxarthritis"
+      t.bigint "barkles"
+      t.bigint "illiquids"
+      t.datetime "unwebs", precision: nil, null: false
+      t.datetime "restains", precision: nil, null: false
+    end
+
+    create_table "rousseauists", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "elephantidaes"
+      t.integer "trivalencies", limit: 2
+      t.integer "enarches", limit: 2
+      t.boolean "balachongs"
+      t.boolean "idryls"
+      t.boolean "floppilies"
+      t.boolean "trunkbacks"
+      t.datetime "capivis", precision: nil
+      t.datetime "ramonas", precision: nil
+    end
+
+    create_table "acetacetics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "roadables", null: false
+      t.datetime "justments", precision: nil
+      t.datetime "pathophoreses", precision: nil
+      t.integer "subconicals"
+      t.integer "crepitants"
+      t.integer "therapeutics"
+      t.bigint "megatheroids"
+      t.string "insacks"
+      t.bigint "burgherhoods"
+      t.text "silkworks"
+      t.text "comminatives"
+      t.datetime "thwarteous", precision: nil, null: false
+      t.datetime "congregationalizes", precision: nil, null: false
+    end
+
+    create_table "phyllophyllins", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "sigaultians", null: false
+      t.string "hanafites", null: false
+      t.string "mongcorns", null: false
+      t.datetime "panaceas", precision: nil, null: false
+      t.boolean "seropreventions", default: false, null: false
+      t.datetime "chackers", precision: nil
+      t.datetime "nonadmissions", precision: nil
+    end
+
+    create_table "equationists", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.boolean "vacuefies", default: false, null: false
+      t.string "epithelioids", null: false
+      t.datetime "karyolymphs", precision: nil
+      t.datetime "slaggabilities", precision: nil
+    end
+
+    create_table "danaids", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "warbles", limit: 36, null: false
+      t.boolean "outsteams"
+      t.bigint "eonisms", null: false
+      t.datetime "outplaces", precision: nil
+      t.datetime "perniciouslies", precision: nil
+    end
+
+    create_table "lepidenes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "apples"
+      t.string "courils"
+      t.boolean "globules", default: true
+      t.datetime "barologies", precision: nil, null: false
+      t.datetime "mantistics", precision: nil, null: false
+      t.boolean "beautifiers", default: true, null: false
+      t.string "underofficials", default: "debit_date", null: false
+      t.datetime "thirteenfolds", precision: nil
+      t.datetime "impoisoners", precision: nil
+      t.string "semostomous"
+      t.datetime "geerahs", precision: nil
+      t.bigint "gimberjaweds"
+      t.boolean "practicablies", default: true, null: false
+    end
+
+    create_table "geishas", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "gracious", null: false
+      t.bigint "unrevealednesses", null: false
+      t.bigint "puttyworks", null: false
+      t.datetime "spunkies", precision: nil
+      t.datetime "eozoics", precision: nil, null: false
+      t.datetime "garnishries", precision: nil, null: false
+      t.bigint "neuromyics", null: false
+      t.string "catharizations", null: false
+    end
+
+    create_table "fittings", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "vassalizes"
+      t.integer "verboses", limit: 2
+      t.integer "socializations", limit: 1
+      t.datetime "cardiaplegia", precision: nil, null: false
+      t.datetime "hyenics", precision: nil, null: false
+      t.string "oats"
+      t.boolean "file_1099s", default: true
+      t.boolean "tuchunates", default: true
+      t.text "sammiers"
+      t.boolean "spontaneities", default: true
+      t.datetime "phenolsulphonates", precision: nil
+      t.datetime "adoptionists", precision: nil
+      t.boolean "mongrels", default: false
+      t.boolean "tempos", default: false
+    end
+
+    create_table "creolizes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "praxis", null: false
+      t.bigint "periorbits"
+      t.datetime "fascios", precision: nil
+      t.datetime "wollops", precision: nil
+    end
+
+    create_table "blahlauts", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "napeads"
+      t.string "oometers"
+      t.string "ectoplasmatics"
+      t.string "floebergs"
+      t.datetime "philodinidaes", precision: nil, null: false
+      t.datetime "petaliferous", precision: nil, null: false
+    end
+
+    create_table "alymphia", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "bushlikes", null: false
+      t.string "varguenos", null: false
+      t.string "phantasmata", null: false
+      t.datetime "vermicularia", precision: nil, null: false
+      t.datetime "bisexualities", precision: nil, null: false
+    end
+
+    create_table "ideophones", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "supradentals"
+      t.datetime "expects", precision: nil, null: false
+      t.datetime "vivas", precision: nil, null: false
+      t.string "desoxalates"
+      t.bigint "lymphadenia"
+    end
+
+    create_table "tamers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "pterodactylians"
+      t.datetime "ascertains", precision: nil, null: false
+      t.datetime "pseudolunules", precision: nil, null: false
+      t.boolean "matriarches", default: false
+      t.boolean "dentirostrates", default: true, null: false
+      t.string "encephalomalaxis", default: "debit_date", null: false
+      t.string "intrapsychicals"
+    end
+
+    create_table "pneumonometers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "gammarines", null: false
+      t.string "vaporizers", null: false
+      t.string "rearranges", null: false
+      t.string "arsenophenylglycins", null: false
+      t.integer "gingeries", null: false
+      t.datetime "weskits", precision: nil, null: false
+      t.datetime "scorpionics", precision: nil, null: false
+    end
+
+    create_table "cockmasters", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.integer "cuspeds", null: false
+      t.bigint "transversallies", null: false
+      t.bigint "handgrasps", null: false
+      t.string "saturateds", null: false
+      t.string "nocakes", limit: 36, null: false
+      t.decimal "swallowables", precision: 16, scale: 2
+      t.decimal "dreaminglies", precision: 16, scale: 2
+      t.decimal "cnemidia", precision: 16, scale: 2
+      t.string "hyoglycocholics"
+      t.datetime "dinkies", precision: nil
+      t.datetime "hematocyanins", precision: nil
+    end
+
+    create_table "unprismatics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.date "bloodripenesses"
+      t.string "tripletails"
+      t.bigint "hoarilies"
+      t.string "keratomas"
+      t.string "pageanteers"
+      t.string "asymbolia"
+      t.string "upbelches"
+      t.datetime "penthemimerals", precision: nil
+      t.datetime "scarificators", precision: nil
+      t.decimal "illusivelies", precision: 16, scale: 2
+      t.text "petitioners"
+      t.string "glaiks"
+      t.string "pancreaticogastrostomies"
+      t.bigint "frescos"
+      t.string "erythrozincites"
+    end
+
+    create_table "dokmaroks", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "unmannerlies"
+      t.string "technicons"
+      t.integer "martyresses"
+      t.datetime "onagras", precision: nil
+      t.datetime "overspeeds", precision: nil, null: false
+      t.datetime "kathies", precision: nil, null: false
+    end
+
+    create_table "unadulterouslies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "nidis", null: false
+      t.bigint "misexpresses", null: false
+      t.string "snubs", limit: 36, null: false
+      t.datetime "snarks", precision: nil, null: false
+      t.datetime "parkins", precision: nil, null: false
+      t.bigint "reworkeds", null: false
+    end
+
+    create_table "heterostrophics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.date "hatchways", null: false
+      t.date "pelecanoidinaes", null: false
+      t.date "prospectors", null: false
+      t.boolean "cryptogams", null: false
+      t.bigint "proctostomies", null: false
+      t.boolean "pilotries", null: false
+      t.text "laryngotomies"
+      t.string "bethinks", limit: 36, null: false
+      t.datetime "herniaria", precision: nil, null: false
+      t.datetime "unraceds", precision: nil, null: false
+      t.datetime "seismoscopes", precision: nil
+    end
+
+    create_table "brenders", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "pentalogues", null: false
+      t.date "phrygianizes", null: false
+      t.date "monoplegics", null: false
+      t.date "importancies", null: false
+      t.boolean "flyflaps", null: false
+      t.bigint "powdereds"
+      t.boolean "jailages", null: false
+      t.datetime "balaenopteras", precision: nil, null: false
+      t.datetime "unstatelies", precision: nil, null: false
+      t.string "unminuteds", null: false
+      t.text "tilemakings"
+      t.string "ottrelives", limit: 36, null: false
+    end
+
+    create_table "proteoclastics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "zonulars", null: false
+      t.bigint "gammarids"
+      t.date "unobvious", null: false
+      t.date "assertibles", null: false
+      t.datetime "kamiks", precision: nil
+      t.datetime "testons", precision: nil
+      t.bigint "triliterals"
+      t.text "micrometallographers"
+      t.boolean "samelies", default: false, null: false
+      t.string "hematodynamics", limit: 36, null: false
+    end
+
+    create_table "labbas", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "tinkers", limit: 36, null: false
+      t.string "radicicolous", null: false
+      t.datetime "pseudomasculines", precision: nil, null: false
+      t.datetime "raches", precision: nil, null: false
+    end
+
+    create_table "urginglies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "renvoys", limit: 36, null: false
+      t.text "petals", null: false
+      t.integer "diallagoids", null: false
+      t.text "unadaptives", size: :medium, null: false
+      t.text "mootings", size: :medium
+      t.boolean "bandagists", null: false
+      t.datetime "predays", precision: nil
+      t.datetime "prisonables", precision: nil
+    end
+
+    create_table "prandials", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "prehistorians", limit: 36, null: false
+      t.text "somesthesia", null: false
+      t.integer "korumburras"
+      t.integer "omnitemporals"
+      t.boolean "syconarians"
+      t.decimal "densenesses", precision: 16, scale: 2
+      t.bigint "eightfoils", null: false
+      t.datetime "begraces", precision: nil
+      t.datetime "sciographs", precision: nil
+      t.string "proctalgies"
+      t.string "orobatoideas"
+      t.integer "prespiraculars"
+      t.datetime "overliers", precision: nil
+      t.string "sphenomandibulars", default: "completed", null: false
+    end
+
+    create_table "terebras", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "mooseys"
+      t.bigint "synechologicals"
+      t.string "selensilvers"
+      t.text "unroasteds"
+      t.bigint "parodontitis"
+      t.datetime "bisectionallies", precision: nil
+      t.datetime "thights", precision: nil
+    end
+
+    create_table "mistfuls", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "samsonics", null: false
+      t.string "perspirabilities", null: false
+      t.datetime "unattesteds", precision: nil, null: false
+      t.datetime "pedunculations", precision: nil, null: false
+    end
+
+    create_table "leatherworkings", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "jagats"
+      t.bigint "sibbaldus"
+      t.bigint "gravellies"
+      t.string "streltzis"
+      t.datetime "cyrtographs", precision: nil
+      t.datetime "drumfires", precision: nil
+      t.boolean "lacelesses", default: true
+      t.decimal "mendaites", precision: 16, scale: 2, default: "0.0"
+      t.string "killers"
+      t.boolean "loxophthalmus", default: false
+      t.string "nonchalantlies", limit: 36, null: false
+      t.datetime "befavors", precision: nil
+      t.string "platformlesses"
+      t.bigint "phyllostomines"
+      t.string "wrongheadedlies"
+    end
+
+    create_table "nephrostomas", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "verminers"
+      t.string "jackshays"
+      t.datetime "slews", precision: nil
+      t.datetime "presentals", precision: nil
+      t.bigint "podagricals"
+    end
+
+    create_table "compsognathus", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "trophoblastics", null: false
+      t.bigint "astoops"
+      t.boolean "amphioxididaes", default: false
+      t.datetime "bromoforms", precision: nil
+      t.datetime "labiotenaculums", precision: nil
+    end
+
+    create_table "tonelessnesses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "theatricables", null: false
+      t.bigint "sepals", null: false
+      t.string "semicantilevers", null: false
+      t.bigint "cosmopolitanizations", null: false
+      t.string "quadrenniallies", null: false
+      t.date "tetramorphous"
+      t.datetime "idiomusculars", precision: nil
+      t.datetime "tunablenesses", precision: nil
+    end
+
+    create_table "semiferous", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "submembranaceous", limit: 36, null: false, collation: "ascii_general_ci"
+      t.bigint "prodigalizes", null: false
+      t.bigint "jessamies", null: false
+      t.datetime "unfesters", precision: nil
+      t.datetime "antibubonics", precision: nil
+    end
+
+    create_table "pensticks", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "unquietables", limit: 36, null: false, collation: "ascii_general_ci"
+      t.bigint "unestimateds", null: false
+      t.string "squanderinglies", default: "blocked", null: false
+      t.datetime "unannihilables", precision: nil
+      t.datetime "maxillopalatines", precision: nil
+      t.date "carbonatations"
+      t.decimal "organochordia", precision: 16, scale: 2
+    end
+
+    create_table "indefatigablenesses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "outbrings"
+      t.string "pes"
+      t.text "frightfullies"
+      t.integer "regulates", null: false
+      t.integer "malikalas", default: 0
+      t.datetime "polylinguists", precision: nil, null: false
+      t.datetime "beteelas", precision: nil, null: false
+    end
+
+    create_table "caconychia", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "dendroicas", null: false
+      t.bigint "conservations", null: false
+      t.string "scarabaeinaes", null: false
+      t.string "paparchicals", null: false
+      t.datetime "myographers", precision: nil
+      t.datetime "significancies", precision: nil
+      t.bigint "sniffinesses"
+      t.integer "tailorlies", default: 0, null: false
+      t.boolean "elucidatories", default: true
+      t.datetime "substantialists", precision: nil
+      t.text "atrienses"
+      t.bigint "cacographers"
+      t.boolean "corns", default: true, null: false
+      t.bigint "inculpatories"
+    end
+
+    create_table "compresences", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "headrails"
+      t.bigint "keenas", null: false
+      t.string "postmusculars", null: false
+      t.string "underreaches", null: false
+      t.integer "establishmentarianisms"
+      t.string "parietoviscerals"
+      t.string "pleurorrheas", null: false
+      t.datetime "unroofeds", precision: nil
+      t.date "uncatalogueds"
+      t.datetime "empiricalnesses", precision: nil
+      t.datetime "pangwes", precision: nil
+      t.decimal "misappoints", precision: 16, scale: 2
+    end
+
+    create_table "erasmians", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "distomes", null: false
+      t.string "goodyeras"
+      t.bigint "haves"
+      t.string "azoxytoluidines", null: false
+      t.datetime "vertebraes", precision: nil, null: false
+      t.datetime "goldlikes", precision: nil, null: false
+      t.datetime "leans", precision: nil, null: false
+      t.datetime "bicyclists", precision: nil, null: false
+    end
+
+    create_table "graafians", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.text "factordoms"
+      t.bigint "iodinates", null: false
+      t.datetime "suprarationalisms", precision: nil
+      t.datetime "underprompters", precision: nil
+    end
+
+    create_table "bacterioidals", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "fringeflowers", null: false
+      t.bigint "chiropterous", null: false
+      t.text "uncontentables"
+      t.datetime "whafabouts", precision: nil
+      t.datetime "octuplets", precision: nil
+    end
+
+    create_table "rapefuls", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "improvisatorizes", null: false
+      t.bigint "piperaceaes", null: false
+      t.datetime "crankums", precision: nil, null: false
+      t.datetime "sesquipedals", precision: nil
+      t.datetime "walers", precision: nil, null: false
+      t.datetime "tocks", precision: nil, null: false
+    end
+
+    create_table "telethermometers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "groggeries", null: false
+      t.string "magniloquentlies", null: false
+      t.boolean "outstrokes", null: false
+      t.datetime "lamellicorns", precision: nil
+      t.datetime "unlandeds", precision: nil
+      t.boolean "besprents", null: false
+    end
+
+    create_table "possibilists", charset: "latin1", force: :cascade do |t|
+      t.datetime "unvoyageables", precision: nil, null: false
+      t.datetime "pedicels", precision: nil, null: false
+      t.string "streamsides", null: false
+      t.bigint "pendants", null: false
+      t.string "forsts", collation: "latin1_bin"
+      t.integer "chondrocoracoids", default: 0, null: false
+      t.string "antisoporifics"
+      t.bigint "bibbons", null: false
+      t.string "balaamiticals", limit: 15
+    end
+
+    create_table "polladzs", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "retinasphalta", null: false
+      t.bigint "uninfectious"
+      t.datetime "abysses", precision: nil, null: false
+      t.datetime "bunts", precision: nil, null: false
+      t.string "mesotaeniales"
+      t.datetime "loggats", precision: nil
+      t.integer "cryptographs", default: 0
+      t.bigint "photosculpturals"
+      t.decimal "hydrotimeters", precision: 16, scale: 2, default: "0.0"
+      t.string "nonpoets", default: "unpaid", null: false
+      t.string "wansonsies", default: "unpaid", null: false
+      t.datetime "eumolpides", precision: nil
+      t.datetime "raphania", precision: nil
+      t.bigint "nymphicals"
+      t.bigint "helions"
+      t.integer "typhlostenoses", default: 0
+      t.decimal "vagabondishes", precision: 16, scale: 2, default: "0.0"
+      t.boolean "physiologians"
+    end
+
+    create_table "kinnikinnicks", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.date "slopings", null: false
+      t.decimal "thimblefuls", precision: 16, scale: 2
+      t.integer "traducements"
+      t.string "woodrocks", null: false
+      t.string "retoothers", limit: 36, null: false
+      t.datetime "fierasferoids", precision: nil
+      t.datetime "peritheces", precision: nil
+    end
+
+    create_table "loasaceaes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.date "clamorers"
+      t.decimal "olenidaes", precision: 16, scale: 2, null: false
+      t.string "cratemakings", limit: 36, null: false
+      t.string "hypernutritions"
+      t.string "rewelcomes", null: false
+      t.datetime "gregariouslies", precision: nil
+      t.datetime "uncompassions", precision: nil
+    end
+
+    create_table "tetrahydrateds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.decimal "gobbledygooks", precision: 16, scale: 2, null: false
+      t.string "actinoblasts", limit: 36, null: false
+      t.bigint "quinaldinics", null: false
+      t.bigint "paradoxures", null: false
+      t.string "catonians", null: false
+      t.datetime "explainables", precision: nil
+      t.datetime "sarcocystis", precision: nil
+    end
+
+    create_table "vaccinationists", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.decimal "tricolumnars", precision: 16, scale: 2, null: false
+      t.bigint "naggingnesses", null: false
+      t.string "postcalcaneals", null: false
+      t.string "pyrrolines", limit: 36, null: false
+      t.datetime "adorers", precision: nil
+      t.datetime "psychologicallies", precision: nil
+      t.integer "trippets"
+      t.text "lancelies"
+      t.string "posttarsals", null: false
+    end
+
+    create_table "offs", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.date "insensiblies", null: false
+      t.decimal "appellancies", precision: 16, scale: 2
+      t.integer "fertilizes"
+      t.string "pneumonocaces", null: false
+      t.string "scotchifies", limit: 36, null: false
+      t.string "chloroacetates", null: false
+      t.datetime "crestfallens", precision: nil
+      t.datetime "coelacanthoids", precision: nil
+    end
+
+    create_table "semipendents", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.date "jiffles"
+      t.decimal "rotguts", precision: 16, scale: 2, null: false
+      t.string "underisives", limit: 36, null: false
+      t.string "mistlesses"
+      t.string "pezizoids", null: false
+      t.datetime "renablies", precision: nil
+      t.datetime "limacidaes", precision: nil
+    end
+
+    create_table "unkins", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.decimal "superiors", precision: 16, scale: 2, null: false
+      t.string "vulgarizes", limit: 36, null: false
+      t.bigint "symphilics", null: false
+      t.bigint "ocelliforms", null: false
+      t.string "careens", null: false
+      t.datetime "gists", precision: nil
+      t.datetime "hypodermatomies", precision: nil
+    end
+
+    create_table "bryaceous", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.decimal "barbarousnesses", precision: 16, scale: 2, null: false
+      t.bigint "rudderlikes", null: false
+      t.string "sansars", null: false
+      t.string "advantageousnesses", limit: 36, null: false
+      t.string "potassia", null: false
+      t.datetime "aftermilks", precision: nil
+      t.datetime "schefferites", precision: nil
+      t.text "gymnodiniaceaes"
+      t.string "preceptorates", null: false
+      t.integer "trollies"
+    end
+
+    create_table "sulliables", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "shaws", limit: 36, null: false
+      t.bigint "proceremonialisms"
+      t.boolean "warriorhoods", default: false, null: false
+      t.text "barwises"
+      t.string "scuffles"
+      t.string "ulnars", default: "", null: false
+      t.datetime "protragedies", precision: nil
+      t.datetime "upbrims", precision: nil
+    end
+
+    create_table "hyaenidaes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "forefins", limit: 36, null: false
+      t.bigint "schwarzs", null: false
+      t.text "isoagglutinations", null: false
+      t.datetime "neoimpressionisms", precision: nil, null: false
+      t.datetime "orthodiaenes", precision: nil, null: false
+      t.string "suaviloquences"
+    end
+
+    create_table "brideweeds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "sorrowfuls", limit: 36, null: false
+      t.string "aas", limit: 36, null: false
+      t.boolean "bloodstanches", null: false
+      t.datetime "hakus", precision: nil, null: false
+      t.datetime "bichromics", precision: nil, default: "3000-01-01 00:00:00", null: false
+      t.datetime "birostrateds", precision: nil
+      t.datetime "splenalgics", precision: nil
+    end
+
+    create_table "unurgings", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "kiacks", limit: 36, null: false
+      t.bigint "untimbereds", null: false
+      t.string "ceilidhs", null: false
+      t.string "octavinas", null: false
+      t.string "quiscos"
+      t.datetime "mistrysts", precision: nil
+      t.datetime "amentaceous", precision: nil
+      t.datetime "unembaseds", precision: nil
+      t.datetime "prelithics", precision: nil
+      t.datetime "turnduns", precision: nil
+      t.bigint "gruneritizations"
+      t.boolean "succubas", default: false, null: false
+      t.boolean "turkeries", default: false, null: false
+    end
+
+    create_table "scorpaenoids", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "deozonizes", limit: 36, null: false
+      t.string "engraveds", limit: 36, null: false
+      t.text "viduinaes"
+      t.string "septimetritis", limit: 36
+      t.datetime "unmalignants", precision: nil, null: false
+      t.datetime "oxyopidaes", precision: nil, null: false
+    end
+
+    create_table "acantholyses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "molassies", null: false
+      t.text "unwaggables"
+      t.decimal "corkscrews", precision: 16, scale: 2, default: "0.0"
+      t.datetime "palaeotropicals", precision: nil
+      t.datetime "unactivities", precision: nil
+    end
+
+    create_table "crazies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "angiostomizes"
+      t.string "indivisibles"
+      t.boolean "vintems", default: false
+      t.datetime "undertraineds", precision: nil, null: false
+      t.datetime "cocainomaniacs", precision: nil, null: false
+    end
+
+    create_table "becomingnesses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "nonsidereals", null: false
+      t.integer "undivorceables", limit: 1, null: false
+      t.text "sanoserous", null: false
+      t.integer "pseudonymals", limit: 1, null: false
+      t.datetime "pittsburghers", precision: nil
+      t.datetime "protelytropteras", precision: nil
+      t.string "hyracoids"
+      t.string "anadipsia"
+      t.integer "ultraspiritualisms"
+      t.datetime "mismenstruations", precision: nil
+      t.boolean "nonabsolutes", default: false, null: false
+      t.string "ploys"
+      t.string "cojurors"
+      t.string "unswelleds"
+      t.string "overtimorousnesses"
+      t.string "exuviables", limit: 36
+    end
+
+    create_table "waiata", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "dickeys", null: false
+      t.bigint "octoates", null: false
+      t.text "ras", null: false
+      t.datetime "wagandas", precision: nil
+      t.datetime "ascribes", precision: nil
+    end
+
+    create_table "grots", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.decimal "scupplers", precision: 16, scale: 2
+      t.date "sullenlies"
+      t.boolean "sabbathbreakers", default: false
+      t.bigint "homishes"
+      t.datetime "seateds", precision: nil
+      t.datetime "sororates", precision: nil
+      t.bigint "gelatinifies"
+      t.boolean "achates", default: false, null: false
+    end
+
+    create_table "epiphyllous", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "nonisotropics", null: false
+      t.datetime "spongilies", precision: nil
+      t.datetime "amphimorulas", precision: nil
+      t.integer "uprushes", default: 1, null: false
+      t.datetime "ipomeas", precision: nil
+      t.datetime "pinnatilobates", precision: nil
+    end
+
+    create_table "thanatophidians", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.integer "surveyances"
+      t.bigint "cloakmakings"
+      t.datetime "tyrannouslies", precision: nil
+      t.datetime "integuments", precision: nil
+    end
+
+    create_table "thicknessings", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "brams"
+      t.boolean "thaumaturgia", default: true, null: false
+      t.datetime "existibles", precision: nil, null: false
+      t.bigint "tirribis"
+      t.datetime "ammodytoids", precision: nil
+      t.datetime "reshines", precision: nil
+    end
+
+    create_table "counterparts", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.decimal "discontentednesses", precision: 16, scale: 2
+      t.boolean "culteranismos"
+      t.bigint "amyelics"
+      t.date "kashmiris"
+      t.date "africanisms"
+      t.datetime "bogmires", precision: nil
+      t.datetime "unmanipulateds", precision: nil
+      t.decimal "bassanites", precision: 16, scale: 2
+      t.decimal "ethnics", precision: 16, scale: 2
+      t.bigint "woolshearers"
+      t.bigint "scorzoneras"
+    end
+
+    create_table "extramorainals", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "perfectionistics", null: false
+      t.bigint "hatchels"
+      t.datetime "necropsies", precision: nil
+      t.datetime "homefarers", precision: nil
+      t.string "inspiringlies", null: false
+    end
+
+    create_table "triterpenes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.decimal "thingsteads", precision: 16, scale: 6, null: false
+      t.boolean "wemlesses", null: false
+      t.decimal "concocts", precision: 16, scale: 2, null: false
+      t.decimal "krausens", precision: 16, scale: 2, null: false
+      t.decimal "uncincts", precision: 16, scale: 2, null: false
+      t.bigint "manumotives", null: false
+      t.bigint "aminoformics", null: false
+      t.datetime "thoughtens", precision: nil
+      t.datetime "topazies", precision: nil
+    end
+
+    create_table "nainsels", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.text "raspatories", null: false
+      t.text "onegites", null: false
+      t.text "warmths", null: false
+      t.decimal "butchers", precision: 16, scale: 2, null: false
+      t.decimal "duplas", precision: 16, scale: 2, null: false
+      t.integer "bafflinglies", null: false
+      t.integer "cutchers", null: false
+      t.bigint "tapiocas", null: false
+      t.bigint "unappreciativelies", null: false
+      t.datetime "chronophotographies", precision: nil
+      t.datetime "onomatoplasms", precision: nil
+    end
+
+    create_table "sabdariffas", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "tanquens"
+      t.bigint "woodenwares"
+      t.string "lunches"
+      t.decimal "hemianopsia", precision: 16, scale: 2
+      t.string "tillandsia"
+      t.string "upsups"
+      t.string "filieties"
+      t.string "bank_address_1"
+      t.string "taxeopodies"
+      t.string "cosegments"
+      t.string "unsmoothlies"
+      t.datetime "aistopodes", precision: nil
+      t.datetime "acuations", precision: nil
+      t.bigint "papios"
+      t.string "meromyarians"
+    end
+
+    create_table "zoantharians", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "petreities"
+      t.string "macropinacoidals", null: false
+      t.string "nonclassifications"
+      t.string "hegaris"
+      t.integer "abhorsons"
+      t.datetime "univalves", precision: nil
+      t.datetime "sabbathaians", precision: nil
+      t.datetime "selamins", precision: nil
+    end
+
+    create_table "antimonides", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "lagophthalmos"
+      t.date "steatoceles"
+      t.string "proletarizations"
+      t.datetime "knessets", precision: nil
+      t.decimal "unrejoiceds", precision: 16, scale: 2
+      t.integer "unloyalties"
+      t.datetime "calorimetrics", precision: nil
+      t.datetime "lycopins", precision: nil
+    end
+
+    create_table "hydrobiplanes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "radiothallia"
+      t.bigint "protonephros"
+      t.bigint "malacophyllous"
+      t.decimal "aclouds", precision: 16, scale: 2
+      t.decimal "amphistylics", precision: 16, scale: 2
+      t.decimal "overgenials", precision: 16, scale: 2
+      t.decimal "hillets", precision: 16, scale: 2
+      t.datetime "steaminesses", precision: nil, null: false
+      t.datetime "crankbirds", precision: nil, null: false
+    end
+
+    create_table "ecchymoses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "viddhals", null: false
+      t.decimal "unindulgents", precision: 16, scale: 2, null: false
+      t.decimal "tunbellies", precision: 16, scale: 2, null: false
+      t.decimal "seders", precision: 16, scale: 2, null: false
+      t.decimal "unsatedlies", precision: 16, scale: 2
+      t.decimal "infestives", precision: 16, scale: 2
+      t.string "guanajuatites"
+      t.decimal "shillets", precision: 16, scale: 2
+      t.integer "testamentallies"
+      t.boolean "precanonicals", default: false
+      t.integer "searcloths", limit: 1
+      t.string "predelinquents"
+      t.datetime "brains", precision: nil
+      t.datetime "cocklights", precision: nil
+      t.string "prewashes"
+      t.string "synostoticals"
+    end
+
+    create_table "picidaes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.text "uninstanceds", null: false
+      t.string "billowies", null: false
+      t.string "aeolipiles", null: false
+      t.string "hyperdemocracies", null: false
+      t.string "gesticulates", null: false
+      t.integer "understudies"
+      t.string "multiformeds", null: false
+      t.string "prerupts", limit: 36, null: false
+      t.boolean "favoredlies", null: false
+      t.datetime "notogaeans", precision: nil
+      t.datetime "evenlongs", precision: nil
+      t.string "balanoplasties"
+      t.datetime "teetotals", precision: nil
+    end
+
+    create_table "hackamores", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "metageneses", null: false
+      t.string "helvetians", null: false
+      t.bigint "coxbones", null: false
+      t.datetime "unfadingnesses", precision: nil
+      t.datetime "crins", precision: nil
+      t.bigint "sprangs"
+      t.string "subbourdons"
+      t.integer "renickels", limit: 2
+      t.bigint "ferriers"
+    end
+
+    create_table "ethmomaxillaries", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "pholas", null: false
+      t.string "resents", null: false
+      t.decimal "sublimators", precision: 16, scale: 2, null: false
+      t.decimal "wiltons", precision: 16, scale: 2, null: false
+      t.decimal "multijets", precision: 16, scale: 2
+      t.decimal "fanfoots", precision: 16, scale: 2
+      t.text "delightings"
+      t.text "cochurchwardens"
+      t.text "miners"
+      t.boolean "unnecessarinesses", default: false
+      t.datetime "erotetics", precision: nil
+      t.datetime "plesiomorphous", precision: nil
+      t.boolean "timorous", default: false
+      t.decimal "duers", precision: 16, scale: 2
+      t.boolean "empathizes", default: false, null: false
+      t.bigint "earners"
+      t.string "preconsonantals", limit: 64
+      t.string "parsonishes", limit: 64
+      t.string "cauterizes", limit: 36
+      t.text "promemorials"
+      t.text "pyraustinaes"
+      t.boolean "abromas"
+      t.datetime "corallus", precision: nil
+      t.text "vasifactives"
+      t.bigint "saturnalia"
+      t.bigint "drapes"
+    end
+
+    create_table "sexerns", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "pennales", null: false
+      t.string "bestraughts", null: false
+      t.bigint "nazareans", null: false
+      t.string "minatorilies", null: false
+      t.datetime "hoves", precision: nil
+      t.datetime "mesoseismals", precision: nil
+      t.bigint "superfluxes"
+    end
+
+    create_table "semiparameters", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "pituitaries", null: false
+      t.bigint "murlies", null: false
+      t.string "unarraignables", null: false
+      t.string "proprietaries", null: false
+      t.string "triboroughs", limit: 36, null: false
+      t.datetime "biferous", precision: nil, null: false
+      t.datetime "inexists", precision: nil, null: false
+    end
+
+    create_table "postclimaxes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "aphanites", limit: 36, null: false
+      t.date "aldebarania", null: false
+      t.string "pyruloids", null: false
+      t.string "coarsishes"
+      t.decimal "empididaes", precision: 16, scale: 2
+      t.datetime "sommaites", precision: nil
+      t.datetime "decapitables", precision: nil
+      t.boolean "robigalia", default: false
+    end
+
+    create_table "antiprohibitions", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.decimal "thecals", precision: 16, scale: 2, null: false
+      t.bigint "unmedullateds", null: false
+      t.bigint "marhalas", null: false
+      t.string "barbarizes", limit: 36, null: false
+      t.datetime "shiverweeds", precision: nil
+      t.datetime "counterbores", precision: nil
+    end
+
+    create_table "amullas", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "transversus", limit: 36, null: false
+      t.integer "unconscientiouslies"
+      t.decimal "leverages", precision: 16, scale: 2, null: false
+      t.string "triploidites", null: false
+      t.string "serbdoms", null: false
+      t.string "unlifteds", null: false
+      t.string "hemipodiis", null: false
+      t.integer "anemones", null: false
+      t.datetime "servages", precision: nil
+      t.datetime "endowers", precision: nil
+      t.text "overdiscourages"
+      t.bigint "euphuists"
+      t.bigint "unimpressiblies"
+    end
+
+    create_table "haggards", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "anuretics", limit: 36, null: false
+      t.string "buffers", null: false
+      t.bigint "nauseas", null: false
+      t.datetime "treaders", precision: nil
+      t.string "ruellia"
+      t.datetime "unsnaffleds", precision: nil
+      t.datetime "esophagoscopes", precision: nil
+    end
+
+    create_table "iguanids", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "reasseverates", limit: 36, null: false
+      t.date "demihorses", null: false
+      t.string "hamitals", null: false
+      t.string "chasselas"
+      t.decimal "pseudosolutions", precision: 16, scale: 2
+      t.datetime "outshines", precision: nil
+      t.datetime "consecraters", precision: nil
+      t.boolean "undukes", default: false
+    end
+
+    create_table "lingels", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "tormentedlies", null: false
+      t.string "thanelands"
+      t.string "hangkangs"
+      t.datetime "dawnlikes", precision: nil
+      t.datetime "nongalvanizeds", precision: nil
+    end
+
+    create_table "arcanites", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "brachyfacials", null: false
+      t.bigint "graphorrheas"
+      t.datetime "galactopoieses", precision: nil
+      t.text "unharvesteds"
+      t.datetime "superimpositions", precision: nil, null: false
+      t.datetime "extraterritorialities", precision: nil, null: false
+      t.string "degeneratives", default: "pending"
+    end
+
+    create_table "putriforms", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "liberalities", null: false
+      t.string "meroblastics"
+      t.integer "hotheadeds", limit: 1
+      t.datetime "inkstones", precision: nil, null: false
+      t.datetime "dipneustals", precision: nil, null: false
+    end
+
+    create_table "unblushings", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "humoralisms"
+      t.string "sphinxians"
+      t.string "unexplodeds"
+      t.datetime "undiscourageds", precision: nil, null: false
+      t.datetime "phrenomesmerisms", precision: nil
+      t.datetime "seaquakes", precision: nil, null: false
+      t.datetime "coarbitrators", precision: nil, null: false
+    end
+
+    create_table "unpainstakings", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "nonmorals", null: false
+      t.bigint "kamichis", null: false
+      t.decimal "panichthyophagous", precision: 16, scale: 2
+      t.decimal "recompetitors", precision: 16, scale: 2
+      t.datetime "squadrons", precision: nil, null: false
+      t.datetime "suspendeds", precision: nil, null: false
+      t.string "unconcernedlies", default: "created", null: false
+    end
+
+    create_table "windflaws", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "aloewoods"
+      t.string "sheavelesses"
+      t.datetime "allogeneous", precision: nil
+      t.datetime "gynecratics", precision: nil
+      t.datetime "athenees", precision: nil
+    end
+
+    create_table "mislabors", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "ethanediols", null: false
+      t.bigint "inspirationists", null: false
+      t.datetime "atticals", precision: nil, null: false
+      t.datetime "pyrosulphates", precision: nil, null: false
+      t.string "matreeds"
+      t.bigint "fluoridates"
+      t.bigint "grudgings"
+      t.bigint "unluffeds"
+      t.bigint "bacteriophagous"
+    end
+
+    create_table "katipuneros", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "underagents", null: false
+      t.bigint "circumambiences", null: false
+      t.string "neanderthals", null: false
+      t.text "notopteridaes", null: false
+      t.datetime "clippings", precision: nil
+      t.datetime "nonbilious", precision: nil
+      t.datetime "incommensuratenesses", precision: nil
+      t.string "balineses", limit: 36, null: false
+      t.string "intemperatelies", null: false
+    end
+
+    create_table "heroologists", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.datetime "ennoblements", precision: nil, null: false
+      t.boolean "shrublands", null: false
+      t.bigint "trulies", null: false
+      t.bigint "mesmericals", null: false
+      t.boolean "myoelectrics", null: false
+      t.string "orthics", limit: 36, null: false
+      t.datetime "formalities", precision: nil, null: false
+      t.datetime "unblinds", precision: nil, null: false
+    end
+
+    create_table "interchecks", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "viritrates", null: false
+      t.bigint "philhellenisms", null: false
+      t.datetime "redigests", precision: nil
+      t.datetime "metaloscopes", precision: nil
+      t.string "counterdistinctions"
+    end
+
+    create_table "sorites", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "tinamines", limit: 36, null: false
+      t.bigint "inconstruables", null: false
+      t.string "unhusbandeds", limit: 36, null: false
+      t.bigint "interiorities", null: false
+      t.string "increatelies", limit: 36, null: false
+      t.bigint "northumbers", null: false
+      t.string "unwitherables", limit: 36, null: false
+      t.date "agags", null: false
+      t.integer "frosters", null: false
+      t.string "inviolacies", null: false
+      t.string "bezzos", null: false
+      t.decimal "supersonants", precision: 16, scale: 2, null: false
+      t.decimal "impregnablenesses", precision: 16, scale: 2, null: false
+      t.datetime "mausers", precision: nil, null: false
+      t.datetime "bebrines", precision: nil, null: false
+    end
+
+    create_table "trammelinglies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "reiterateds", limit: 36, null: false
+      t.bigint "shortsighteds", null: false
+      t.string "yurujures", limit: 36, null: false
+      t.bigint "cancans", null: false
+      t.string "germantowns", limit: 36, null: false
+      t.bigint "ungibbets", null: false
+      t.string "unreligioneds", limit: 36, null: false
+      t.date "udalers"
+      t.string "sheepishnesses", null: false
+      t.decimal "transorbitals", precision: 16, scale: 2, null: false
+      t.decimal "ingests", precision: 16, scale: 2, null: false
+      t.decimal "arsines", precision: 16, scale: 2, null: false
+      t.decimal "acutangulars", precision: 16, scale: 2, null: false
+      t.decimal "termitaries", precision: 16, scale: 2, null: false
+      t.decimal "puthers", precision: 16, scale: 2, null: false
+      t.decimal "pyknics", precision: 16, scale: 2, null: false
+      t.decimal "saunas", precision: 16, scale: 2, null: false
+      t.decimal "lokets", precision: 16, scale: 2, null: false
+      t.decimal "unmindfullies", precision: 16, scale: 2, null: false
+      t.decimal "grandfatherships", precision: 16, scale: 2, null: false
+      t.decimal "unidealistics", precision: 16, scale: 2, null: false
+      t.decimal "repursues", precision: 16, scale: 2, null: false
+      t.decimal "smiris", precision: 16, scale: 2, null: false
+      t.datetime "jargons", precision: nil, null: false
+      t.datetime "pneumatotherapeutics", precision: nil, null: false
+    end
+
+    create_table "reracks", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "amesites", limit: 36, null: false
+      t.bigint "augurs", null: false
+      t.string "deserves", limit: 36, null: false
+      t.bigint "provisionalnesses"
+      t.string "extricablies", limit: 36
+      t.bigint "sublethals", null: false
+      t.string "aladfars", limit: 36, null: false
+      t.date "pseudostalactiticals", null: false
+      t.string "delomorphous", null: false
+      t.string "courts", null: false
+      t.decimal "revelationists", precision: 16, scale: 2, null: false
+      t.decimal "mycetophilidaes", precision: 16, scale: 2, null: false
+      t.decimal "underdevelops", precision: 16, scale: 2, null: false
+      t.decimal "pipkins", precision: 16, scale: 2, null: false
+      t.decimal "modalists", precision: 16, scale: 2, null: false
+      t.boolean "unthumpeds", null: false
+      t.datetime "scalewises", precision: nil, null: false
+      t.datetime "ethaldehydes", precision: nil, null: false
+    end
+
+    create_table "perchlorates", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "filars"
+      t.datetime "townlies", precision: nil
+      t.bigint "clannings", null: false
+      t.integer "tiptopsomes"
+      t.datetime "procidences", precision: nil
+      t.datetime "preinterviews", precision: nil
+    end
+
+    create_table "temblors", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "chromotropisms", null: false
+      t.string "ungainsayablies", null: false
+      t.string "ragsorters"
+      t.datetime "lewisites", precision: nil
+      t.datetime "polyphonisms", precision: nil
+    end
+
+    create_table "punnables", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "presystoles", null: false
+      t.text "animateds"
+      t.datetime "reimages", precision: nil
+      t.datetime "abasia", precision: nil
+      t.string "mysels", null: false
+    end
+
+    create_table "palminerveds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "pseudoparasitics"
+      t.bigint "specklies"
+      t.boolean "rackfuls"
+      t.datetime "myas", precision: nil
+      t.datetime "appointables", precision: nil
+      t.bigint "cotises"
+      t.datetime "nonagreements", precision: nil
+      t.string "barouchets"
+    end
+
+    create_table "misanthropizes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "carbamines", limit: 36, null: false
+      t.string "unneedfuls"
+      t.bigint "petitors", null: false
+      t.datetime "indicatives", precision: nil
+      t.datetime "unoccludeds", precision: nil
+      t.string "psychrophores"
+      t.text "counterfallers"
+      t.integer "concubinaries"
+    end
+
+    create_table "pseudoperculars", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "contrates", limit: 36, null: false
+      t.datetime "elaterids", precision: nil, null: false
+      t.datetime "mozarabs", precision: nil, null: false
+      t.string "rhizoctonioses", limit: 36, null: false
+      t.string "unworkables", limit: 36, null: false
+    end
+
+    create_table "warlikenesses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "roys", limit: 36, null: false
+      t.string "eleonorites", null: false
+      t.datetime "lymphocytes", precision: nil, null: false
+      t.datetime "terebellums", precision: nil, null: false
+    end
+
+    create_table "whosomevers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "overchecks", null: false
+      t.string "turkeyberries", null: false
+      t.text "pretrains"
+      t.text "toxicotraumatics", null: false
+      t.integer "phoenicaceous"
+      t.string "destines", limit: 36, null: false
+      t.datetime "putridlies", precision: nil
+      t.datetime "boeotics", precision: nil, null: false
+      t.datetime "unpaireds", precision: nil, null: false
+      t.string "intransmissibles", null: false
+      t.string "hypericaceaes", null: false
+      t.string "incompatibles", null: false
+      t.string "unbendingnesses", null: false
+      t.boolean "perifolliculitis", default: false
+      t.string "paraperiodics"
+      t.string "ptenoglossas"
+    end
+
+    create_table "dungeoners", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "overtreatments", null: false
+      t.string "theokrasia", null: false
+      t.float "neuromatoses", null: false
+      t.boolean "corders", default: false, null: false
+      t.boolean "slicklies", default: false, null: false
+      t.boolean "preparietals", default: false, null: false
+      t.boolean "solicitous", default: false, null: false
+      t.boolean "carps", default: false, null: false
+      t.boolean "dewaters", default: false, null: false
+      t.datetime "broches", precision: nil
+      t.datetime "laggens", precision: nil
+    end
+
+    create_table "vellalas", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "rompies", null: false
+      t.string "counterrestorations", null: false
+      t.text "tecnoctonia"
+      t.datetime "fissirostrals", precision: nil
+      t.datetime "abhenries", precision: nil
+      t.datetime "limbats", precision: nil, null: false
+      t.bigint "polystomidaes"
+      t.bigint "witchwomen"
+      t.string "palaverists"
+      t.string "unfarceds", limit: 36
+    end
+
+    create_table "aldoximes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "gantlets", null: false
+      t.text "chlorometries", size: :medium
+      t.datetime "mediodigitals", precision: nil, null: false
+      t.datetime "coenoecics", precision: nil, null: false
+    end
+
+    create_table "tabus", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "proteinochromogens", null: false
+      t.decimal "outrushes", precision: 16, scale: 15, default: "0.0"
+      t.decimal "tiliaceous", precision: 16, scale: 15, default: "0.0"
+      t.text "groomers"
+      t.datetime "camphanics", precision: nil, null: false
+      t.datetime "dairymen", precision: nil, null: false
+      t.text "staymakers"
+    end
+
+    create_table "spirignathous", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "baynesses", null: false
+      t.bigint "tipproofs"
+      t.string "harmfulnesses", null: false
+      t.integer "darlingtonia", default: 0, null: false
+      t.datetime "fruitists", precision: nil, null: false
+      t.datetime "homogenous", precision: nil, null: false
+      t.string "withinwards"
+    end
+
+    create_table "kurumayas", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "luminists"
+      t.string "angiotonins"
+      t.datetime "electrocapillarities", precision: nil
+      t.datetime "polyangia", precision: nil
+    end
+
+    create_table "parrotlikes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "wanthills"
+      t.string "scientizes"
+      t.string "atonalities"
+      t.date "ambulatoria"
+      t.string "thomsonites"
+      t.string "bushvelds"
+      t.boolean "microseconds"
+      t.string "gangliitis"
+      t.string "tarwoods"
+      t.bigint "frabjouslies"
+      t.datetime "cochals", precision: nil, null: false
+      t.datetime "irregenerations", precision: nil, null: false
+      t.bigint "honeworts"
+      t.bigint "entothoraxes"
+      t.boolean "maxillas"
+      t.string "toyhouses", limit: 36
+      t.string "runovers"
+      t.boolean "amphitriaenes", default: false, null: false
+    end
+
+    create_table "kawikas", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "larbolins", null: false
+      t.bigint "rarefications", null: false
+      t.string "unobtrudeds", null: false
+      t.string "repersuades", null: false
+      t.datetime "repegs", precision: nil, null: false
+      t.datetime "subgenuals", precision: nil
+      t.bigint "scatterers", null: false
+      t.datetime "kavasses", precision: nil
+      t.datetime "millworkers", precision: nil
+      t.datetime "paratoluidines", precision: nil
+      t.datetime "brutishlies", precision: nil
+      t.string "indrafts", limit: 36
+      t.text "horticultures"
+      t.text "tarmineds"
+    end
+
+    create_table "waiklies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "appendicalgia", limit: 36, null: false
+      t.string "peroxies", limit: 36, null: false
+      t.string "protothecas", limit: 36, null: false
+      t.datetime "gobiesoxes", precision: nil, null: false
+      t.bigint "pharyngotherapies", null: false
+      t.string "guauaenoks", limit: 50
+      t.string "flockers", limit: 50
+      t.datetime "hagiographals", precision: nil
+      t.datetime "sweetishes", precision: nil
+      t.datetime "himyarites", precision: nil
+    end
+
+    create_table "diaphanousnesses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "petroxolins", limit: 36, null: false
+      t.string "anticastes", limit: 36, null: false
+      t.datetime "noncontradictories", precision: nil, null: false
+      t.bigint "oakesia", null: false
+      t.string "rubbleworks", limit: 50
+      t.string "zermahbubs", limit: 50
+      t.datetime "blattariaes", precision: nil
+      t.datetime "bushmasters", precision: nil
+      t.datetime "auditions", precision: nil
+    end
+
+    create_table "mbalolos", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "eligiblenesses", null: false
+      t.string "pharynges", limit: 36, null: false
+      t.bigint "chorials", null: false
+      t.string "thoracomelus", limit: 50
+      t.string "maliciousnesses", limit: 50
+      t.bigint "boltmakers"
+      t.string "levorotatories", limit: 50
+      t.datetime "darnings", precision: nil, null: false
+      t.datetime "odiouslies", precision: nil, null: false
+    end
+
+    create_table "ornithodelphia", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "sorghums", limit: 36, null: false
+      t.string "segregationals", limit: 36, null: false
+      t.datetime "delegalizes", precision: nil, null: false
+      t.bigint "unbefriends", null: false
+      t.string "vermivorous", limit: 50
+      t.string "manihots", limit: 50
+      t.datetime "sequacious", precision: nil
+      t.datetime "procrastinatings", precision: nil
+      t.datetime "dearworthinesses", precision: nil
+    end
+
+    create_table "brules", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "blennostases", limit: 36, null: false
+      t.datetime "monobutyrins", precision: nil, null: false
+      t.datetime "athletics", precision: nil, null: false
+      t.bigint "moosehoods", null: false
+      t.string "fevergums", limit: 50
+      t.string "oldermosts", limit: 50
+      t.datetime "tutworkers", precision: nil
+      t.datetime "becassockeds", precision: nil
+      t.datetime "crawberries", precision: nil
+    end
+
+    create_table "morosenesses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "meninginas"
+      t.bigint "congers"
+      t.string "distastefuls"
+      t.text "iodobehenates", null: false
+      t.integer "irredentials", limit: 1, default: 0, null: false
+      t.datetime "agomphious", precision: nil
+      t.datetime "roamings", precision: nil
+      t.integer "graminaceaes", limit: 1, default: 0, null: false
+      t.string "privilegers"
+      t.bigint "discophores"
+      t.string "unracks"
+    end
+
+    create_table "aminoaciduria", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "amphipodals"
+      t.datetime "postcommunicants", precision: nil
+      t.datetime "generalizers", precision: nil
+      t.string "fenianisms"
+    end
+
+    create_table "topazines", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "arthropodals", limit: 36, null: false
+      t.text "respondes", null: false
+      t.datetime "pyoxanthoses", precision: nil
+      t.datetime "farmyardies", precision: nil
+      t.string "pterocaryas", null: false
+    end
+
+    create_table "unfistulous", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "merelies", limit: 36, null: false
+      t.string "orthocarpous", null: false
+      t.string "meanlies", null: false
+      t.string "antiskiddings", null: false
+      t.bigint "habilimentations", null: false
+      t.string "disquisitivelies", null: false
+      t.bigint "eyelets"
+      t.datetime "ophthalmodiastimeters", precision: nil
+      t.datetime "monosteles", precision: nil
+    end
+
+    create_table "jinnies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "readablies", limit: 36, null: false
+      t.string "workpeople", null: false
+      t.bigint "preprohibitions", null: false
+      t.string "electroanalyses", null: false
+      t.integer "zaptiahs", null: false
+      t.bigint "straggles", null: false
+      t.string "sarcles", null: false
+      t.datetime "vulturishes", precision: nil, null: false
+      t.datetime "beata", precision: nil, null: false
+      t.bigint "cycadofilicineans", null: false
+      t.datetime "indus", precision: nil
+      t.datetime "nonreportables", precision: nil
+    end
+
+    create_table "taums", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "bushis", limit: 36, null: false
+      t.string "strongbraineds", null: false
+      t.bigint "salays", null: false
+      t.string "cardiorespiratories", null: false
+      t.bigint "uralia", null: false
+      t.text "preconsciouslies", size: :medium
+      t.datetime "irresolvablenesses", precision: nil
+      t.datetime "jussories", precision: nil
+    end
+
+    create_table "obols", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.datetime "phanerics", precision: nil
+      t.string "hepatologists"
+      t.text "hydroscopics", size: :medium
+      t.bigint "unpeaces"
+      t.string "hockdays"
+      t.datetime "doketisms", precision: nil
+      t.datetime "flimflams", precision: nil
+    end
+
+    create_table "unwaxeds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "ethanedials", null: false
+      t.string "pierinaes", null: false
+      t.datetime "pimplas", precision: nil, null: false
+      t.datetime "ediblenesses", precision: nil
+      t.datetime "nonveterans", precision: nil
+      t.datetime "acataposes", precision: nil
+      t.string "amarths"
+    end
+
+    create_table "daygoings", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "remixtures"
+      t.string "abneurals"
+      t.string "baskers"
+      t.bigint "sialosemeiologies"
+      t.string "comenics"
+      t.string "folds"
+      t.boolean "maggotpies"
+      t.boolean "cuddies"
+      t.boolean "pyrheliometrics"
+      t.boolean "rebids"
+      t.text "blithenesses"
+      t.datetime "heteroclitous", precision: nil
+      t.datetime "dangerlesses", precision: nil
+      t.boolean "waysiders"
+      t.datetime "beaverkills", precision: nil
+      t.string "abhorrings"
+      t.datetime "shimmers", precision: nil
+    end
+
+    create_table "mungies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "flaunters"
+      t.string "nephrolysins"
+      t.integer "presettles"
+      t.integer "intermarginals"
+      t.integer "raceabouts"
+      t.integer "circumnuclears"
+      t.string "landways"
+      t.text "idealisticals"
+      t.datetime "catholicals", precision: nil
+      t.datetime "knobbers", precision: nil
+    end
+
+    create_table "styraxes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "uinta", null: false
+      t.bigint "pterostigmatics", null: false
+      t.string "microfossils", null: false
+      t.string "aldines"
+      t.string "foreflaps"
+      t.string "unresumptives"
+      t.string "merychippus"
+      t.datetime "cartages", precision: nil
+      t.integer "wannesses", default: 0, null: false
+      t.datetime "unironeds", precision: nil, null: false
+      t.datetime "becks", precision: nil, null: false
+    end
+
+    create_table "sclerocaulies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "perambulates", null: false
+      t.bigint "nutties", null: false
+      t.datetime "shovelards", precision: nil
+      t.datetime "formularizes", precision: nil
+    end
+
+    create_table "abstracteds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "integrallies"
+      t.date "sicklerites"
+      t.boolean "halophytisms", default: false
+      t.string "chancers"
+      t.string "scratchablies"
+      t.boolean "opprobriates", default: false
+      t.decimal "shools", precision: 16, scale: 2, default: "0.0"
+      t.decimal "brahmanis", precision: 16, scale: 2
+      t.string "borines"
+      t.decimal "sheenies", precision: 16, scale: 6
+      t.decimal "hiortdahlites", precision: 16, scale: 6, default: "0.0"
+      t.decimal "proaulions", precision: 16, scale: 6, default: "0.0"
+      t.text "oysters"
+      t.datetime "cerithioids", precision: nil, null: false
+      t.datetime "placoganoids", precision: nil, null: false
+      t.text "precompasses"
+      t.string "moonlighters"
+    end
+
+    create_table "hakenkreuzlers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "liberalizers"
+      t.date "polytrichous"
+      t.string "stethoscopies"
+      t.text "longobards"
+      t.datetime "asparagines", precision: nil, null: false
+      t.datetime "oblatelies", precision: nil, null: false
+      t.decimal "alkools", precision: 16, scale: 6
+      t.decimal "unconcerteds", precision: 16, scale: 6
+      t.boolean "gritlesses", default: false
+      t.boolean "serobiologicals", default: false, null: false
+    end
+
+    create_table "phosphyls", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "androecials"
+      t.string "inermia"
+      t.text "sorbins"
+      t.datetime "interoffices", precision: nil, null: false
+      t.datetime "anthozoas", precision: nil, null: false
+    end
+
+    create_table "pollenlesses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "witcheries", null: false
+      t.integer "battleships"
+      t.string "pipelines"
+      t.string "countrypeople"
+      t.datetime "flawfuls", precision: nil, null: false
+      t.datetime "desmidiales", precision: nil, null: false
+      t.boolean "subirrigations", default: false, null: false
+    end
+
+    create_table "defouls", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "nonasphalts", limit: 36, null: false
+      t.string "psychoclinicals", limit: 36, null: false
+      t.string "aspidiotus", null: false
+      t.string "satyrinaes"
+      t.string "phraseographics"
+      t.integer "moneygrubbers"
+      t.datetime "vitascopics", precision: nil
+      t.datetime "nonarmigerous", precision: nil, null: false
+      t.datetime "trophoneuroses", precision: nil, null: false
+    end
+
+    create_table "asteroidals", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "occultlies", null: false
+      t.boolean "unsquires"
+      t.string "nigerians"
+      t.string "merchantablenesses"
+      t.string "inexplicitlies"
+      t.string "panhandles"
+      t.string "catholicizers"
+      t.bigint "sedats"
+      t.date "asientos"
+      t.string "aerograms"
+      t.string "eleutherozoans"
+      t.string "persuadablies"
+      t.string "edd_account_security_question_1"
+      t.string "edd_account_security_answer_1"
+      t.string "edd_account_security_question_2"
+      t.string "edd_account_security_answer_2"
+      t.string "edd_account_security_question_3"
+      t.string "edd_account_security_answer_3"
+      t.string "edd_account_security_question_4"
+      t.string "edd_account_security_answer_4"
+      t.datetime "piligans", precision: nil, null: false
+      t.datetime "rattlers", precision: nil, null: false
+      t.boolean "exhilaratinglies"
+      t.date "churnabilities"
+    end
+
+    create_table "lesghs", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "cheliferideas", null: false
+      t.string "gunsticks"
+      t.string "polyenzymatics", null: false
+      t.text "pothuntings", null: false
+      t.string "woodroofs", null: false
+      t.date "accommodations", null: false
+      t.bigint "ceroplastics", null: false
+      t.string "prelacteals", null: false
+      t.datetime "lathesmen", precision: nil, null: false
+      t.datetime "aldoheptoses", precision: nil, null: false
+    end
+
+    create_table "foreshadowers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "wedgies", limit: 36, null: false
+      t.string "hypertorrids", limit: 36, null: false
+      t.string "pulsatives"
+      t.text "chytridials", null: false
+      t.string "overcomes", limit: 6, null: false
+      t.date "overcoys", null: false
+      t.string "cheirographies", null: false
+      t.bigint "negativelies", null: false
+      t.string "cylindricallies", null: false
+      t.datetime "dendrodus", precision: nil, null: false
+      t.datetime "cheatings", precision: nil, null: false
+      t.boolean "duckies"
+      t.boolean "dociles"
+      t.boolean "hungaria"
+      t.boolean "skirlcocks"
+    end
+
+    create_table "egols", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "focaloids", null: false
+      t.bigint "catchflies", null: false
+      t.string "noncapsizables", null: false
+      t.integer "cyrillics", default: 0, null: false
+      t.datetime "polynucleolars", precision: nil, null: false
+      t.datetime "unforgivings", precision: nil, null: false
+    end
+
+    create_table "cayapas", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "gilberts", null: false
+      t.bigint "sirenoideis", null: false
+      t.string "capmints", null: false
+      t.datetime "semidilapidations", precision: nil
+    end
+
+    create_table "anteroventrallies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "forjeskets", null: false
+      t.bigint "solitidals", null: false
+      t.string "chromophobics"
+      t.string "leakages"
+      t.integer "parochins"
+      t.datetime "entrancinglies", precision: nil
+      t.datetime "eroticallies", precision: nil, null: false
+      t.datetime "protoapostates", precision: nil, null: false
+    end
+
+    create_table "knappers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "threptics", null: false
+      t.string "karyoschises", null: false
+      t.string "pandemonia", null: false
+      t.string "triglochins"
+      t.string "conchoids"
+      t.string "homomorphies"
+      t.integer "structuralizations"
+      t.datetime "urucus", precision: nil
+      t.datetime "unfledgeds", precision: nil, null: false
+      t.datetime "microbrachia", precision: nil, null: false
+      t.bigint "extraneities", null: false
+      t.string "soords", limit: 36, collation: "ascii_general_ci"
+      t.bigint "stusses"
+    end
+
+    create_table "squillidaes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "postliminies", limit: 36, null: false
+      t.bigint "yares", null: false
+      t.string "satinies", limit: 2, null: false
+      t.bigint "stylizations", null: false
+      t.datetime "unshamefuls", precision: nil, null: false
+      t.datetime "imbibitions", precision: nil, null: false
+    end
+
+    create_table "wagerers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "myriapods", limit: 36, null: false
+      t.string "oenanthyls", limit: 36, null: false
+      t.boolean "lithemics", default: false, null: false
+      t.date "clegs", null: false
+      t.datetime "misbills", precision: nil, null: false
+      t.datetime "teels", precision: nil, null: false
+    end
+
+    create_table "smoothboreds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "quinquepedals", limit: 36, null: false
+      t.string "aenaches", limit: 36, null: false
+      t.string "vages", null: false
+      t.string "antihemolysins"
+      t.string "exocyclicas"
+      t.string "idioblasts"
+      t.string "recurs"
+      t.string "outstations"
+      t.string "trumpets"
+      t.string "mammulas", null: false
+      t.decimal "capetonians", precision: 16, scale: 2, default: "0.0", null: false
+      t.string "sandans"
+      t.string "bookmarkers"
+      t.string "myliobatoids"
+      t.string "cinenegatives", null: false
+      t.date "monarchianists"
+      t.boolean "berolls"
+      t.string "street_1", null: false
+      t.string "street_2"
+      t.string "oversmites", null: false
+      t.string "hyperthyroidizations", null: false
+      t.string "crustaceous", null: false
+      t.datetime "episcopallies", precision: nil, null: false
+      t.datetime "smelleds", precision: nil, null: false
+    end
+
+    create_table "zoogeologies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "subjectednesses", null: false
+      t.string "coheritors", null: false
+      t.string "cabosheds", null: false
+      t.string "ticketings"
+      t.string "kroons"
+      t.string "uniphases"
+      t.string "hussites", null: false
+      t.date "quinopyrins"
+      t.string "chapelgoers"
+      t.string "kallimas"
+      t.datetime "dusknesses", precision: nil, null: false
+      t.datetime "dioceses", precision: nil, null: false
+      t.string "sootherers"
+    end
+
+    create_table "crabbedlies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "purehearteds", limit: 36, null: false
+      t.string "curvesomenesses", limit: 36, null: false
+      t.bigint "helladians", null: false
+      t.string "bassies", null: false
+      t.date "diarrhetics", null: false
+      t.date "isosulphides", null: false
+      t.decimal "unferreteds", precision: 16, scale: 2, default: "0.0", null: false
+      t.integer "junta", null: false
+      t.datetime "conventionisms", precision: nil, null: false
+      t.datetime "teutonizes", precision: nil, null: false
+    end
+
+    create_table "minders", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "dogshores", null: false
+      t.string "metamerous", null: false
+      t.string "pseudoperiodics"
+      t.string "frigolabiles"
+      t.string "entomophthorous"
+      t.string "triosteums"
+      t.string "asporous"
+      t.string "misinclinations"
+      t.string "ophelimities"
+      t.string "carbonous"
+      t.datetime "unanimatedlies", precision: nil
+      t.datetime "ashrafis", precision: nil
+    end
+
+    create_table "wolfishlies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "forthbrings", limit: 36, null: false, collation: "ascii_general_ci"
+      t.string "quadrivalences", limit: 36, null: false
+      t.string "portmanteauxes", limit: 36, null: false
+      t.string "jodelrs", null: false
+      t.string "crums"
+      t.datetime "unplats", precision: nil, null: false
+      t.datetime "acotyledonous", precision: nil
+      t.datetime "thioantimonites", precision: nil
+    end
+
+    create_table "anothers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "holdinglies", limit: 36, null: false
+      t.bigint "enamellists", null: false
+      t.string "worthlesses", null: false
+      t.datetime "twaddells", precision: nil
+      t.datetime "scaphitoids", precision: nil
+    end
+
+    create_table "longfins", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "alchemistries", limit: 36, null: false
+      t.bigint "steganopodes", null: false
+      t.string "magnesians", null: false
+      t.string "maria", null: false
+      t.string "brutings", null: false
+      t.date "dromotropics"
+      t.date "parabranchiates"
+      t.datetime "bombasticallies", precision: nil
+      t.datetime "camphors", precision: nil
+      t.date "aliptes"
+    end
+
+    create_table "speechings", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "erinaceus", limit: 36, null: false
+      t.bigint "seirospores", null: false
+      t.string "poulardizes", limit: 100, null: false
+      t.datetime "zoosporangiophores", precision: nil, null: false
+      t.datetime "palmfuls", precision: nil, null: false
+    end
+
+    create_table "joggleworks", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "septans", limit: 36, null: false
+      t.bigint "horologicallies", null: false
+      t.decimal "bariles", precision: 16, scale: 2
+      t.decimal "coroplasts", precision: 16, scale: 2
+      t.text "dwellings"
+      t.datetime "flashlights", precision: nil
+      t.datetime "papyrians", precision: nil
+      t.string "onionets", limit: 36
+    end
+
+    create_table "loyalties", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "unpleasurablies", limit: 36, null: false
+      t.bigint "brachistocephalis", null: false
+      t.bigint "purposivenesses", null: false
+      t.string "subconformables", limit: 100, null: false
+      t.datetime "wailakis", precision: nil, null: false
+      t.datetime "peculiarisms", precision: nil, null: false
+    end
+
+    create_table "synapses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "overstalleds", limit: 36, null: false
+      t.string "omnifariouslies"
+      t.boolean "eptatretidaes", default: false
+      t.string "eosins"
+      t.integer "hemelytrals"
+      t.datetime "pharyngitis", precision: nil
+      t.datetime "ungarrisoneds", precision: nil
+    end
+
+    create_table "girouettisms", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.date "bottleflowers"
+      t.string "exteriorates"
+      t.string "disomatics"
+      t.string "canaans"
+      t.string "address_line_1"
+      t.string "address_line_2"
+      t.string "ariels"
+      t.string "helmets"
+      t.string "appalachians"
+      t.string "cardiopericarditis"
+      t.date "tolylenes"
+      t.string "joyfullies"
+      t.date "dids"
+      t.datetime "superspinous", precision: nil, null: false
+      t.datetime "ekahas", precision: nil, null: false
+      t.string "dilutions"
+      t.string "textiferous"
+      t.string "caryopilites"
+      t.string "supraclavicles"
+      t.string "id_card1_number"
+      t.string "id_card1_state"
+      t.string "id_card1_country"
+      t.string "id_card1_type"
+      t.string "id_card2_number"
+      t.string "id_card2_state"
+      t.string "id_card2_country"
+      t.string "id_card2_type"
+      t.bigint "melographics"
+    end
+
+    create_table "akenobeites", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.integer "unexculpables"
+      t.string "eliminators"
+      t.string "reremouses"
+      t.date "hemoglobinurics"
+      t.datetime "lochus", precision: nil, null: false
+      t.datetime "cellars", precision: nil, null: false
+    end
+
+    create_table "syodicons", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "heliotropes"
+      t.date "snerps"
+      t.decimal "ichthyophagians", precision: 16, scale: 2
+      t.decimal "unintersecteds", precision: 16, scale: 2
+      t.decimal "rollinia", precision: 16, scale: 2
+      t.decimal "nondichotomous", precision: 16, scale: 2
+      t.date "ursolics"
+      t.date "hezrons"
+      t.decimal "porules", precision: 16, scale: 2
+      t.string "couthilies"
+      t.boolean "acosmics"
+      t.date "chemis"
+      t.datetime "gangrels", precision: nil, null: false
+      t.datetime "failings", precision: nil, null: false
+      t.string "evocatrixes"
+      t.string "vermicules"
+      t.decimal "eparterials", precision: 16, scale: 2
+      t.string "breakoffs", default: "ACHCO", null: false
+    end
+
+    create_table "circumflects", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "soodlies", null: false
+      t.bigint "misappreciations"
+      t.string "platycephalidaes"
+      t.decimal "ciliaries", precision: 16, scale: 2, null: false
+      t.datetime "syndactylous", precision: nil
+      t.datetime "coemployees", precision: nil
+      t.string "myriologicals"
+      t.string "dictatresses"
+      t.bigint "septennialists"
+    end
+
+    create_table "zoophorus", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "anta"
+      t.string "fightables"
+      t.string "riotinglies"
+      t.datetime "precontaineds", precision: nil
+      t.decimal "debilitateds", precision: 16, scale: 2
+      t.string "reambitious"
+      t.string "quadriloculars"
+      t.string "acephalocysts"
+      t.date "spookologicals"
+      t.datetime "parnellites", precision: nil, null: false
+      t.datetime "osirifications", precision: nil, null: false
+      t.string "hippeds"
+    end
+
+    create_table "staphyleaceous", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "ledens", null: false
+      t.string "niyogas", null: false
+      t.string "underbishoprics", null: false
+      t.string "pseudoprofessorials"
+      t.boolean "preallows", null: false
+      t.datetime "modulos", precision: nil, null: false
+      t.datetime "metabolizables", precision: nil, null: false
+      t.string "porties"
+      t.string "flaughts"
+    end
+
+    create_table "trochis", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.integer "towhees"
+      t.datetime "dermoidectomies", precision: nil, null: false
+      t.datetime "plutarchians", precision: nil, null: false
+      t.string "binaurals", null: false
+      t.string "phascolarctinaes", null: false
+      t.string "outwings"
+      t.string "crookbills"
+    end
+
+    create_table "hades", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "stonewares", null: false
+      t.bigint "pachyperitonitis", null: false
+      t.datetime "aediles", precision: nil
+      t.datetime "rheics", precision: nil
+    end
+
+    create_table "virials", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "wins", null: false
+      t.boolean "midshipmen", default: false
+      t.datetime "diplopodics", precision: nil, null: false
+      t.datetime "lautarites", precision: nil, null: false
+    end
+
+    create_table "ultimobranchials", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "sheep"
+      t.bigint "fulvidnesses"
+      t.integer "verticallies"
+      t.datetime "focallies", precision: nil, null: false
+      t.datetime "pseudepisematics", precision: nil, null: false
+      t.text "palaestras"
+    end
+
+    create_table "circinates", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.boolean "coras", default: true, null: false
+      t.string "symphenomenas", null: false
+      t.string "signalizes", null: false
+      t.string "aweathers", null: false
+      t.integer "unsheathings", limit: 1, null: false
+      t.datetime "overjaweds", precision: nil, null: false
+      t.datetime "flautinos", precision: nil, null: false
+    end
+
+    create_table "streptobacillus", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "luxuries", null: false
+      t.bigint "metics", null: false
+      t.string "ludicroserious"
+      t.datetime "objectionablenesses", precision: nil, null: false
+      t.datetime "antianthraxes", precision: nil, null: false
+    end
+
+    create_table "puriris", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "etherifies", null: false
+      t.bigint "unslaggeds", null: false
+      t.datetime "staidlies", precision: nil
+      t.datetime "trophylesses", precision: nil
+    end
+
+    create_table "wrappings", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "nondirections", null: false
+      t.datetime "comparabilities", precision: nil
+      t.datetime "floriculturallies", precision: nil, null: false
+      t.datetime "clerklesses", precision: nil, null: false
+      t.bigint "enteradenologicals"
+      t.string "nemoricoles"
+    end
+
+    create_table "nonoxygenous", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.integer "earscrews", default: 0
+      t.string "pseudographs"
+      t.bigint "malaccas"
+      t.datetime "leuchaemia", precision: nil
+      t.datetime "weismannisms", precision: nil
+    end
+
+    create_table "awastes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "unbuskins"
+      t.bigint "untwirls"
+      t.string "submarinisms"
+      t.bigint "ginglymostomoids"
+      t.string "sailies"
+      t.string "velloziaceaes", limit: 128
+      t.datetime "spheromeres", precision: nil
+    end
+
+    create_table "pipiles", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "gastropodans"
+      t.integer "misaffecteds", default: 0
+    end
+
+    create_table "scandics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "decaphyllous", limit: 36, null: false
+      t.string "hybrids", limit: 36, null: false
+      t.string "fenestellas", limit: 36, null: false
+      t.date "indoctrinations", null: false
+      t.date "mainpernables"
+      t.datetime "deformations", precision: nil
+      t.datetime "scrimpinglies", precision: nil
+      t.string "beeches"
+      t.string "epiblastemas", limit: 36
+    end
+
+    create_table "puppilies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "glens", limit: 36, null: false
+      t.datetime "tollpennies", precision: nil
+      t.datetime "vanishments", precision: nil
+      t.string "pseudosweatings", limit: 36, null: false
+      t.string "backstrings", null: false
+      t.string "temporarinesses", null: false
+    end
+
+    create_table "hexes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "geostatics", limit: 36, null: false
+      t.datetime "whatnas", precision: nil
+      t.datetime "clausiliidaes", precision: nil
+      t.string "colans", null: false
+      t.string "ornithics", null: false
+      t.bigint "periotics", null: false
+      t.datetime "incomprehensiblenesses", precision: nil, null: false
+      t.string "cribworks", null: false
+    end
+
+    create_table "leafs", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.datetime "jewishlies", precision: nil, null: false
+      t.datetime "probationerships", precision: nil, null: false
+      t.string "desulphurizations", limit: 36, null: false
+      t.bigint "syngnathas", null: false
+      t.bigint "maioids", null: false
+      t.string "plainbacks", limit: 36, null: false
+      t.date "fleetings", null: false
+    end
+
+    create_table "scandalmongerings", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.datetime "anatomizations", precision: nil, null: false
+      t.datetime "frayings", precision: nil, null: false
+      t.string "olivia", limit: 36, null: false
+      t.bigint "prostatitics", null: false
+      t.boolean "surpassings", null: false
+      t.bigint "antipsorics", null: false
+      t.boolean "matchcoats", null: false
+    end
+
+    create_table "ingenerabilities", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.datetime "alarmings", precision: nil, null: false
+      t.datetime "circumoesophagals", precision: nil, null: false
+      t.string "sapsuckers", limit: 36, null: false
+      t.bigint "oligopolies", null: false
+      t.boolean "cornus", null: false
+      t.bigint "mixablenesses", null: false
+      t.string "herdbooks", limit: 36, null: false
+      t.boolean "slavemongers", null: false
+    end
+
+    create_table "meaks", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.datetime "revolubilities", precision: nil, null: false
+      t.datetime "tripelikes", precision: nil, null: false
+      t.string "sclerotitis", limit: 36, null: false
+      t.bigint "cucullas", null: false
+      t.string "moreovers", limit: 2, null: false
+      t.decimal "fitfullies", precision: 16, scale: 6
+      t.decimal "irishwomen", precision: 16, scale: 6
+    end
+
+    create_table "coarsenesses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.datetime "persuadeds", precision: nil, null: false
+      t.datetime "scrimpnesses", precision: nil, null: false
+      t.string "jockeylikes", limit: 36, null: false
+      t.bigint "restainables", null: false
+      t.bigint "levellies", null: false
+    end
+
+    create_table "cachinnations", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.datetime "uvularlies", precision: nil, null: false
+      t.datetime "geissolomataceaes", precision: nil, null: false
+      t.string "absolutories", limit: 36, null: false
+      t.bigint "unhandies", null: false
+      t.string "observables", limit: 2, null: false
+      t.decimal "latticinios", precision: 16, scale: 6
+      t.decimal "methoxychlors", precision: 16, scale: 6
+    end
+
+    create_table "whithers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.datetime "unpityingnesses", precision: nil, null: false
+      t.datetime "bearbanes", precision: nil, null: false
+      t.string "hydrous", limit: 36, null: false
+      t.bigint "unhystericals", null: false
+      t.string "upcomes", limit: 36, null: false
+      t.string "phytotopographicals"
+      t.string "wunnas", limit: 2
+      t.string "morallesses"
+      t.string "dendrochronologies", null: false
+      t.string "unpledgeds", limit: 2, null: false
+      t.string "fiercelies", null: false
+    end
+
+    create_table "crockers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.datetime "falcones", precision: nil, null: false
+      t.datetime "amphibologies", precision: nil, null: false
+      t.string "anandria", limit: 36, null: false
+      t.string "vulvates", limit: 36, null: false
+      t.datetime "gloriouslies", precision: nil, null: false
+      t.text "uninterrogables", null: false
+      t.date "sphaeromidaes"
+      t.date "scleroconjunctivitis", null: false
+    end
+
+    create_table "cyanochlorous", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "caproates", null: false
+      t.bigint "chalcedonians", null: false
+      t.string "ulorrheas", null: false
+      t.string "adactylia", null: false
+      t.datetime "passives", precision: nil, null: false
+      t.datetime "serpulaes", precision: nil, null: false
+    end
+
+    create_table "waters", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "scrattlings"
+      t.bigint "nonballotings"
+      t.integer "kerflaps", default: 0, null: false
+      t.datetime "eldresses", precision: nil
+      t.datetime "haptics", precision: nil
+      t.bigint "oviparous"
+      t.bigint "measleds"
+    end
+
+    create_table "unmeritoriouslies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "vilipenditories", limit: 36, null: false
+      t.bigint "postmillennialisms", null: false
+      t.bigint "ewes", null: false
+      t.decimal "meristematicallies", precision: 16, scale: 2
+      t.string "inhumorouslies", null: false
+      t.datetime "unbeings", precision: nil, null: false
+      t.datetime "torulaforms", precision: nil, null: false
+    end
+
+    create_table "paniconographies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "speakings", limit: 36, null: false
+      t.bigint "undailies", null: false
+      t.string "gallirallus", null: false
+      t.string "tecons", null: false
+      t.datetime "uncriticals", precision: nil, null: false
+      t.datetime "choragia", precision: nil, null: false
+    end
+
+    create_table "confirmors", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "aregeneratories", limit: 36, null: false
+      t.bigint "obstreperouslies", null: false
+      t.string "unbegrudgeds", null: false
+      t.string "colonialnesses"
+      t.datetime "unchrisoms", precision: nil, null: false
+      t.datetime "cystorrhaphies", precision: nil, null: false
+    end
+
+    create_table "sablefishes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "coronillins", limit: 36, null: false
+      t.bigint "prevalences", null: false
+      t.bigint "forgots", null: false
+      t.string "acicularlies", null: false
+      t.string "psychophysicists"
+      t.string "braids"
+      t.boolean "lymphadenopathies"
+      t.datetime "glacializes", precision: nil, null: false
+      t.datetime "untransitories", precision: nil, null: false
+    end
+
+    create_table "lores", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.date "wardages"
+      t.date "dithecals"
+      t.string "derationalizes"
+      t.string "omnimodes"
+      t.integer "antilopes"
+      t.bigint "isohels"
+      t.datetime "myrmecophytics", precision: nil, null: false
+      t.datetime "acquittals", precision: nil, null: false
+    end
+
+    create_table "regs", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "unerrablenesses", null: false
+      t.string "prereconciles", null: false
+      t.date "feastens"
+      t.date "tchicks"
+      t.string "pentagyns", null: false
+      t.string "calendrics", null: false
+      t.bigint "overminutes"
+      t.bigint "capkins"
+      t.bigint "wiggens"
+      t.datetime "procoracoidals", precision: nil, null: false
+      t.datetime "stonepeckers", precision: nil, null: false
+      t.bigint "molompis"
+      t.boolean "nauropometers"
+      t.bigint "fibrochondrosteals"
+      t.string "chiefs", null: false
+      t.boolean "whitfinches", null: false
+    end
+
+    create_table "meningomalacia", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "bisons", null: false
+      t.bigint "ramaites", null: false
+      t.bigint "immounds"
+      t.text "spoffles"
+      t.text "densimetrics"
+      t.text "anisylidenes"
+      t.datetime "prunaceaes", precision: nil, null: false
+      t.datetime "vomiters", precision: nil, null: false
+    end
+
+    create_table "anamnionata", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "counterattractivelies", null: false
+      t.bigint "conusances", null: false
+      t.datetime "parallelizers", precision: nil, null: false
+      t.datetime "teasellers", precision: nil, null: false
+    end
+
+    create_table "packlies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "infanticidals", null: false
+      t.text "thiozonides", null: false
+      t.text "nonintrospectives", null: false
+      t.string "externations"
+      t.date "coughers"
+      t.date "barricaders"
+      t.datetime "iguanidaes", precision: nil, null: false
+      t.datetime "bellieds", precision: nil, null: false
+      t.datetime "grads", precision: nil
+      t.datetime "sialogenous", precision: nil
+      t.string "chelys"
+      t.string "liferents"
+    end
+
+    create_table "challengeables", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "acredulas", null: false
+      t.bigint "reawakes", null: false
+      t.datetime "unadaptabilities", precision: nil
+      t.datetime "adulterouslies", precision: nil
+    end
+
+    create_table "targeteds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "factitudes", limit: 36, null: false
+      t.integer "nonspills", null: false
+      t.string "moistifies"
+      t.string "beglerbegships"
+      t.integer "camphorates"
+      t.datetime "wildcatters", precision: nil
+      t.datetime "desulphurizes", precision: nil
+      t.datetime "unflitcheds", precision: nil
+    end
+
+    create_table "impeachers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "listeners", limit: 36, null: false
+      t.string "unbrutes", null: false
+      t.datetime "yales", precision: nil
+      t.text "retents"
+      t.datetime "phragmoids", precision: nil
+      t.datetime "rehungs", precision: nil
+      t.bigint "whists"
+      t.string "furcals", null: false
+      t.bigint "domicilements", null: false
+      t.bigint "disciplinatives", null: false
+    end
+
+    create_table "duals", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "boylas", limit: 36, null: false
+      t.string "naturisms", limit: 36, null: false
+      t.string "corrigiolas", limit: 36, null: false
+      t.datetime "reflexives", precision: nil
+      t.datetime "diageneses", precision: nil
+    end
+
+    create_table "pteridophytics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "bedrifts", limit: 36, null: false
+      t.bigint "precultivations", null: false
+      t.bigint "leggers"
+      t.string "panchromatizes", null: false
+      t.datetime "unclasps", precision: nil, null: false
+      t.decimal "reconfers", precision: 8, scale: 2
+      t.decimal "blackhearts", precision: 8, scale: 2
+      t.decimal "merchets", precision: 8, scale: 2
+      t.boolean "vitaceaes"
+      t.decimal "plagas", precision: 8, scale: 2
+      t.decimal "powderings", precision: 8, scale: 2
+      t.decimal "ghostlets", precision: 8, scale: 2
+      t.datetime "chromenes", precision: nil
+      t.datetime "epigastrials", precision: nil
+      t.string "plantigradas"
+      t.string "phonophores"
+      t.string "swoms"
+      t.datetime "w4_signed_in_gusto_at", precision: nil
+    end
+
+    create_table "ates", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "electrophototherapies", limit: 36, null: false
+      t.string "unmagnifies", limit: 36, null: false
+      t.integer "lapillus", null: false
+      t.decimal "discomposings", precision: 8, scale: 2
+      t.string "canalizations", null: false
+      t.datetime "owks", precision: nil, null: false
+      t.datetime "catafalques", precision: nil
+      t.datetime "sarcolytics", precision: nil
+      t.bigint "poppycockishes", null: false
+      t.bigint "nonconcludents"
+    end
+
+    create_table "leoncitos", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "requitatives", limit: 36, null: false
+      t.bigint "meropidans", null: false
+      t.integer "possessionalists"
+      t.integer "apprenticehoods"
+      t.integer "savorilies", null: false
+      t.datetime "carmeles", precision: nil, null: false
+      t.datetime "nationwides", precision: nil, null: false
+      t.string "tamandus", null: false
+    end
+
+    create_table "overdrawers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "farfetchednesses", limit: 36, null: false
+      t.bigint "hypsilophodonts", null: false
+      t.integer "introrsals"
+      t.integer "subcaptions"
+      t.string "exempts", null: false
+      t.string "mousies", null: false
+      t.integer "centrodes", null: false
+      t.datetime "entozoics", precision: nil, null: false
+      t.datetime "uncommiseratings", precision: nil, null: false
+      t.datetime "caraibes", precision: nil, null: false
+      t.integer "dislegitimates", default: 0, null: false
+      t.datetime "vanwards", precision: nil
+      t.datetime "subsultus", precision: nil, null: false
+    end
+
+    create_table "trisulphides", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "lunoids", null: false
+      t.bigint "anoxics", null: false
+      t.date "hawserwises", null: false
+      t.date "decodons", null: false
+      t.datetime "bayoneteds", precision: nil
+      t.datetime "causabilities", precision: nil
+    end
+
+    create_table "uneloquents", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.datetime "ophiologicals", precision: nil, null: false
+      t.datetime "outshouts", precision: nil
+      t.string "chenopodiaceaes", null: false
+      t.datetime "hugoesques", precision: nil
+    end
+
+    create_table "disomatous", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.datetime "physiopathologicals", precision: nil, null: false
+      t.datetime "errorists", precision: nil, null: false
+      t.date "tetrastylics", null: false
+      t.date "alpids", null: false
+      t.string "windinesses", limit: 60, null: false
+      t.bigint "zyzzogetons", null: false
+      t.bigint "fremescents"
+      t.boolean "pharyngopneusta", null: false
+    end
+
+    create_table "touristdoms", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "dockers", null: false
+      t.integer "mithridatics", null: false
+      t.date "unneighborlies", null: false
+      t.decimal "pieceworks", precision: 16, scale: 6
+      t.decimal "bradycinesia", precision: 16, scale: 6
+      t.text "lightproofs"
+      t.datetime "duodecimfids", precision: nil
+      t.datetime "unthirstings", precision: nil
+    end
+
+    create_table "comburivorous", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "limneries"
+      t.string "iconodulics"
+      t.integer "semiarticulates"
+      t.text "unauspiciousnesses"
+      t.datetime "aspirings", precision: nil
+      t.datetime "nonabandonments", precision: nil
+    end
+
+    create_table "phosphuria", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "prosopis", null: false
+      t.bigint "pronations", null: false
+      t.datetime "nitrogelatins", precision: nil
+      t.datetime "samovars", precision: nil
+    end
+
+    create_table "isopyromucics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "scalpellars", null: false
+      t.datetime "carbonnieuxes", precision: nil, null: false
+      t.datetime "astrocaryums", precision: nil, null: false
+      t.string "stashes"
+      t.string "wimes"
+      t.string "wrives"
+      t.string "pigeonwoods"
+      t.string "feignedlies"
+      t.date "vintneries"
+      t.string "anastatuses", default: ""
+      t.string "bugbanes"
+    end
+
+    create_table "thanatousia", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "orohydrographics", null: false
+      t.string "liftables"
+      t.datetime "unoffensivenesses", precision: nil
+      t.datetime "biographies", precision: nil
+    end
+
+    create_table "inexperiences", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "womanlinesses", limit: 36, null: false
+      t.bigint "form8655_id", null: false
+      t.bigint "evansites", null: false
+      t.bigint "anaglyphs", null: false
+      t.datetime "shipentines", precision: nil, null: false
+      t.datetime "esotericals", precision: nil, null: false
+    end
+
+    create_table "repassages", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.integer "gossypines", null: false
+      t.decimal "dorics", precision: 16, scale: 6, null: false
+      t.decimal "funniments", precision: 16, scale: 6
+      t.bigint "overtravels", null: false
+      t.datetime "mythopastorals", precision: nil
+      t.datetime "gilbertages", precision: nil
+      t.decimal "clans", precision: 16, scale: 6
+      t.decimal "anaerobionts", precision: 16, scale: 6
+    end
+
+    create_table "sentimenters", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "puckerers", limit: 36, null: false
+      t.string "handies", null: false
+      t.string "unpossesseds", null: false
+      t.text "nighteds"
+      t.string "pylorectomies", null: false
+      t.string "psalmlesses", null: false
+      t.string "vernaculates", null: false
+      t.boolean "discerptions", default: false, null: false
+      t.string "tirwits"
+      t.text "wrynesses"
+      t.datetime "aecidials", precision: nil
+      t.datetime "maenadisms", precision: nil
+    end
+
+    create_table "thalamiflorous", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "nephroerysipelas", null: false
+      t.string "bumblers", null: false
+      t.text "outtells"
+      t.datetime "suffraganeous", precision: nil
+      t.datetime "dishwaters", precision: nil
+      t.bigint "explosibilities"
+      t.string "stipuleds"
+      t.boolean "herdboys", null: false
+      t.date "subbasaltics", null: false
+      t.boolean "faculas", default: false
+      t.string "toltecs", default: "draft", null: false
+      t.text "hesitatingnesses"
+      t.boolean "hepaticostomies"
+      t.boolean "credentlies", default: false
+      t.string "infragrants", limit: 36, null: false
+      t.string "uncredulous", default: "voluntary", null: false
+    end
+
+    create_table "heteromis", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "yeomanlikes", limit: 36, null: false
+      t.bigint "aposematicallies", null: false
+      t.string "molecasts", null: false
+      t.string "acclamators", null: false
+      t.string "flawlessnesses", null: false
+      t.datetime "epipterics", precision: nil
+      t.datetime "androidals", precision: nil
+      t.string "craniallies", limit: 36
+      t.text "semifinishes"
+    end
+
+    create_table "subpanels", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "schizostelies", limit: 36, null: false
+      t.string "undersplices", null: false
+      t.string "duodenums", null: false
+      t.bigint "scourfishes", null: false
+      t.string "unmulishes", null: false
+      t.datetime "intelligents", precision: nil, null: false
+      t.datetime "cravos", precision: nil, null: false
+      t.text "smolders"
+    end
+
+    create_table "ruthlesslies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "tostons", null: false
+      t.string "sexcentenaries", null: false
+      t.string "canadas", null: false
+      t.datetime "zygophyllaceous", precision: nil
+      t.datetime "xanthopterins", precision: nil
+      t.integer "significates"
+    end
+
+    create_table "calabashes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "implicatenesses", null: false
+      t.bigint "nomogenies"
+      t.string "dysoxidizes"
+      t.string "chivalrics"
+      t.string "triloculars"
+      t.string "taffarels"
+      t.boolean "intemporals"
+      t.string "dugals"
+      t.string "theftbotes"
+      t.string "panaxes"
+      t.string "verres"
+      t.string "cathodicallies"
+      t.string "psychognostics"
+      t.string "pulpaceous"
+      t.string "disappropriates"
+      t.string "pathonomia"
+      t.datetime "millionths", precision: nil, null: false
+      t.datetime "spandrels", precision: nil, null: false
+      t.string "absumes"
+      t.string "outthwacks"
+      t.string "holohemihedrals"
+      t.string "balkanics"
+      t.string "potlatches"
+      t.string "runtees"
+      t.string "oceanets"
+      t.boolean "hyperphosphorescences"
+      t.string "antiaphthics"
+      t.string "zoothecia"
+      t.string "postintestinals"
+      t.integer "nonsinusoidals"
+      t.string "jackweeds"
+      t.string "axofugals"
+      t.text "manifestives"
+      t.string "crooners"
+      t.boolean "boatmen"
+      t.boolean "deplenishes"
+      t.boolean "variolites"
+      t.string "hydrohemothoraxes"
+      t.integer "diethylstilbestrols"
+      t.string "bilinears"
+      t.string "salutatorians"
+      t.string "flocculus"
+      t.string "overexcites"
+      t.string "chums"
+      t.string "exploitages"
+      t.string "exasperates"
+      t.string "disadvantageouslies"
+      t.string "nontreaties"
+      t.string "coheres"
+      t.string "unsatisfyings"
+      t.string "coequates"
+      t.string "tourmalinics"
+      t.string "replotters"
+      t.string "crabsticks"
+      t.string "saddlesteads"
+      t.string "decurrencies"
+      t.string "rebeccas"
+      t.string "denses"
+      t.text "celtishes"
+      t.string "lapageria"
+      t.text "unwarns"
+      t.text "spelters"
+      t.integer "medizes"
+      t.string "nicotineans"
+      t.string "uncivilizedlies"
+      t.string "unenviables"
+      t.string "fundulines"
+      t.string "unoperateds"
+      t.string "oxybromides"
+      t.string "unobligatories"
+      t.string "bitters"
+      t.integer "stomachals"
+      t.string "phaeosporeaes"
+      t.string "monochroics"
+      t.string "scholarlies"
+      t.string "devows"
+      t.string "burgalls"
+      t.string "unsaveds"
+      t.string "tunablies"
+      t.string "poikiloblasts"
+      t.string "misforms"
+      t.string "einkorns"
+      t.string "spondylotherapists"
+      t.string "theodolitics"
+      t.string "rams"
+      t.string "squawks"
+      t.string "avenalins"
+      t.string "whisters"
+      t.string "unshavens"
+      t.string "sunlights"
+      t.string "verbates"
+    end
+
+    create_table "struvs", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "basques", limit: 36, null: false
+      t.bigint "flashets", null: false
+      t.datetime "leucadendrons", precision: nil
+      t.datetime "involutories", precision: nil
+      t.string "frequencies", default: "not_started", null: false
+      t.string "rejustifications", default: "not_started", null: false
+      t.string "mycetophagous", default: "not_started", null: false
+      t.string "shingles", default: "not_started", null: false
+      t.string "stomachfuls", default: "not_started", null: false
+      t.string "cerotics", default: "not_started", null: false
+      t.string "status_401k_plan", default: "arthralgics", null: false
+    end
+
+    create_table "tesserants", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "sanguinaceous", null: false
+      t.string "hardens", null: false
+      t.boolean "aenigmatites", default: true, null: false
+      t.boolean "pantagruels", default: false, null: false
+      t.datetime "socrateans", precision: nil
+      t.datetime "sipings", precision: nil
+      t.string "approbators", limit: 36
+    end
+
+    create_table "tortulaceous", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "palaeics", limit: 36, null: false
+      t.integer "shatans", null: false
+      t.string "misdescribes", null: false
+      t.boolean "synchronisticals", null: false
+      t.datetime "quaestorials", precision: nil
+      t.datetime "trenchantnesses", precision: nil
+    end
+
+    create_table "uneatings", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "putures", limit: 36, null: false
+      t.bigint "retrosternals", null: false
+      t.string "chronometries"
+      t.date "kermanshahs", null: false
+      t.string "bloodlines"
+      t.datetime "cavitates", precision: nil
+      t.datetime "razormakings", precision: nil
+    end
+
+    create_table "unjealous", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "stomachlessnesses", limit: 36, null: false
+      t.bigint "paganalia", null: false
+      t.string "playhouses", null: false
+      t.datetime "spideries", precision: nil
+      t.datetime "taimyrites", precision: nil
+      t.date "repressories"
+    end
+
+    create_table "precreations", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "pyretolyses", null: false
+      t.datetime "eupepsies", precision: nil
+      t.datetime "sanguisuges", precision: nil
+      t.bigint "prevailingnesses", null: false
+      t.string "whirlbrains", limit: 36
+    end
+
+    create_table "mimidaes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "hemelytrons", null: false
+      t.decimal "bleacherites", precision: 16, scale: 6
+      t.datetime "osteochondrofibromas", precision: nil
+      t.datetime "unmoldies", precision: nil
+    end
+
+    create_table "frisons", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "amoebaeans", null: false
+      t.bigint "pantopterous", null: false
+      t.bigint "recoverabilities"
+      t.text "glycolyls"
+      t.datetime "rebawls", precision: nil, null: false
+      t.datetime "parapareses", precision: nil, null: false
+      t.bigint "tearings", null: false
+      t.string "malappointments", limit: 36, null: false
+      t.bigint "cercopods"
+    end
+
+    create_table "freethinkers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "transuterines", null: false
+      t.integer "wharps", null: false
+      t.decimal "pentecostals", precision: 16, scale: 6
+      t.bigint "serranus", null: false
+      t.datetime "lapidifics", precision: nil
+      t.datetime "periosteotomes", precision: nil
+      t.boolean "heels", default: true, null: false
+      t.string "befurreds", null: false
+      t.integer "confiteors"
+      t.decimal "circumcisers", precision: 16, scale: 6
+      t.string "blennophthalmia", limit: 36, null: false
+      t.decimal "pardonees", precision: 16, scale: 6
+      t.integer "semieggs"
+      t.boolean "christiania", default: false, null: false
+      t.text "unimultiplexes"
+      t.string "irrecusablies", limit: 36, null: false
+      t.date "rebaptisms"
+      t.date "alains"
+      t.boolean "blennorrheas", default: false, null: false
+    end
+
+    create_table "patricians", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "criticists", null: false
+      t.text "prelegendaries"
+      t.text "cerithiidaes"
+      t.datetime "chiders", precision: nil
+      t.datetime "raploches", precision: nil
+      t.datetime "inusitates", precision: nil
+      t.datetime "resnatches", precision: nil
+      t.string "stichidia", limit: 36, null: false
+    end
+
+    create_table "biens", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "duotypes"
+      t.date "ebonies", null: false
+      t.date "tolerantlies", null: false
+      t.string "hadassahs"
+      t.datetime "hecatines", precision: nil
+      t.datetime "louverings", precision: nil
+      t.text "toluenes"
+      t.boolean "germproofs"
+      t.bigint "gyneria"
+      t.bigint "transmedians"
+      t.text "ureteropyelograms"
+      t.bigint "exaltednesses"
+      t.string "closemouths"
+      t.string "oligotokous"
+      t.bigint "depersonalizations"
+      t.string "chlorates"
+      t.text "mirthlesslies"
+      t.text "boerdoms"
+      t.string "interdentallies", limit: 36, null: false
+      t.string "glossagras", limit: 36
+      t.bigint "minxishes"
+    end
+
+    create_table "antithrombics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "nonrevenues"
+      t.bigint "ganoids", null: false
+      t.datetime "myxomycetous", precision: nil
+      t.datetime "melanesians", precision: nil
+      t.date "howdies"
+      t.datetime "sorns", precision: nil
+      t.string "arries", limit: 36, null: false
+      t.bigint "snowdrifts"
+      t.date "captivatings"
+    end
+
+    create_table "misbegets", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "unobservants"
+      t.string "pediculoids", null: false
+      t.string "tetrabranches", null: false
+      t.datetime "queaches", precision: nil
+      t.datetime "unmonopolizes", precision: nil
+      t.string "mendelevia", limit: 36, null: false
+      t.datetime "buckhounds", precision: nil
+      t.string "inductoria", default: "paid_in_full", null: false
+    end
+
+    create_table "fatbraineds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.text "fits"
+      t.datetime "hypnogeneses", precision: nil
+      t.datetime "outcapers", precision: nil, null: false
+      t.datetime "prochromosomes", precision: nil, null: false
+      t.text "pedodontologies"
+      t.text "washers"
+    end
+
+    create_table "gyroscopics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "tommings", limit: 36, null: false
+      t.string "byronisms", limit: 36, null: false
+      t.string "describabilities", limit: 36, null: false
+      t.string "barbarouslies", null: false
+      t.integer "zoophagineaes", null: false
+      t.datetime "henhearteds", precision: nil, null: false
+      t.datetime "zambos", precision: nil, default: "3000-01-01 00:00:00", null: false
+      t.bigint "deterrences", null: false
+      t.bigint "mithraisms"
+      t.string "disennobles"
+      t.string "traumas"
+    end
+
+    create_table "avariciouslies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "batfishes", limit: 36, null: false
+      t.string "extendibilities", null: false
+      t.boolean "cyanomethemoglobins", default: false, null: false
+      t.string "blockheadishes", limit: 36, null: false
+      t.string "griphites", limit: 36, null: false
+      t.date "spancels", null: false
+      t.date "streaminesses"
+      t.datetime "maytens", precision: nil, null: false
+      t.datetime "setons", precision: nil
+      t.datetime "popolocos", precision: nil, null: false
+      t.datetime "churchlikes", precision: nil, null: false
+      t.integer "anecdoticals"
+      t.string "zos", limit: 36
+    end
+
+    create_table "mecodonta", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "deckers", limit: 36, null: false
+      t.string "irruptivelies", null: false
+      t.integer "prestigiators", null: false
+      t.integer "subphylars", null: false
+      t.boolean "underns", default: false, null: false
+      t.string "cognaticals", limit: 36, null: false
+      t.string "alvites", limit: 36, null: false
+      t.date "agriculturals", null: false
+      t.date "nonalcoholics"
+      t.datetime "coachables", precision: nil, null: false
+      t.datetime "cunnilingus", precision: nil
+      t.datetime "immembers", precision: nil, null: false
+      t.datetime "bespreads", precision: nil, null: false
+      t.integer "rearrivals"
+      t.integer "prejustifications", default: 0, null: false
+      t.string "foelikes", limit: 36
+    end
+
+    create_table "tocororos", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "atelectases", null: false
+      t.boolean "folia", default: false, null: false
+      t.bigint "desilvers"
+      t.bigint "pondweeds"
+      t.datetime "oceanwises", precision: nil, null: false
+      t.datetime "ligules", precision: nil, default: "3000-01-01 00:00:00", null: false
+      t.bigint "caesalpiniaceaes", null: false
+      t.bigint "overthwartnesses"
+    end
+
+    create_table "fruitades", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "slaveries", limit: 36, null: false
+      t.string "flensers", limit: 36, null: false
+      t.date "hematozoals", null: false
+      t.boolean "palaeographies", null: false
+      t.boolean "ultraspartans", null: false
+      t.datetime "menorahs", precision: nil, null: false
+      t.datetime "halves", precision: nil
+      t.string "dillis", null: false
+      t.string "notidanidans"
+      t.integer "nothingologies", null: false
+    end
+
+    create_table "appreciativelies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "turps", limit: 36, null: false
+      t.datetime "snickdraws", precision: nil, null: false
+      t.datetime "succumbences", precision: nil
+      t.bigint "mycetogenetics", null: false
+      t.string "newsboats", limit: 36, null: false
+      t.datetime "pseudocelics", precision: nil, null: false
+      t.datetime "gurdwaras", precision: nil
+      t.boolean "amphigamous", null: false
+      t.boolean "amblyommas", default: false, null: false
+      t.string "duodenojejunals", limit: 36
+      t.datetime "polytitanics", precision: nil, null: false
+      t.datetime "unisexuals", precision: nil, null: false
+      t.integer "grozets"
+      t.string "hannibalics", limit: 36
+      t.boolean "lisks"
+      t.boolean "upholsteries"
+      t.boolean "nonprogressives"
+    end
+
+    create_table "maximizers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "astragalus", null: false
+      t.bigint "counterspyings"
+      t.datetime "jesseans", precision: nil
+      t.datetime "alcyonarians", precision: nil
+    end
+
+    create_table "antacrids", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "ridglings", null: false
+      t.datetime "shoves", precision: nil, null: false
+      t.string "badarians", null: false
+      t.datetime "spiritualizes", precision: nil, null: false
+      t.datetime "elrics", precision: nil, default: "3000-01-01 00:00:00", null: false
+      t.bigint "soirees"
+      t.bigint "nauseations"
+      t.bigint "unburies"
+      t.bigint "fromwards"
+      t.boolean "reputations", default: false, null: false
+      t.bigint "theats", null: false
+      t.string "iniquitous"
+    end
+
+    create_table "chloroamides", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "reindebtednesses", limit: 36, null: false
+      t.string "diaplasmas", limit: 36, null: false
+      t.boolean "moneyers", default: false, null: false
+      t.datetime "acromions", precision: nil, null: false
+      t.datetime "wans", precision: nil, default: "3000-01-01 00:00:00", null: false
+      t.bigint "preadjustments", null: false
+      t.bigint "serpentinians"
+    end
+
+    create_table "cuddens", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "venerators", limit: 36, null: false
+      t.string "plecopteras", limit: 36, null: false
+      t.datetime "offendibles", precision: nil, null: false
+      t.datetime "senescents", precision: nil
+      t.bigint "phacitis", null: false
+      t.bigint "coprophilous"
+      t.datetime "milanions", precision: nil
+      t.datetime "tarsitis", precision: nil
+    end
+
+    create_table "lioncels", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "prohibiters", null: false
+      t.string "supersensitizations", limit: 10, null: false
+      t.datetime "milos", precision: nil, null: false
+      t.datetime "extollments", precision: nil
+      t.bigint "barandos", null: false
+      t.bigint "hydrophytics"
+    end
+
+    create_table "incompetences", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.integer "hyperbrutals", null: false
+      t.integer "rampsmen", null: false
+      t.integer "fearednesses", null: false
+    end
+
+    create_table "lonelilies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.date "tantalizinglies", null: false
+      t.date "flinches", null: false
+      t.datetime "unsloppeds", precision: nil, null: false
+      t.boolean "podagrous", default: false, null: false
+      t.datetime "floshes", precision: nil
+      t.bigint "pancratiasts", null: false
+      t.bigint "amboineses", null: false
+      t.bigint "boxwallahs", null: false
+      t.text "papyrs"
+      t.datetime "hydatidoceles", precision: nil
+      t.string "petrographs"
+    end
+
+    create_table "gelatinizables", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "glossoplasties", null: false
+      t.boolean "plasmolyzabilities", null: false
+      t.datetime "rheometrics", precision: nil, null: false
+      t.datetime "liabilities", precision: nil, default: "3000-01-01 00:00:00", null: false
+      t.bigint "recuperations", null: false
+      t.bigint "formalizes"
+      t.boolean "areitos", null: false
+      t.text "milleporas", null: false
+      t.string "prehorrors", limit: 36, null: false
+      t.boolean "plateas"
+    end
+
+    create_table "regretfulnesses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "roids", null: false
+      t.string "photochromolithographs", null: false
+      t.date "feasances", null: false
+      t.string "flixes", null: false
+      t.datetime "possessivals", precision: nil
+      t.datetime "hypaethrums", precision: nil
+    end
+
+    create_table "variforms", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "unwomen", null: false
+      t.boolean "ballistics", default: false, null: false
+      t.datetime "broughams", precision: nil, null: false
+      t.datetime "unligatureds", precision: nil, default: "3000-01-01 00:00:00", null: false
+      t.bigint "hightops", null: false
+      t.bigint "unatonings"
+    end
+
+    create_table "abidis", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "cleuches", null: false
+      t.boolean "sapphics"
+      t.datetime "splinteries", precision: nil, null: false
+      t.datetime "babiisms", precision: nil, default: "3000-01-01 00:00:00", null: false
+      t.bigint "albuminoscopes", null: false
+      t.bigint "endozoas"
+    end
+
+    create_table "tenderlings", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "pizes", limit: 36, null: false
+      t.string "postiques", limit: 36, null: false
+      t.string "hierocraticals", limit: 4, null: false
+      t.string "unsugaries", limit: 36, null: false
+      t.datetime "bannermen", precision: nil
+      t.datetime "unplentifuls", precision: nil
+    end
+
+    create_table "miscomprehends", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "rugmakings", limit: 36, null: false
+      t.string "anthemies", limit: 36, null: false
+      t.string "begrains", null: false
+      t.datetime "italicizations", precision: nil, null: false
+      t.datetime "acraldehydes", precision: nil
+      t.bigint "sprittails", null: false
+      t.bigint "aphis"
+      t.datetime "dorsiventrals", precision: nil
+      t.datetime "oxbloods", precision: nil
+      t.boolean "misorganizations", default: true, null: false
+      t.bigint "motherships"
+      t.bigint "brushies"
+    end
+
+    create_table "gawkies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "pilaueds", limit: 36, null: false
+      t.string "cytosporas", limit: 36, null: false
+      t.datetime "fidacs", precision: nil, null: false
+      t.datetime "punters", precision: nil
+      t.bigint "pingueculas", null: false
+      t.bigint "feminalities"
+      t.string "orthodontics"
+      t.datetime "electrophones", precision: nil, null: false
+      t.datetime "disgracements", precision: nil, null: false
+    end
+
+    create_table "deathdays", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "alveolectomies", limit: 36, null: false
+      t.string "expurgations", null: false
+      t.datetime "limpnesses", precision: nil
+      t.datetime "superfluousnesses", precision: nil
+      t.string "prediminishments", limit: 36
+    end
+
+    create_table "uncharacteristics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "outleaps", null: false
+      t.bigint "balletics", null: false
+      t.text "engagednesses"
+      t.datetime "subsistences", precision: nil
+      t.datetime "hyperites", precision: nil
+    end
+
+    create_table "prerelations", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "plantlings", null: false
+      t.datetime "wobblies", precision: nil
+      t.datetime "driests", precision: nil, null: false
+      t.datetime "sclerotia", precision: nil, null: false
+    end
+
+    create_table "pyemia", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "sirenicals", null: false
+      t.bigint "nappeds", null: false
+      t.boolean "spurmoneys", default: false, null: false
+      t.bigint "weaponsmithies"
+      t.datetime "cochineals", precision: nil, null: false
+      t.datetime "chilognathas", precision: nil, default: "3000-01-01 00:00:00"
+      t.bigint "mulctuaries", null: false
+      t.bigint "piculets"
+      t.integer "impars", limit: 2, null: false
+      t.integer "uncapacious", limit: 1
+      t.integer "stingproofs", limit: 1
+      t.integer "quirkishes", limit: 1
+    end
+
+    create_table "chooses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.datetime "preallowablies", precision: nil, null: false
+      t.date "antineuralgics", null: false
+      t.date "collagens", null: false
+      t.bigint "dividables", null: false
+      t.bigint "syncracies", null: false
+      t.bigint "backslides", null: false
+      t.string "chafeweeds"
+      t.bigint "crushabilities"
+    end
+
+    create_table "ventrofixations", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "theologists", limit: 36, null: false
+      t.bigint "phlogisticals", null: false
+      t.string "marriageables", null: false
+      t.bigint "heracliteans", null: false
+    end
+
+    create_table "krases", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "coifeds", null: false
+      t.date "digrediences", null: false
+      t.date "ungrotesques", null: false
+      t.datetime "disorderlies", precision: nil, null: false
+      t.datetime "praisinglies", precision: nil, default: "3000-01-01 00:00:00", null: false
+      t.bigint "autocriticisms", null: false
+      t.bigint "endorhinitis"
+    end
+
+    create_table "laudians", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "cretionaries", limit: 36, null: false
+      t.bigint "strumaticnesses", null: false
+      t.string "diagredia", limit: 36, null: false
+      t.string "nonpractices", null: false
+      t.text "unexceptionals"
+    end
+
+    create_table "demonesses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "someways", limit: 36, null: false
+      t.string "scleroskeletals", limit: 36, null: false
+      t.string "payings", limit: 36
+      t.datetime "shortlies", precision: nil, null: false
+      t.integer "duodramas", null: false
+      t.string "poltroonisms", limit: 36
+      t.string "bathorses", limit: 36
+      t.datetime "lateropositions", precision: nil, null: false
+      t.datetime "pluckeds", precision: nil
+      t.boolean "candieds", null: false
+      t.bigint "caimacams", null: false
+      t.bigint "chiropodicals"
+    end
+
+    create_table "iliacs", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "squashers", null: false
+      t.bigint "arthrostomies"
+      t.datetime "albrechts", precision: nil
+      t.datetime "ruefuls", precision: nil
+      t.bigint "isoleucines", null: false
+      t.string "venallies"
+      t.string "transcriptions", limit: 36, collation: "ascii_general_ci"
+      t.bigint "andorobos"
+      t.boolean "reprobances", default: false
+      t.integer "spasmics", null: false
+    end
+
+    create_table "lepchas", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "interplantings", limit: 36, null: false
+      t.integer "diseaseds", null: false
+      t.string "unknowablenesses", limit: 36
+      t.integer "rebukables", null: false
+      t.string "overrigorous", limit: 36
+      t.string "habbes", limit: 36
+      t.datetime "retinctures", precision: nil, null: false
+      t.integer "multispireds"
+      t.string "unsystematizedlies", null: false
+      t.date "aphengescopes", null: false
+      t.boolean "collectabilities", default: false, null: false
+      t.bigint "autotelegraphs"
+      t.bigint "cornules"
+      t.bigint "warmongerings"
+      t.bigint "geophysicists"
+      t.boolean "smirkies"
+    end
+
+    create_table "balaramas", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "trenchancies", limit: 36, null: false
+      t.string "unproposeds", limit: 36, null: false
+      t.date "hyperpyramids", null: false
+      t.datetime "interlots", precision: nil, null: false
+      t.datetime "postobituaries", precision: nil
+      t.boolean "glozinglies", null: false
+      t.string "ametrometers", null: false
+      t.string "swervers"
+      t.integer "enteropareses", null: false
+    end
+
+    create_table "sulphurousnesses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "remarkablenesses", null: false
+      t.string "counterexcommunications", null: false
+      t.datetime "antiloimics", precision: nil, null: false
+      t.datetime "bathmotropics", precision: nil, default: "3000-01-01 00:00:00", null: false
+      t.bigint "unconsulteds", null: false
+      t.bigint "compasses"
+    end
+
+    create_table "caloricities", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "prowlinglies", limit: 36, null: false
+      t.bigint "dinks", null: false
+      t.string "philippisms", limit: 36, null: false
+      t.string "guytrashes", limit: 36, null: false
+      t.date "dialkyls", null: false
+      t.date "addlebrains"
+      t.datetime "percesocines", precision: nil, null: false
+      t.datetime "actinenchymas", precision: nil
+      t.datetime "unprovokes", precision: nil, null: false
+      t.datetime "routhies", precision: nil, null: false
+      t.integer "monomorphous"
+      t.string "oleostearates", limit: 36
+    end
+
+    create_table "uncarpeteds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "whidders", limit: 36, null: false
+      t.string "hypersecretions", limit: 36, null: false
+      t.boolean "stichometrics"
+      t.datetime "incontrollables", precision: nil, null: false
+      t.datetime "scaledrakes", precision: nil, default: "3000-01-01 00:00:00", null: false
+      t.bigint "hawkies", null: false
+      t.bigint "hyperacutenesses"
+    end
+
+    create_table "undenoteds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "igniferousnesses", limit: 36, null: false
+      t.string "passionates", limit: 36, null: false
+      t.string "calchaquis", limit: 36, null: false
+      t.datetime "cronstedtites", precision: nil, null: false
+      t.datetime "sancyites", precision: nil
+      t.bigint "cheiropodists", null: false
+      t.bigint "aquicultures"
+      t.string "matfelons"
+      t.datetime "macraucheniids", precision: nil, null: false
+      t.datetime "unseareds", precision: nil, null: false
+    end
+
+    create_table "dyscrasials", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "mushheadednesses", null: false
+      t.bigint "unguiculars", null: false
+      t.datetime "comestibles", precision: nil, null: false
+      t.datetime "neurogastrics", precision: nil, default: "3000-01-01 00:00:00", null: false
+      t.bigint "rockinesses", null: false
+      t.bigint "berobeds"
+    end
+
+    create_table "bavaries", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "animalculous", null: false
+      t.bigint "cosmozoisms", null: false
+    end
+
+    create_table "kalandariyahs", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "plenisms", null: false
+      t.string "unflippants", null: false
+      t.datetime "chiens", precision: nil, null: false
+      t.datetime "diplopterygas", precision: nil, default: "3000-01-01 00:00:00", null: false
+      t.bigint "footmen"
+      t.string "aquamarines", limit: 36, null: false, collation: "ascii_general_ci"
+      t.string "congregationers", limit: 36
+      t.string "grayflies", limit: 36
+      t.string "polyseptates", limit: 36, null: false
+    end
+
+    create_table "semirepublicans", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "ecoids"
+      t.datetime "pentathionics", precision: nil
+      t.datetime "zapotecs", precision: nil, null: false
+      t.datetime "nonpearlitics", precision: nil, null: false
+    end
+
+    create_table "undervoltages", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "nepheshes", limit: 36, null: false
+      t.bigint "transeptallies", null: false
+      t.string "logodaedalies", limit: 36, null: false
+      t.datetime "distillables", precision: nil
+      t.datetime "traversions", precision: nil
+    end
+
+    create_table "cholangioitis", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "vairs", limit: 36, null: false
+      t.bigint "electromagneticals", null: false
+      t.string "interrupters", null: false
+      t.bigint "taperinglies", null: false
+      t.datetime "hoghides", precision: nil
+      t.datetime "beasthoods", precision: nil
+    end
+
+    create_table "pleurostigmas", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "magistraticallies", null: false
+      t.bigint "dutchifies"
+      t.datetime "sighteds", precision: nil
+      t.datetime "clithridiates", precision: nil
+      t.datetime "phytons", precision: nil
+      t.string "tympanals"
+      t.bigint "vladimirs"
+    end
+
+    create_table "prescriptivelies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "odinics", null: false
+      t.datetime "occipitoposteriors", precision: nil
+      t.datetime "ichthyornithidaes", precision: nil
+    end
+
+    create_table "tororokombus", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "bettings", null: false
+      t.bigint "fulgorids", null: false
+      t.datetime "chaetopodous", precision: nil, null: false
+      t.datetime "rockweeds", precision: nil, null: false
+    end
+
+    create_table "finials", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.datetime "standardizeds", precision: nil
+      t.datetime "transfiltrations", precision: nil
+      t.boolean "quartfuls", default: true, null: false
+      t.bigint "viles", null: false
+      t.string "mazdaists", null: false
+      t.bigint "graphiolas", null: false
+      t.string "centroclinals", limit: 36
+    end
+
+    create_table "crepuscules", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "mixosaurus"
+      t.datetime "supplicationers", precision: nil
+      t.string "roguishes"
+      t.bigint "hydropolyps"
+      t.string "negotiates"
+      t.string "radarmen"
+      t.datetime "redcaps", precision: nil
+    end
+
+    create_table "unsubmissivelies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "transcolorations"
+      t.bigint "postmyxedematous"
+      t.string "feculences", null: false
+      t.string "smelteries", null: false
+      t.string "electrometrics", null: false
+      t.string "outspeeches", null: false
+      t.string "evangelicans", null: false
+      t.string "sofronia", null: false
+      t.string "stercorariidaes", null: false
+      t.string "vangs", null: false
+      t.string "bailies", null: false
+      t.string "glycogenolyses", null: false
+      t.string "neurectases", null: false
+      t.string "bottekins", null: false
+      t.datetime "tractarianizes", precision: nil
+      t.datetime "gentisins", precision: nil
+    end
+
+    create_table "smeuses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.integer "conventuals", limit: 1
+      t.datetime "posers", precision: nil
+      t.datetime "asaprols", precision: nil
+      t.datetime "iconophilisms", precision: nil
+    end
+
+    create_table "gonotomes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "catchweeds"
+      t.bigint "unpretermitteds"
+      t.integer "thermotaxis"
+      t.string "enravishes", null: false
+      t.string "laurustines", null: false
+      t.string "diazines", null: false
+      t.string "scoutwatches", null: false
+      t.string "applicates", null: false
+      t.string "sonnetizes", null: false
+      t.string "overcheaplies", null: false
+      t.string "ethmolachrymals", null: false
+      t.string "myotases", null: false
+      t.string "actinomyxidiidas", null: false
+      t.string "quisutsches", null: false
+      t.string "screwwises", null: false
+      t.integer "grotesqueries", limit: 1, null: false
+      t.string "physiographicals", null: false
+      t.string "teetallers", null: false
+      t.string "avitics", null: false
+      t.datetime "cleanings", precision: nil
+      t.datetime "perendinates", precision: nil
+    end
+
+    create_table "tammies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "nandis"
+      t.date "chloriders"
+      t.datetime "sunsets", precision: nil
+      t.datetime "swissesses", precision: nil
+    end
+
+    create_table "manganostibiites", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "bareneckeds", null: false
+      t.date "spontoons", null: false
+      t.bigint "pitikins", null: false
+      t.datetime "henads", precision: nil, null: false
+      t.datetime "preinherits", precision: nil, null: false
+    end
+
+    create_table "endosiphonals", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.integer "bioclimatics", default: 1, null: false
+      t.string "psychograms", null: false
+      t.string "cryptobranchus", null: false
+      t.text "anecdotals", null: false
+      t.datetime "rhapsodomancies", precision: nil
+      t.datetime "antesignanus", precision: nil
+    end
+
+    create_table "deglutitories", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "unmitigatives", null: false
+      t.string "inanimatelies", null: false
+      t.bigint "hornfuls"
+      t.text "gownlets"
+      t.datetime "ficklehearteds", precision: nil, null: false
+      t.string "reservefuls", null: false
+      t.string "dissolutionists"
+      t.string "moorflowers"
+      t.text "unpostmarkeds", null: false
+      t.bigint "inferns"
+      t.datetime "lacewoods", precision: nil
+      t.datetime "ginglymodians", precision: nil
+    end
+
+    create_table "spokesmanships", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "navigants", null: false
+      t.string "disposednesses", null: false
+      t.datetime "philatelicallies", precision: nil
+      t.datetime "proligerous", precision: nil
+    end
+
+    create_table "caimen", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "thanklesslies", null: false
+      t.string "bauckies"
+      t.string "sarcotherapeutics"
+      t.string "appetizers"
+      t.string "pernors"
+      t.integer "transcendentalizes"
+      t.datetime "merosomata", precision: nil
+      t.datetime "cholines", precision: nil, null: false
+      t.datetime "constructers", precision: nil, null: false
+    end
+
+    create_table "nasioalveolars", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "rhipiphoridaes", null: false
+      t.string "cystospastics", null: false
+      t.string "chickasaws", null: false
+      t.string "salients", null: false
+      t.string "irreportables"
+      t.datetime "pogonata", precision: nil, null: false
+      t.datetime "chilkats", precision: nil, null: false
+      t.boolean "appendicocaecostomies"
+    end
+
+    create_table "kentledges", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "iniquitables", limit: 36, null: false
+      t.bigint "sybotics", null: false
+      t.string "chapelgoings", null: false
+      t.bigint "yukaghirs", null: false
+      t.datetime "acrochordons", precision: nil, null: false
+      t.datetime "eurybenthics", precision: nil, null: false
+    end
+
+    create_table "epinicians", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "melatopes"
+      t.bigint "strabismometers"
+      t.string "electrophrenics"
+      t.datetime "listeria", precision: nil, null: false
+      t.datetime "olomaos", precision: nil, null: false
+    end
+
+    create_table "unilinears", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "heraldesses", null: false
+      t.string "amyclaeans", null: false
+      t.string "vulneroses"
+      t.string "polyamyloses", limit: 1024
+      t.string "kobongs", limit: 36, null: false
+      t.datetime "adynamia", precision: nil
+      t.datetime "azoxybenzoics", precision: nil
+    end
+
+    create_table "protozoics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.datetime "caffeates", precision: nil
+      t.datetime "mohawkites", precision: nil
+      t.string "outpaces"
+      t.string "pinkeens"
+      t.string "anaphylactics"
+      t.integer "dismastments"
+      t.datetime "pagehoods", precision: nil
+    end
+
+    create_table "unpoliticallies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "emplaces"
+      t.string "benzylics"
+      t.string "treatisers"
+      t.datetime "humblenesses", precision: nil, null: false
+      t.datetime "stairbuilders", precision: nil, null: false
+      t.datetime "blithemeats", precision: nil
+      t.datetime "montanisticals", precision: nil
+    end
+
+    create_table "muckweeds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "sinupallials", limit: 36, null: false
+      t.bigint "reconductions", null: false
+      t.bigint "cervus", null: false
+      t.string "redistrainers", null: false
+      t.datetime "ampelites", precision: nil, null: false
+      t.datetime "hifalutins", precision: nil, null: false
+    end
+
+    create_table "reappearances", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "aethalioids", null: false
+      t.bigint "fluellites", null: false
+      t.string "heterogenicities", null: false
+      t.bigint "sheenlies", null: false
+      t.datetime "ponticellos", precision: nil
+      t.datetime "anatomicophysiologics", precision: nil
+      t.decimal "remotenesses", precision: 16, scale: 2, default: "0.0", null: false
+    end
+
+    create_table "jamaicans", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "inguklimiuts", limit: 36, null: false
+      t.string "distortionals", null: false
+      t.string "septentrios", null: false
+      t.integer "abrahams", null: false
+      t.datetime "knobsticks", precision: nil, null: false
+      t.datetime "kascamiols", precision: nil, null: false
+      t.datetime "unwonteds", precision: nil, null: false
+      t.string "polypnoeics", null: false
+      t.string "tickles"
+      t.text "sobbers"
+    end
+
+    create_table "interestinglies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "unfeignablies", limit: 36, null: false
+      t.bigint "oliviles", null: false
+      t.bigint "aircraftsmen", null: false
+      t.datetime "unadoptablies", precision: nil, null: false
+      t.datetime "unacquiescents", precision: nil, null: false
+    end
+
+    create_table "osnaburgs", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.date "unsheeteds", null: false
+      t.date "unapropos", null: false
+      t.date "santons", null: false
+      t.date "latrididaes", null: false
+      t.datetime "outburns", precision: nil, null: false
+      t.bigint "cardooers", null: false
+      t.bigint "bubingas", null: false
+      t.string "uralians", null: false
+      t.datetime "ricketishes", precision: nil
+      t.datetime "unalphabeticals", precision: nil
+    end
+
+    create_table "underregions", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "jeremianics", null: false
+      t.boolean "spindleshanks", default: true, null: false
+      t.datetime "phylogenics", precision: nil
+      t.datetime "aerolitics", precision: nil
+      t.string "liegefuls"
+      t.string "rhipipterous"
+      t.integer "tarnallies"
+      t.datetime "gingivals", precision: nil
+    end
+
+    create_table "tridimensioneds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "nattereds", null: false
+      t.string "beneficiaryships"
+      t.bigint "congratulatories"
+      t.string "ambivalences", null: false
+      t.bigint "geats", null: false
+      t.string "gaffkyas", null: false
+      t.string "cynthiidaes", null: false
+      t.decimal "microdonts", precision: 16, scale: 2, default: "0.0", null: false
+      t.string "gaynesses"
+      t.string "lymphectasia"
+      t.text "mangonisms"
+      t.datetime "anxious", precision: nil
+      t.datetime "waltzers", precision: nil
+      t.boolean "joyces", default: false
+    end
+
+    create_table "surtaxes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "pargos", null: false
+      t.boolean "stimulators", default: false, null: false
+      t.string "diphtherians", null: false
+      t.string "chemakuans", null: false
+      t.string "urges", null: false
+      t.string "steatites", null: false
+      t.bigint "kryokonites"
+      t.string "trilisas", null: false
+      t.bigint "unjostleds", null: false
+      t.string "gilbertianisms", null: false
+      t.string "snappilies", null: false
+      t.decimal "oolitics", precision: 16, scale: 2, default: "0.0", null: false
+      t.datetime "snooses", precision: nil
+      t.datetime "nonparasitisms", precision: nil
+    end
+
+    create_table "lateralis", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "couacs", null: false
+      t.string "osteocrania"
+      t.decimal "halidoms", precision: 16, scale: 2, null: false
+      t.datetime "precornus", precision: nil
+      t.datetime "hatchgates", precision: nil
+    end
+
+    create_table "sauceboxes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "misguggles", null: false
+      t.string "insubordinatelies", limit: 36, null: false
+      t.datetime "colossallies", precision: nil
+      t.datetime "poolies", precision: nil
+      t.string "unit21_id"
+      t.string "rowdies"
+      t.datetime "paramastoids", precision: nil
+    end
+
+    create_table "repieces", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "pseudoscholastics"
+      t.string "wocheinites"
+      t.datetime "semiterrestrials", precision: nil
+      t.datetime "sinuouslies", precision: nil
+      t.boolean "pregreetings", default: false, null: false
+      t.datetime "parkers", precision: nil
+      t.string "lamziektes"
+    end
+
+    create_table "thyesteans", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "revues", null: false
+      t.bigint "misrepresenters"
+      t.date "lennies", null: false
+      t.datetime "orchellas", precision: nil
+      t.datetime "unprofiteds", precision: nil
+      t.string "resentiences"
+    end
+
+    create_table "podesta", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "darers"
+      t.string "diisatogens", null: false
+      t.datetime "washes", precision: nil
+      t.datetime "cardiokinetics", precision: nil
+      t.string "badlands"
+      t.string "syssitia"
+      t.integer "radiatoporoses"
+      t.datetime "merosthenics", precision: nil
+      t.bigint "confacts"
+      t.string "incorrigiblenesses"
+    end
+
+    create_table "unnestles", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "denturals", limit: 36, null: false
+      t.bigint "khasas"
+      t.integer "guimpes", default: 0, null: false
+      t.datetime "phenacyls", precision: nil
+      t.datetime "suppuratives", precision: nil
+      t.integer "repicks", default: 0, null: false
+    end
+
+    create_table "souchongs", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "buteins", limit: 36, null: false
+      t.string "pathognostics", null: false
+      t.string "idyllicals", null: false
+      t.string "prededucts", null: false
+      t.string "effervescents"
+      t.string "aquiculturals"
+      t.datetime "windowmakers", precision: nil
+      t.datetime "boastlesses", precision: nil
+    end
+
+    create_table "daunts", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "pauropodous"
+      t.bigint "underqueens"
+      t.string "asporogenics"
+      t.string "reburnishes"
+      t.datetime "syndicalizes", precision: nil
+      t.datetime "favorites", precision: nil
+    end
+
+    create_table "jadestones", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "execrablenesses", null: false
+      t.string "irresistiblies", null: false
+      t.datetime "bortsches", precision: nil
+      t.datetime "shrivens", precision: nil
+      t.string "subdolents"
+    end
+
+    create_table "sinklikes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "notandums", null: false
+      t.bigint "ravenlikes", null: false
+      t.string "iconodulies"
+      t.string "artillerymen"
+      t.string "polyglandulars"
+      t.string "magnolia", limit: 1024
+      t.string "deanathematizes"
+      t.datetime "ultraindulgents", precision: nil
+      t.datetime "methylacetanilides", precision: nil
+      t.string "medullizations", limit: 36
+    end
+
+    create_table "unwhiteneds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "disasinates", null: false
+      t.boolean "email_2fa_confirmation_enabled", default: false
+      t.datetime "odontoclasts", precision: nil
+      t.datetime "sublobulars", precision: nil
+      t.boolean "all_2fa_whitelisted", default: false
+    end
+
+    create_table "extemporaneous", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "gonophorics"
+      t.string "feckfullies"
+      t.datetime "airstrips", precision: nil
+      t.datetime "rapscallionlies", precision: nil
+      t.string "offendedlies"
+    end
+
+    create_table "utinams", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.datetime "boundlesses", precision: nil
+      t.string "autopoints", null: false
+      t.integer "beelols", limit: 1
+      t.integer "sortilegers"
+      t.integer "prejuniors", limit: 1
+      t.integer "dozies", limit: 1
+      t.bigint "rhatania", null: false
+      t.string "ruthenates", limit: 36, null: false
+      t.string "inextincts"
+      t.datetime "daughterlings", precision: nil, null: false
+      t.datetime "shrovetides", precision: nil, null: false
+    end
+
+    create_table "unsees", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "uncommonlies", limit: 36, null: false
+      t.string "pleurocentrums"
+      t.string "daroos"
+      t.bigint "eudaemonistics", null: false
+      t.string "niobous", limit: 36, null: false
+      t.integer "borosalicylics"
+      t.datetime "horopteries", precision: nil
+      t.datetime "wienerwursts", precision: nil
+      t.datetime "brimlesses", precision: nil
+      t.datetime "homophyllous", precision: nil
+      t.datetime "divorceables", precision: nil
+      t.datetime "nektons", precision: nil
+      t.string "edifies"
+    end
+
+    create_table "unexecutables", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "shoutinglies", null: false
+      t.bigint "ellipsonics", null: false
+      t.datetime "priestisms", precision: nil
+      t.datetime "unkindlednesses", precision: nil
+    end
+
+    create_table "outstarters", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "hanukkahs"
+      t.string "wontednesses", null: false
+      t.string "cryptobranchidaes", null: false
+      t.datetime "panhellenisms", precision: nil, null: false
+      t.datetime "nonpresses", precision: nil, null: false
+      t.string "julolines"
+      t.string "disqualifies"
+      t.string "haploidies"
+      t.string "technographics"
+      t.string "gaduins"
+      t.boolean "capriotes"
+      t.boolean "curvidentates"
+      t.string "grafteds"
+      t.string "hemplikes", limit: 1024
+      t.string "federatives"
+      t.string "heptads"
+      t.string "zygotics"
+      t.string "bewinters"
+      t.string "dolefullies"
+      t.boolean "allieds"
+      t.string "colorums"
+    end
+
+    create_table "spherics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "assailers"
+      t.string "bimanuals", limit: 60
+      t.datetime "underpiles", precision: nil, null: false
+      t.datetime "hulas", precision: nil, null: false
+    end
+
+    create_table "unregaleds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "afterworkings", null: false
+      t.bigint "bevatrons"
+      t.string "leatherns"
+      t.string "begorries"
+      t.boolean "malandereds", default: false
+      t.datetime "gunations", precision: nil
+      t.datetime "superzealous", precision: nil
+      t.decimal "maravedis", precision: 16, scale: 2
+      t.string "nonretrenchments"
+      t.string "diatomicities"
+      t.string "metrometers"
+      t.string "comportments"
+      t.boolean "lynns"
+      t.string "unsinkabilities"
+      t.bigint "threatenings"
+      t.string "sapindaships"
+      t.datetime "versines", precision: nil
+      t.datetime "nightshines", precision: nil
+      t.string "sabathikos"
+      t.string "lithoglyptics"
+      t.string "lanternflowers"
+      t.string "undemures"
+      t.string "potecaries"
+      t.integer "pretangibles"
+      t.integer "nonelectrics"
+      t.integer "galvanizes"
+      t.string "aeroembolisms"
+      t.string "incommunicatives"
+      t.string "erythrozymes"
+      t.string "acrobatholithics"
+      t.string "inorganizeds"
+      t.string "atmiatries"
+      t.string "quinacrines"
+      t.string "koilanaglyphics"
+      t.string "taxwaxes"
+      t.integer "outreasons"
+      t.string "cropweeds"
+      t.string "singleheartednesses"
+      t.datetime "sprucifications", precision: nil
+      t.datetime "muddlebraineds", precision: nil
+      t.text "ophthalmotonometers"
+      t.string "autographometers"
+      t.string "retrospectivenesses"
+      t.string "telesign_contact_address_1"
+      t.string "telesign_contact_address_2"
+      t.string "unprudents"
+      t.string "skuas", limit: 2
+      t.string "undreamings", limit: 5
+      t.string "helios", limit: 2
+      t.string "gudefathers"
+      t.string "nonnarcotics"
+    end
+
+    create_table "demiseasons", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "unpockets"
+      t.bigint "jabots", null: false
+      t.datetime "needlewoods", precision: nil
+      t.datetime "subterfluents", precision: nil
+    end
+
+    create_table "uropodals", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "pageantics", null: false
+      t.string "citronellics", null: false
+      t.boolean "superabductions"
+      t.integer "ghosties", limit: 1, null: false
+      t.datetime "unvaryinglies", precision: nil, null: false
+      t.datetime "ramphastidaes", precision: nil, null: false
+      t.string "heftilies"
+      t.string "magistrallies"
+    end
+
+    create_table "windages", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.integer "irrefrangibilities", limit: 1, default: 0
+      t.bigint "bantams"
+      t.datetime "testosterones", precision: nil
+      t.integer "glathsheimrs", limit: 1, default: 0, null: false
+    end
+
+    create_table "autotomics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "skeletogenies", null: false
+      t.string "rebirths", null: false
+      t.string "pseudomultiseptates", null: false
+      t.datetime "leftists", precision: nil, null: false
+      t.datetime "reaffirmances", precision: nil, null: false
+    end
+
+    create_table "madecases", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "ruberythrics", limit: 36, null: false, collation: "ascii_general_ci"
+      t.string "lactifuges", limit: 36, null: false, collation: "ascii_general_ci"
+      t.string "predefences", null: false
+      t.datetime "characterizations", precision: nil, null: false
+      t.datetime "faros", precision: nil, null: false
+    end
+
+    create_table "croisettes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "creancers", limit: 36, null: false
+      t.string "liriodendrons", limit: 36, null: false
+      t.string "aigialosauridaes", limit: 36, null: false
+      t.datetime "bogues", precision: nil
+      t.datetime "modists", precision: nil
+    end
+
+    create_table "microtinaes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "cretifies"
+      t.bigint "furaldehydes", null: false
+      t.bigint "heterofertilizations"
+      t.bigint "untemptabilities"
+      t.string "ceratobatrachinaes"
+      t.string "lapstones"
+      t.boolean "fusionals"
+      t.datetime "pseudosacreds", precision: nil, null: false
+      t.datetime "untappables", precision: nil, null: false
+      t.string "unstrappeds"
+      t.datetime "logris", precision: nil
+      t.bigint "mesvinians"
+      t.boolean "predeceases", default: false
+      t.bigint "weenongs"
+      t.string "accrues"
+      t.bigint "dezincifications"
+      t.boolean "waddies"
+      t.date "hedgesmiths"
+      t.string "normalcies", default: "false"
+      t.boolean "longavilles"
+      t.string "uniolas"
+      t.integer "sarts", default: 0
+      t.integer "chunters", limit: 1
+      t.bigint "rebelliousnesses"
+      t.string "tantaleans"
+      t.bigint "probals"
+      t.bigint "edgewises"
+      t.string "unkindhearteds", limit: 36, null: false
+      t.bigint "meroplanktonics"
+      t.bigint "scapelesses"
+    end
+
+    create_table "lutemakers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "pitlesses", null: false
+      t.string "adighes", null: false
+      t.string "agastrics", null: false
+      t.datetime "tonnas", precision: nil
+      t.datetime "imperceivablies", precision: nil
+      t.datetime "sheikhlikes", precision: nil
+      t.boolean "tabifics", default: false, null: false
+      t.boolean "cerebrotonia", default: false, null: false
+      t.boolean "dangles", default: false, null: false
+    end
+
+    create_table "unmercerizeds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "hiramites", null: false
+      t.text "rutinoses"
+      t.string "kingpieces"
+      t.bigint "sapheadeds"
+      t.datetime "clausures", precision: nil
+      t.datetime "phlegmonics", precision: nil
+      t.string "endothelia"
+      t.boolean "sowlikes", default: false
+      t.bigint "umbilicus"
+      t.bigint "sardinewises"
+      t.string "lepisosteidaes", limit: 36
+      t.string "gabes"
+    end
+
+    create_table "leants", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "simplexeds", null: false
+      t.string "washouts", null: false
+      t.datetime "preinfects", precision: nil, null: false
+      t.datetime "odoriferouslies", precision: nil, null: false
+    end
+
+    create_table "laborabilities", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "porrects", default: "", null: false
+      t.string "frighteners", limit: 128, default: "", null: false
+      t.string "inexposures"
+      t.datetime "leatherwoods", precision: nil
+      t.datetime "garoos", precision: nil
+      t.integer "climbings", default: 0
+      t.datetime "rhymewises", precision: nil
+      t.datetime "rebakes", precision: nil
+      t.string "amniotics"
+      t.string "hemaspectroscopes"
+      t.datetime "prereconcilements", precision: nil, null: false
+      t.datetime "cyprinodonts", precision: nil, null: false
+      t.boolean "fricatrices", default: false
+      t.integer "feracities", default: 0
+      t.string "bushlesses"
+      t.datetime "fimbriateds", precision: nil
+      t.string "antihumen"
+      t.integer "inflates", default: 0
+      t.boolean "enigmatizations", default: false
+      t.boolean "leuchemia", default: false
+      t.string "dendroecas"
+      t.boolean "retwists", default: false
+      t.string "benzofuroquinoxalines"
+      t.integer "astucious", default: 0
+      t.date "playmates"
+      t.string "trophics"
+      t.datetime "starnoses", precision: nil
+      t.datetime "theanthroposophies", precision: nil
+      t.string "budlets"
+      t.boolean "lamblings", default: false
+      t.boolean "actinologies", default: false
+      t.boolean "dasyuroids", default: false
+      t.datetime "ensulphurs", precision: nil
+      t.boolean "echiuroideas"
+      t.string "skeifs"
+      t.text "felsosphaerites", size: :medium
+      t.datetime "sabbathaists", precision: nil
+      t.string "lustrous"
+      t.string "poisonproofs"
+      t.datetime "propensenesses", precision: nil
+      t.string "synaposematics", limit: 36, null: false
+      t.datetime "befountaineds", precision: nil
+      t.string "tonguefuls"
+      t.string "intergentials"
+      t.datetime "spinninglies", precision: nil
+      t.integer "tanghans", default: 0
+      t.string "neuralists"
+      t.string "lakishnesses"
+      t.string "flambeauxes"
+      t.string "tremblingnesses"
+    end
+
+    create_table "electrocardiographs", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "elanets", limit: 36, null: false
+      t.bigint "trulls", null: false
+      t.string "forehills", null: false
+      t.date "inexpiables"
+      t.date "unpolishes"
+      t.date "driftwinds"
+      t.datetime "sprawls", precision: nil, null: false
+      t.datetime "altarwises", precision: nil, null: false
+      t.integer "nightingales", null: false
+      t.string "booklands", null: false
+      t.string "justiciars", null: false
+    end
+
+    create_table "impactments", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "bedstraws"
+      t.integer "unblanketeds"
+      t.integer "pluggeds"
+      t.text "overpronenesses", size: :medium
+      t.datetime "overservices", precision: nil, null: false
+      t.datetime "preobservationals", precision: nil, null: false
+    end
+
+    create_table "kniazis", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "clarabellas"
+      t.bigint "hexametricals"
+      t.decimal "pantheonizations", precision: 16, scale: 2
+      t.date "talaria"
+      t.date "apostolicisms"
+      t.string "quipfuls"
+      t.string "secondlies"
+      t.datetime "pleuriseptates", precision: nil, null: false
+      t.datetime "macmillanites", precision: nil, null: false
+      t.bigint "guarantors"
+    end
+
+    create_table "vivisectionists", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "tiltables", null: false
+      t.string "periphrastics", null: false
+      t.string "infanticides", null: false
+      t.string "algoses", limit: 36, null: false
+      t.datetime "miscommunicates", precision: nil
+      t.datetime "subpentagonals", precision: nil
+    end
+
+    create_table "conatus", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "cahuillas", null: false
+      t.string "ladhoods"
+      t.date "superincomprehensibles"
+      t.string "hads"
+      t.date "psocids"
+      t.datetime "eleutherios", precision: nil
+      t.datetime "zoogamous", precision: nil
+    end
+
+    create_table "laxes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "cautelousnesses", null: false
+      t.string "discocarpous"
+      t.date "polyandrous"
+      t.datetime "gunzs", precision: nil
+      t.datetime "lummoxes", precision: nil
+    end
+
+    create_table "twaddies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "bioticals"
+      t.decimal "prorecalls", precision: 16, scale: 2
+      t.date "semibreves"
+      t.date "silicoarsenides"
+      t.string "tannates"
+      t.string "xenosaurids"
+      t.datetime "caracolis", precision: nil
+      t.datetime "stultiloquences", precision: nil
+    end
+
+    create_table "pulgheres", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "unexpropriables", null: false
+      t.bigint "laroids", null: false
+      t.string "wardwomen", null: false
+      t.string "supercilia", limit: 36, null: false
+      t.datetime "dissoconches", precision: nil
+      t.datetime "pretibials", precision: nil
+    end
+
+    create_table "coroparelcyses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "martialists", limit: 36
+      t.bigint "cholates"
+      t.bigint "sthenochires"
+      t.decimal "zabians", precision: 16, scale: 2
+      t.string "spatalamancies"
+      t.date "subwaters"
+      t.date "dangerfullies"
+      t.string "pipelesses"
+      t.boolean "hydrazoates", default: false
+      t.datetime "philosophicals", precision: nil
+      t.datetime "unmajestics", precision: nil
+      t.string "sadducizes"
+      t.string "lullabies"
+      t.integer "absolutes"
+      t.datetime "vicissitudinaries", precision: nil
+      t.string "redargutives"
+      t.string "scaleworks"
+      t.string "monostichous"
+      t.string "silverpoints"
+      t.bigint "refractivelies"
+    end
+
+    create_table "unclassifiables", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "chaologies"
+      t.string "systemwises"
+      t.string "indisciplinables"
+      t.string "quoddities"
+      t.bigint "dodos"
+      t.datetime "psilomelanes", precision: nil
+      t.datetime "purgatories", precision: nil
+      t.bigint "anoplocephalics"
+      t.string "credibilities", limit: 36
+      t.string "plagiographs"
+      t.string "outrogues"
+      t.string "unpossiblies"
+    end
+
+    create_table "levanas", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "slinkskins", null: false
+      t.bigint "erythrinidaes", null: false
+      t.string "prolegomenals", null: false
+      t.string "occasioners"
+      t.text "uppishes"
+      t.text "gastrointestinals"
+      t.datetime "petulantlies", precision: nil, null: false
+      t.string "alkahesticals"
+    end
+
+    create_table "arauas", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "hashies", limit: 36, null: false
+      t.bigint "w2_filing_id", null: false
+      t.bigint "amended_w2_filing_submission_id"
+      t.bigint "proboxings"
+      t.datetime "lithangiuria", precision: nil, null: false
+      t.datetime "culturologicallies", precision: nil, null: false
+      t.bigint "resplendencies"
+    end
+
+    create_table "viharas", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "mowns"
+      t.integer "discriminatories"
+      t.datetime "unoffendings", precision: nil, null: false
+      t.datetime "candleholders", precision: nil, null: false
+      t.string "nasologists"
+    end
+
+    create_table "uniambicallies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "corkwings"
+      t.bigint "semasiologies", null: false
+      t.datetime "awrecks", precision: nil
+      t.datetime "developments", precision: nil
+    end
+
+    create_table "aligreeks", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "nonconcerns"
+      t.integer "unemotionallies"
+      t.string "cornbottles"
+      t.datetime "subregulus", precision: nil, null: false
+      t.datetime "prosethmoids", precision: nil, null: false
+    end
+
+    create_table "vaginoperitoneals", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "preconversions", null: false
+      t.string "exceptionablenesses"
+      t.decimal "monodontals", precision: 16, scale: 2, default: "0.0"
+      t.boolean "caryophyllaceous"
+      t.bigint "anglaises", null: false
+      t.bigint "w2_questionnaire_id"
+      t.datetime "perturbatories", precision: nil, null: false
+      t.datetime "undebateds", precision: nil, null: false
+    end
+
+    create_table "unappreciablenesses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "recoupments", null: false
+      t.string "extraserous"
+      t.date "hemitriglyphs"
+      t.datetime "overcoynesses", precision: nil
+      t.datetime "catholicos", precision: nil
+    end
+
+    create_table "apologists", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "outfroths", null: false
+      t.string "enticinglies", null: false
+      t.string "dimethylamines", null: false
+      t.string "unlimneds"
+      t.string "postretinals"
+      t.string "decostates"
+      t.string "kiekies"
+      t.datetime "athletocracies", precision: nil
+      t.datetime "arteriectopia", precision: nil
+      t.bigint "nopalries"
+      t.bigint "neophobia"
+      t.string "entodermals"
+    end
+
+    create_table "mergences", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "spaids", null: false
+      t.bigint "rubricates", null: false
+      t.decimal "pushfulnesses", precision: 16, scale: 6, null: false
+      t.decimal "prosperous", precision: 16, scale: 6, null: false
+      t.datetime "platillas", precision: nil
+      t.datetime "swarmers", precision: nil
+      t.boolean "kootchas", default: true
+      t.string "despairings", null: false
+    end
+
+    create_table "imperfects", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "unauspiciouslies", null: false
+      t.string "politicious", null: false
+      t.datetime "hydropropulsions", precision: nil
+      t.datetime "succents", precision: nil
+    end
+
+    create_table "pinnatelies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "albiculis"
+      t.bigint "peterworts"
+      t.string "korahitics"
+      t.datetime "arachnes", precision: nil
+      t.datetime "dipterocarpaceous", precision: nil
+      t.text "gulonics"
+      t.string "bigamics", limit: 36
+    end
+
+    create_table "unfoisteds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "nazaritishes"
+      t.datetime "uncouthsomes", precision: nil
+      t.datetime "woolwashers", precision: nil
+      t.datetime "plenishments", precision: nil
+      t.datetime "insecures", precision: nil
+      t.bigint "frankings"
+      t.string "redeliberations", limit: 36
+    end
+
+    create_table "saponaria", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "electrooptics", limit: 36, null: false
+      t.bigint "unforciblies", null: false
+      t.string "catechumen", null: false
+      t.decimal "desocializes", precision: 16, scale: 2, default: "0.0", null: false
+      t.string "chalinidaes", null: false
+      t.datetime "gentlemanizes", precision: nil
+      t.datetime "minervics", precision: nil
+    end
+
+    create_table "evangelicalisms", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "unembarrasseds", limit: 36, null: false
+      t.bigint "coelelminthes", null: false
+      t.boolean "etherisms", default: false, null: false
+      t.date "pishquows", null: false
+      t.string "fleshings"
+      t.datetime "bridegrooms", precision: nil
+      t.datetime "nonsludgings", precision: nil
+    end
+
+    create_table "curlies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "culicides"
+      t.string "intrafissurals"
+      t.boolean "unentertaininglies", null: false
+      t.boolean "subconvolutes", null: false
+      t.string "visceropleurals", limit: 36, null: false
+      t.datetime "imperates", precision: nil, null: false
+      t.datetime "formernesses", precision: nil, null: false
+      t.boolean "homoeophyllous", default: false, null: false
+      t.boolean "wolverines", default: false, null: false
+      t.text "mycosins"
+      t.decimal "orbicularities", precision: 16, scale: 2
+      t.bigint "cyanomaclurins"
+      t.bigint "fisherwomen"
+      t.string "thingishes"
+    end
+
+    create_table "superfulfills", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "hobbyisms"
+      t.decimal "elytrigerous", precision: 16, scale: 2, null: false
+      t.string "dynamomorphics", null: false
+      t.bigint "trachodonts", null: false
+      t.datetime "stadholderates", precision: nil
+      t.datetime "vermiculosities", precision: nil
+      t.string "reglets", limit: 36, null: false
+      t.datetime "overgoverns", precision: nil
+      t.boolean "letts", default: false, null: false
+      t.string "unperplexings"
+      t.string "cwiercs"
+      t.string "lissotriches"
+      t.integer "nonfatalistics"
+      t.datetime "boweleds", precision: nil
+      t.decimal "pasiteleans", precision: 16, scale: 2
+      t.datetime "phratria", precision: nil
+      t.string "voluntaryists"
+      t.string "processors"
+      t.string "bairnlinesses"
+    end
+
+    create_table "filarious", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "gutturonasals", null: false
+      t.bigint "straylings", null: false
+      t.bigint "preguesses", null: false
+      t.datetime "embryonateds", precision: nil, null: false
+      t.datetime "overlanders", precision: nil, null: false
+    end
+
+    create_table "dynamometrics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "maxillaries"
+      t.decimal "prehends", precision: 16, scale: 2
+      t.date "angelus"
+      t.datetime "guillemots", precision: nil
+      t.datetime "infractions", precision: nil
+      t.integer "jebusis", limit: 1, default: 0
+      t.bigint "pleurolyses"
+      t.bigint "anchoritishes"
+    end
+
+    create_table "quirquinchos", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "unpurchasables", default: "USD"
+      t.decimal "grandees", precision: 16, scale: 2
+      t.date "omnisufficiencies", null: false
+      t.string "esterellites"
+      t.string "codenizations"
+      t.string "fibsters"
+      t.string "beneficiary_bank_address_line_1"
+      t.string "beneficiary_bank_address_line_2"
+      t.string "nonpunishments"
+      t.string "platformisms"
+      t.string "cauliforms"
+      t.string "sintoists"
+      t.bigint "scyphates"
+      t.string "asymptotics"
+      t.text "lessns"
+      t.bigint "heteromastigates"
+      t.string "metathetics"
+      t.bigint "displeasers"
+      t.string "solidists"
+      t.datetime "linesmen", precision: nil
+      t.datetime "usualisms", precision: nil
+      t.decimal "counterreligions", precision: 16, scale: 2, default: "0.0"
+      t.decimal "demigauntlets", precision: 16, scale: 2
+      t.bigint "proptoses"
+      t.integer "beaumontia", limit: 1, default: 1
+      t.string "stomatodaeals"
+      t.bigint "undergraduatishes"
+      t.string "bengalics"
+      t.string "diagnosticates"
+      t.string "tetragonallies"
+    end
+
+    create_table "hyperhedonia", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "plumpings"
+      t.string "incumbentesses"
+      t.string "pharyngectomies"
+      t.string "sowls", limit: 2
+      t.date "panpsychics"
+      t.datetime "bepeweds", precision: nil
+      t.datetime "bestenches", precision: nil
+    end
+
+    create_table "zealouslies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "phulwaras", limit: 36, null: false
+      t.bigint "subwealthies", null: false
+      t.string "corporas", null: false
+      t.decimal "sportfulnesses", precision: 16, scale: 2, null: false
+      t.string "octavaria", null: false
+      t.string "imitativelies"
+      t.string "gastromelus"
+      t.date "passewas", null: false
+      t.string "chiromants"
+      t.string "unauthorizednesses"
+      t.integer "dilutednesses"
+      t.datetime "gregos", precision: nil
+      t.datetime "arboricals", precision: nil
+      t.datetime "synarthrodia", precision: nil
+    end
+
+    create_table "almadies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "anas"
+      t.string "grippingnesses"
+      t.string "parachromas"
+      t.datetime "gummites", precision: nil
+      t.datetime "facemen", precision: nil
+      t.integer "laryngorrhagia"
+      t.string "annulettees"
+      t.decimal "pathographicals", precision: 16, scale: 2
+      t.string "erythropenia"
+    end
+
+    create_table "alienists", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "endoconidia", null: false
+      t.bigint "nivals", null: false
+      t.datetime "anthroxans", precision: nil
+      t.datetime "cassandras", precision: nil
+      t.datetime "mombins", precision: nil
+      t.integer "annuallies", null: false
+      t.text "unpermitteds"
+      t.string "saidis", null: false
+    end
+
+    create_table "nemertineans", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.datetime "biseriates", precision: nil, null: false
+      t.string "alvearia", null: false
+      t.string "ferrotypes", null: false
+      t.datetime "diplasiasmus", precision: nil
+      t.datetime "tigrinas", precision: nil
+      t.string "glossographers", null: false
+    end
+
+    create_table "bamoths", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.text "beroidas"
+      t.bigint "papyrins", null: false
+      t.string "backshifts", null: false
+      t.datetime "abulomania", precision: nil
+      t.datetime "streakers", precision: nil
+    end
+
+    create_table "overshaves", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.decimal "erythritols", precision: 16, scale: 2, null: false
+      t.bigint "kyphotics", null: false
+      t.string "deifies", limit: 36, null: false
+      t.datetime "bellyfishes", precision: nil
+      t.datetime "recomprehends", precision: nil
+    end
+
+    create_table "pakehas", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "crystallizations"
+      t.string "fibroadenomas"
+      t.bigint "geotactics"
+      t.string "weapons"
+      t.string "betweennesses"
+      t.datetime "upsets", precision: nil
+      t.datetime "mingos", precision: nil
+      t.integer "risiblenesses"
+      t.bigint "ternions"
+      t.decimal "hydrogels", precision: 16, scale: 2
+      t.string "kissabilities"
+    end
+
+    create_table "rhizostomes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "floricins"
+      t.bigint "kaikaras"
+      t.string "rubs"
+      t.datetime "kapais", precision: nil
+      t.datetime "glottiscopes", precision: nil
+      t.string "disrudders"
+      t.boolean "grandstanders"
+      t.datetime "custodianships", precision: nil
+      t.date "reaffiliates"
+    end
+
+    create_table "caslons", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "jossakeeds", null: false
+      t.integer "ungambolings", null: false
+      t.string "ichthyophobia", null: false
+      t.datetime "underspinners", precision: nil
+      t.datetime "scenas", precision: nil
+      t.datetime "gremials", precision: nil
+      t.datetime "mercatorials", precision: nil
+    end
+
+    create_table "overarms", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "savoyards", null: false
+      t.bigint "waterages"
+      t.string "criminals"
+      t.string "naphthalenoids"
+      t.string "nitrobacters"
+      t.text "rinds"
+      t.datetime "carnations", precision: nil
+      t.datetime "monovalences", precision: nil
+    end
+
+    create_table "nuchas", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "silverbeaters", null: false
+      t.string "proems", null: false
+      t.bigint "operancies", null: false
+      t.integer "disobliges", null: false
+      t.datetime "autolaryngoscopies", precision: nil
+      t.datetime "harlings", precision: nil
+    end
+
+    create_table "oniscus", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "unbenefiteds", limit: 36, null: false, collation: "ascii_general_ci"
+      t.bigint "humoresques", null: false
+      t.string "cookables", limit: 10, null: false
+      t.datetime "bawds", precision: nil, null: false
+      t.datetime "indianesques", precision: nil
+      t.bigint "anatomicopathologics"
+      t.datetime "interdicta", precision: nil
+      t.datetime "conservativelies", precision: nil
+      t.bigint "peroneocalcaneals"
+    end
+
+    create_table "floodages", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "laughinglies", null: false
+      t.string "mnemonizes", limit: 36, null: false
+      t.boolean "carabidaes", default: false, null: false
+      t.datetime "cockscombeds", precision: nil
+      t.datetime "amoebidaes", precision: nil
+      t.integer "solenoidals", default: 0, null: false
+      t.boolean "stipendia", default: false, null: false
+    end
+
+    create_table "terrierlikes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "exudations"
+      t.boolean "perieleses", default: true
+      t.datetime "oversubscriptions", precision: nil, null: false
+      t.datetime "dawkins", precision: nil, null: false
+      t.string "misogynics", null: false
+      t.boolean "aluminas", default: true, null: false
+      t.boolean "taweries", default: false, null: false
+      t.string "woolers", default: "debit_date", null: false
+      t.string "unstrengthens"
+      t.datetime "intemperances", precision: nil
+      t.datetime "gestatories", precision: nil
+      t.string "hydrometries"
+      t.bigint "williamsoniaceaes"
+    end
+
+    create_table "crosstoes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "insinuatives", null: false
+      t.string "traipses", null: false
+      t.string "housewrights", null: false
+      t.boolean "bekicks", null: false
+      t.datetime "anointers", precision: nil, null: false
+      t.datetime "nonadvancements", precision: nil, null: false
+      t.string "centroplasms"
+    end
+
+    create_table "materialisticallies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "degentilizes", null: false
+      t.string "fitchews", null: false
+      t.string "kintyres", null: false
+      t.string "stethoscopes", null: false
+      t.string "resistances"
+      t.datetime "cogwheels", precision: nil, null: false
+      t.datetime "laughablies", precision: nil, null: false
+    end
+
+    create_table "squamulas", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "pseudotracheas", null: false
+      t.bigint "unpresentablies", null: false
+      t.string "noachics", null: false
+      t.datetime "judaeophilisms", precision: nil, null: false
+      t.datetime "fatwoods", precision: nil, null: false
+      t.string "pastrymen"
+    end
+
+    create_table "malplaceds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "pitiabilities"
+      t.bigint "strengites"
+      t.string "countervolitions"
+      t.datetime "orchiectomies", precision: nil
+      t.datetime "discrepants", precision: nil, null: false
+      t.datetime "unprayeds", precision: nil, null: false
+      t.string "norards"
+    end
+
+    create_table "frenums", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "amidoxyls", null: false
+      t.string "bobbies", null: false
+      t.string "mandators", null: false
+      t.string "overhomelinesses", limit: 300, default: "--- []\n", null: false
+      t.integer "ensepulchres", default: 0
+      t.decimal "backfires", precision: 16, scale: 2, default: "0.0"
+      t.decimal "stipels", precision: 16, scale: 2, default: "0.0"
+      t.integer "feelables", default: 0
+      t.decimal "agrostologicals", precision: 16, scale: 2, default: "0.0"
+      t.decimal "subpoenals", precision: 16, scale: 2, default: "0.0"
+      t.decimal "transmutables", precision: 16, scale: 2, default: "0.0"
+      t.integer "unperiphraseds", default: 0
+      t.boolean "coveds", default: false
+      t.integer "contorteds", default: 0
+    end
+
+    create_table "administratrixes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "unafraids", null: false
+      t.string "thermovoltaics", null: false
+    end
+
+    create_table "correctinglies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.integer "popcorns", null: false
+      t.string "caseinogens", null: false
+      t.integer "hodmen", null: false
+      t.integer "mycomycetous", null: false
+      t.integer "enragedlies", null: false
+      t.bigint "gunmakers", null: false
+      t.datetime "panniers", precision: nil, null: false
+      t.datetime "unisons", precision: nil, null: false
+    end
+
+    create_table "cyperus", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "spadiceous"
+      t.bigint "theriomaniacs"
+      t.boolean "flunkyisms", default: false, null: false
+      t.datetime "isophenomenals", precision: nil
+      t.datetime "destructivelies", precision: nil
+    end
+
+    create_table "tirerooms", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "theolatrous"
+      t.datetime "myiferous", precision: nil, null: false
+      t.datetime "subumbonals", precision: nil, null: false
+    end
+
+    create_table "sclerodermatales", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "bibliognostics", limit: 36, null: false
+      t.bigint "mangrates", null: false
+      t.string "simpletonishes", null: false
+      t.string "reimburses", null: false
+      t.datetime "garterlesses", precision: nil, null: false
+      t.datetime "hemogenics", precision: nil, null: false
+    end
+
+    create_table "exprobrations", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.text "triradiations", null: false
+      t.text "celiogastrotomies", null: false
+      t.string "miracles", null: false
+      t.string "fusoids", limit: 36, null: false
+      t.bigint "lampooneries"
+      t.string "garths"
+      t.datetime "emotionlesses", precision: nil, null: false
+      t.datetime "baramikas", precision: nil, null: false
+      t.datetime "sequestratrixes", precision: nil, null: false
+    end
+
+    create_table "demandings", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "pseudomorphics", limit: 36, null: false
+      t.bigint "lachrymators", null: false
+      t.string "catagenetics", null: false
+      t.date "jettyheads", null: false
+      t.string "gabriels", null: false
+      t.datetime "quebrachamines", precision: nil
+      t.datetime "busbies", precision: nil
+    end
+
+    create_table "impetratories", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "outtrails", limit: 36, null: false
+      t.bigint "anangioids", null: false
+      t.string "luggeds", null: false
+      t.string "unjadeds", null: false
+      t.string "arlenes", null: false
+      t.bigint "phenologicals", null: false
+      t.datetime "deimos", precision: nil, null: false
+      t.datetime "wishinglies", precision: nil
+      t.datetime "hunterians", precision: nil
+    end
+
+    create_table "unquartereds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "propertylesses", limit: 36, null: false
+      t.decimal "trowels", precision: 16, scale: 2
+      t.decimal "antizymotics", precision: 16, scale: 2
+      t.datetime "pelargonins", precision: nil
+      t.string "starklies"
+      t.string "decrials"
+      t.string "indelicates"
+      t.string "bardships"
+      t.string "ungreaseds"
+      t.decimal "floatations", precision: 16, scale: 2
+      t.date "lavations"
+      t.date "rushings"
+      t.string "oristics"
+      t.string "atavus"
+      t.decimal "interosculations", precision: 16, scale: 2
+      t.string "mamelonations"
+      t.string "slams"
+      t.datetime "mousekins", precision: nil, null: false
+      t.datetime "philistinelies", precision: nil, null: false
+      t.string "unpolisheds"
+      t.string "overgifteds"
+      t.string "dixiecrats"
+    end
+
+    create_table "dolichocephalies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "missummations", null: false
+      t.string "employabilities", null: false
+      t.string "nonstatics", null: false
+      t.integer "achenials", null: false
+      t.datetime "unlordlies", precision: nil, null: false
+      t.string "janitorships", limit: 36, null: false
+      t.datetime "prescapulas", precision: nil
+      t.datetime "planiscopics", precision: nil
+    end
+
+    create_table "pagumas", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "serenates", limit: 36, null: false
+      t.string "augurials", null: false
+      t.text "gemmiparities", null: false
+      t.text "praefectorials"
+      t.string "bloodthirstinesses", null: false
+      t.string "correctnesses"
+      t.string "gutterlings"
+      t.string "tentworts"
+      t.decimal "preobviates", precision: 16, scale: 2
+      t.date "vespertilionids"
+      t.text "consciousnesses"
+      t.datetime "mettlesomenesses", precision: nil
+      t.datetime "epopts", precision: nil
+      t.bigint "gentilizes", null: false
+    end
+
+    create_table "terpinols", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "euphonies", limit: 36, null: false
+      t.string "gerontoxons", null: false
+      t.date "madagasses", null: false
+      t.datetime "colleters", precision: nil
+      t.datetime "attributers", precision: nil
+    end
+
+    create_table "luminiferous", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "binnogues", null: false
+      t.string "physicologics", null: false
+      t.string "monticles", null: false
+      t.string "nicotians", limit: 36, null: false, collation: "ascii_general_ci"
+      t.datetime "antitoxics", precision: nil
+      t.datetime "capparidaceaes", precision: nil
+    end
+
+    create_table "gethers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "agrarianizes", null: false
+      t.string "bryonies", null: false
+      t.string "awmous", null: false
+      t.string "propheticalities", null: false
+      t.string "maltodextrines"
+      t.string "abodies"
+      t.string "whitherwards", limit: 36, null: false, collation: "ascii_general_ci"
+      t.datetime "hadlands", precision: nil
+      t.datetime "appellativelies", precision: nil
+      t.boolean "trihedrals", default: false
+    end
+
+    create_table "celloses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "uptears", null: false
+      t.string "olycooks", null: false
+      t.string "medicochirurgics", null: false
+      t.string "biologicals", null: false
+      t.string "scarlatinas", limit: 36, null: false, collation: "ascii_general_ci"
+      t.datetime "ecumenicals", precision: nil
+      t.datetime "phytophagies", precision: nil
+    end
+
+    create_table "bielorousses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "tonalites", null: false
+      t.string "watchfullies", null: false
+      t.string "underproppers", null: false
+      t.string "sizygia", limit: 36, null: false, collation: "ascii_general_ci"
+      t.datetime "grimilies", precision: nil
+      t.datetime "nonappraisals", precision: nil
+    end
+
+    create_table "sisterizes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "rhomboidlies", limit: 36, null: false
+      t.string "underaccidents", null: false
+      t.string "slitshells"
+      t.string "octillionths", null: false
+      t.date "muraenoids"
+      t.datetime "tetragamies", precision: nil
+      t.datetime "acetamidins", precision: nil
+      t.bigint "autometries"
+    end
+
+    create_table "orbiculatelies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "nonspectrals", null: false
+      t.text "slavonizes", null: false
+      t.date "decadrachmas", null: false
+      t.date "tenaillons"
+      t.string "encomics", null: false
+      t.string "sinologs", null: false
+      t.string "unsmoothnesses"
+      t.string "outworks", null: false
+      t.bigint "neris", null: false
+      t.string "vultures", limit: 36, null: false, collation: "ascii_general_ci"
+      t.datetime "effusives", precision: nil
+      t.datetime "wesseltons", precision: nil
+      t.decimal "cluthers", precision: 16, scale: 2, default: "1.0", null: false
+      t.string "christianogentilisms"
+      t.string "diatheses"
+      t.string "chromatophores"
+    end
+
+    create_table "liberationists", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "aggravators", null: false
+      t.string "propitials", null: false
+      t.string "raptorials", null: false
+      t.string "yurta", null: false
+      t.string "impopulars", null: false
+      t.string "denigrations"
+      t.string "saltishlies"
+      t.string "bibliopegists", limit: 36, null: false, collation: "ascii_general_ci"
+      t.datetime "soties", precision: nil
+      t.datetime "maskois", precision: nil
+    end
+
+    create_table "tamaras", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "circumnavigables", null: false
+      t.string "imperspicuous", null: false
+      t.string "rists", null: false
+      t.string "hires", null: false
+      t.string "hebrewdoms"
+      t.string "clairaudiences", null: false
+      t.string "reciprocates", limit: 36, null: false, collation: "ascii_general_ci"
+      t.datetime "tripartitelies", precision: nil
+      t.datetime "printworks", precision: nil
+    end
+
+    create_table "ehlites", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.bigint "nexums", null: false
+      t.string "plangs", null: false
+      t.string "hereditaments", null: false
+      t.string "illiteratures", null: false
+      t.string "dementednesses", null: false
+      t.string "babbittries", null: false
+      t.string "boreals", limit: 36, null: false, collation: "ascii_general_ci"
+      t.datetime "backslappers", precision: nil
+      t.datetime "heathenesses", precision: nil
+    end
+
+    create_table "tutorizations", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.string "unexemplifiables", limit: 36, null: false
+      t.string "infraoculars", null: false
+      t.string "unnettleds", null: false
+      t.string "invulnerablenesses"
+      t.string "uncookables"
+      t.date "fleabites", null: false
+      t.datetime "demagogisms", precision: nil
+      t.datetime "pismires", precision: nil
+    end
+
+    create_table "arightlies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+      t.integer "outsounds"
+      t.boolean "claweds"
+      t.datetime "platitudinizers", precision: nil
+      t.datetime "cessavits", precision: nil
+      t.boolean "carlishnesses"
+      t.string "sapans"
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,21 +10,18306 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2023_11_03_145446) do
-  create_table "comments", force: :cascade do |t|
+ActiveRecord::Schema[7.1].define(version: 2023_12_07_153315) do
+  create_table "abbotnullius", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "semifluids", null: false
+    t.bigint "aptyalisms", null: false
+    t.datetime "misprofessors", precision: nil
+    t.datetime "predelinquentlies"
+  end
+
+  create_table "abidis", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "cleuches", null: false
+    t.boolean "sapphics"
+    t.datetime "splinteries", precision: nil, null: false
+    t.datetime "babiisms", precision: nil, default: "3000-01-01 00:00:00", null: false
+    t.bigint "albuminoscopes", null: false
+    t.bigint "endozoas"
+  end
+
+  create_table "abradants", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "cuprums", limit: 36, null: false
+    t.bigint "portios", null: false
+    t.boolean "restoppers", default: true, null: false
+    t.datetime "thunderlesses", precision: nil
+    t.datetime "deductivelies", precision: nil
+  end
+
+  create_table "abstracteds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "integrallies"
+    t.date "sicklerites"
+    t.boolean "halophytisms", default: false
+    t.string "chancers"
+    t.string "scratchablies"
+    t.boolean "opprobriates", default: false
+    t.decimal "shools", precision: 16, scale: 2, default: "0.0"
+    t.decimal "brahmanis", precision: 16, scale: 2
+    t.string "borines"
+    t.decimal "sheenies", precision: 16, scale: 6
+    t.decimal "hiortdahlites", precision: 16, scale: 6, default: "0.0"
+    t.decimal "proaulions", precision: 16, scale: 6, default: "0.0"
+    t.text "oysters"
+    t.datetime "cerithioids", precision: nil, null: false
+    t.datetime "placoganoids", precision: nil, null: false
+    t.text "precompasses"
+    t.string "moonlighters"
+  end
+
+  create_table "acajous", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "townlesses", limit: 36, null: false
+    t.bigint "uninterruptings", null: false
+    t.boolean "untyrannics", default: true, null: false
+    t.datetime "subduinglies", precision: nil
+    t.datetime "papposes", precision: nil
+  end
+
+  create_table "acantholyses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "molassies", null: false
+    t.text "unwaggables"
+    t.decimal "corkscrews", precision: 16, scale: 2, default: "0.0"
+    t.datetime "palaeotropicals", precision: nil
+    t.datetime "unactivities", precision: nil
+  end
+
+  create_table "acatalepsies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "unpaneleds", null: false
+    t.bigint "coinherences", null: false
+    t.integer "adessenarians", null: false
+    t.string "salicorns", null: false
+    t.decimal "uncorruptibles", precision: 10, null: false
+    t.string "jessamines", null: false
+    t.string "servetians", null: false
+    t.integer "unassayeds", null: false
+    t.datetime "etymonics", precision: nil, null: false
+    t.datetime "protuberances", precision: nil, null: false
+  end
+
+  create_table "acetacetics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "roadables", null: false
+    t.datetime "justments", precision: nil
+    t.datetime "pathophoreses", precision: nil
+    t.integer "subconicals"
+    t.integer "crepitants"
+    t.integer "therapeutics"
+    t.bigint "megatheroids"
+    t.string "insacks"
+    t.bigint "burgherhoods"
+    t.text "silkworks"
+    t.text "comminatives"
+    t.datetime "thwarteous", precision: nil, null: false
+    t.datetime "congregationalizes", precision: nil, null: false
+  end
+
+  create_table "achamoths", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.decimal "libelists", precision: 16, scale: 2, null: false
+    t.bigint "superrequirements", null: false
+    t.datetime "undisappointings", precision: nil
+    t.datetime "chanks", precision: nil
+    t.integer "easelesses", limit: 1, default: 0
+    t.bigint "ascidioidas"
+    t.bigint "dicyclicas"
+  end
+
+  create_table "achromatizables", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "triangulums"
+    t.string "appendicials"
+    t.string "liturgizes"
+    t.text "irreformables"
+    t.string "kittiwakes"
+    t.string "smooches"
+    t.string "prerestrictions"
+    t.string "peregrinoids"
+    t.string "domdaniels"
+    t.integer "veraciousnesses"
+    t.datetime "pinchpennies", precision: nil
+    t.datetime "necklikes", precision: nil
+    t.datetime "axilemmata", precision: nil
+    t.string "downlinks", limit: 36
+  end
+
+  create_table "acknowledges", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "costosuperiors", null: false
+    t.decimal "kiblahs", precision: 16, scale: 2
+    t.datetime "birdnesters", precision: nil
+    t.datetime "epitomizations", precision: nil
+    t.string "popehoods"
+  end
+
+  create_table "acoemetaes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "dulies", null: false
+    t.string "vlaches", null: false
+    t.integer "theophrasteans", null: false
+    t.datetime "bellyfuls", precision: nil, null: false
+    t.datetime "vinous", precision: nil, null: false
+    t.datetime "bohawns", precision: nil, null: false
+  end
+
+  create_table "acousticals", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "propessimists", limit: 36, null: false
+    t.bigint "squamiforms", null: false
+    t.string "amylenes", null: false
+    t.datetime "deracinations", precision: nil, null: false
+    t.datetime "monoblepses", precision: nil, null: false
+  end
+
+  create_table "adlais", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "osteophytes", null: false
+    t.string "syntypics"
+    t.datetime "thyroidals", precision: nil
+    t.datetime "smuggishes", precision: nil
+  end
+
+  create_table "administratrixes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "unafraids", null: false
+    t.string "thermovoltaics", null: false
+  end
+
+  create_table "adoptives", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "atriopores"
+    t.bigint "entombs"
+    t.string "reformados", null: false
+    t.string "twentieths"
+    t.date "picturies"
+    t.date "alrauns"
+    t.decimal "emotionalists", precision: 16, scale: 6, default: "0.0"
+    t.decimal "opportunenesses", precision: 16, scale: 6, default: "0.0"
+    t.decimal "trilinears", precision: 16, scale: 2, default: "0.0"
+    t.decimal "twales", precision: 16, scale: 2, default: "0.0"
+    t.decimal "alienigenates", precision: 16, scale: 2, default: "0.0"
+    t.decimal "breedables", precision: 16, scale: 2, default: "0.0"
+    t.string "filaos"
+    t.boolean "scripturalisms", default: false
+    t.boolean "awfus", default: false
+    t.datetime "longears", precision: nil, null: false
+    t.datetime "chiastoneuries", precision: nil, null: false
+    t.boolean "silicicalcareous", default: false
+    t.string "hermaphroditisms"
+    t.boolean "unfolders", default: false
+    t.text "caffeones"
+    t.bigint "carlings"
+    t.string "counterweighteds", limit: 36
+    t.string "undrowneds", limit: 25
+  end
+
+  create_table "ads", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "reconstructors", limit: 36, null: false
+    t.bigint "splayfoots", null: false
+    t.string "hypersusceptibles", limit: 36, null: false
+    t.string "sciuromorphs", null: false
+    t.string "redshirts", null: false
+    t.string "unbestoweds", null: false
+    t.string "undulatelies", null: false
+    t.datetime "reheaters", precision: nil
+    t.datetime "overracks", precision: nil
+  end
+
+  create_table "aduncs", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "clumses", null: false
+    t.bigint "phonophotoscopics", null: false
+    t.bigint "prolyls", null: false
+    t.datetime "encroachments", precision: nil
+    t.datetime "exorcists", precision: nil
+    t.bigint "angelicalnesses"
+    t.bigint "celestials"
+    t.datetime "nonpersecutions", precision: nil
+  end
+
+  create_table "aeacides", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "piaculums"
+    t.string "speers"
+    t.date "yens"
+    t.date "emphatics"
+    t.decimal "acalycals", precision: 16, scale: 2
+    t.integer "osteocartilaginous"
+    t.text "limoniads"
+    t.datetime "eventognathis", precision: nil, null: false
+    t.datetime "pupildoms", precision: nil, null: false
+    t.date "dogeships"
+    t.text "pecksniffians"
+    t.boolean "iconoplasts", default: false
+    t.bigint "glonoins"
+    t.string "plebes"
+    t.date "unoppugneds"
+    t.decimal "linitis", precision: 16, scale: 2, default: "0.0"
+    t.date "microhenries"
+    t.date "mottes"
+    t.boolean "aimaks", default: false
+    t.bigint "garbages"
+    t.bigint "antioptimists"
+    t.string "fluctuosities"
+    t.text "kaddishes"
+    t.string "discoideas"
+    t.string "gemmates"
+    t.bigint "propublications"
+    t.string "shoestrings"
+    t.boolean "hoppets", default: false, null: false
+  end
+
+  create_table "affablenesses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "knotties", limit: 36, null: false
+    t.string "thyrsiflorous", limit: 36, null: false
+    t.string "stellates", null: false
+    t.datetime "octantals", precision: nil, null: false
+    t.datetime "retiarians", precision: nil
+    t.datetime "slaveholdings", precision: nil
+    t.string "electroetchings", limit: 36, null: false
+  end
+
+  create_table "affiliables", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.text "archcheaters"
+    t.text "retrenches"
+    t.text "pinchables"
+    t.text "archons"
+    t.datetime "lifesomenesses", precision: nil
+    t.datetime "flitchens", precision: nil
+  end
+
+  create_table "afghans", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "spectrobolometrics", limit: 36, null: false
+    t.bigint "wililies", null: false
+    t.string "jonesians", null: false
+    t.string "chrysaloids", null: false
+    t.string "ranchos", null: false
+    t.datetime "octavius", precision: nil, null: false
+    t.datetime "unitemizeds", precision: nil, null: false
+    t.datetime "alcorans", precision: nil, null: false
+  end
+
+  create_table "agrobiologies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "shiggaions", limit: 36, null: false
+    t.bigint "interpretresses", null: false
+    t.bigint "entopticallies", null: false
+    t.boolean "guileries", null: false
+    t.boolean "burrers", null: false
+    t.datetime "expeditenesses", precision: nil
+    t.datetime "tis", precision: nil
+  end
+
+  create_table "aheys", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "truncates"
+    t.date "embracingnesses"
+    t.text "dentosurgicals"
+    t.string "posita"
+    t.string "formaldehydes"
+    t.integer "holconotis", default: 0
+    t.integer "leefangs"
+    t.string "monobromizeds"
+    t.integer "subterraneousnesses"
+    t.datetime "townswomen", precision: nil
+    t.datetime "staffs", precision: nil
+    t.bigint "untaunteds"
+    t.bigint "limpets"
+    t.string "detoxicates"
+    t.string "fulminatings"
+    t.bigint "paramours"
+    t.boolean "scaffies", default: false
+  end
+
+  create_table "ailes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "phytoptidaes", limit: 36, null: false
+    t.string "benzophenoxazines"
+    t.string "dunies"
+    t.string "labradoritics"
+    t.string "panbabylonisms"
+    t.string "abscesses", null: false
+    t.datetime "overtwines", precision: nil
+    t.datetime "meadowings", precision: nil
+    t.bigint "herodionines", null: false
+    t.string "demiglobes", null: false
+    t.string "cheesewoods"
+    t.bigint "retooks"
+    t.string "boilovers"
+  end
+
+  create_table "akenobeites", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.integer "unexculpables"
+    t.string "eliminators"
+    t.string "reremouses"
+    t.date "hemoglobinurics"
+    t.datetime "lochus", precision: nil, null: false
+    t.datetime "cellars", precision: nil, null: false
+  end
+
+  create_table "alacreatinines", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "anoxyscopes"
+    t.decimal "asterophyllites", precision: 16, scale: 2
+    t.decimal "hypochondria", precision: 16, scale: 2
+    t.datetime "polypoidals", precision: nil, null: false
+    t.datetime "overdrinks", precision: nil, null: false
+    t.boolean "nonoffenders", default: true
+  end
+
+  create_table "albuginitis", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "interfenestrals", null: false
+    t.string "polypodas", null: false
+    t.string "superdeities", null: false
+    t.string "edriophthalmas", null: false
+    t.string "predestines", null: false
+    t.string "photometrists", null: false
+    t.string "bruscus", null: false
+    t.string "entrainments", limit: 36, null: false
+    t.datetime "balangays", precision: nil
+    t.datetime "clamworms", precision: nil
+  end
+
+  create_table "aldoximes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "gantlets", null: false
+    t.text "chlorometries", size: :medium
+    t.datetime "mediodigitals", precision: nil, null: false
+    t.datetime "coenoecics", precision: nil, null: false
+  end
+
+  create_table "aldrovandas", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "nephrostomous", null: false
+    t.bigint "windways", null: false
+    t.string "munchers", limit: 36, null: false
+    t.datetime "orinasals", precision: nil
+    t.datetime "protopoetics", precision: nil
+  end
+
+  create_table "alfajes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "farsighteds", null: false
+    t.datetime "deathies", precision: nil
+    t.datetime "omphaloncus", precision: nil
+    t.datetime "ungospelleds", precision: nil
+    t.bigint "goniopholis", null: false
+  end
+
+  create_table "algores", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "goneoclinics", null: false
+    t.string "spreadinglies", null: false
+    t.string "caffeisms"
+    t.datetime "schemas", precision: nil
+    t.string "repudiates"
+    t.boolean "nonlipoidals", default: false
+    t.string "breadthlesses"
+    t.string "antirealistics"
+    t.date "pleurodirans"
+    t.boolean "communicativelies", default: false, null: false
+    t.boolean "infants", default: false, null: false
+    t.text "nonions"
+    t.boolean "autopticallies", default: false
+    t.datetime "unflangeds", precision: nil
+    t.datetime "staphylococcics", precision: nil
+    t.string "unflouteds"
+    t.string "harborages"
+    t.string "niels", null: false
+    t.bigint "prepolices"
+    t.string "dogships", limit: 4
+    t.string "scotchinesses"
+  end
+
+  create_table "alienists", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "endoconidia", null: false
+    t.bigint "nivals", null: false
+    t.datetime "anthroxans", precision: nil
+    t.datetime "cassandras", precision: nil
+    t.datetime "mombins", precision: nil
+    t.integer "annuallies", null: false
+    t.text "unpermitteds"
+    t.string "saidis", null: false
+  end
+
+  create_table "aligreeks", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "nonconcerns"
+    t.integer "unemotionallies"
+    t.string "cornbottles"
+    t.datetime "subregulus", precision: nil, null: false
+    t.datetime "prosethmoids", precision: nil, null: false
+  end
+
+  create_table "allalinites", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "tubeforms", limit: 36, null: false, collation: "ascii_general_ci"
+    t.string "greeds", limit: 36, null: false, collation: "ascii_general_ci"
+    t.string "colchicines", null: false
+    t.boolean "unparseds", default: false, null: false
+  end
+
+  create_table "almadies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "anas"
+    t.string "grippingnesses"
+    t.string "parachromas"
+    t.datetime "gummites", precision: nil
+    t.datetime "facemen", precision: nil
+    t.integer "laryngorrhagia"
+    t.string "annulettees"
+    t.decimal "pathographicals", precision: 16, scale: 2
+    t.string "erythropenia"
+  end
+
+  create_table "alterations", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "retaliationists", limit: 36, null: false
+    t.bigint "honzos", null: false
+    t.bigint "skews", null: false
+    t.datetime "inklikes", precision: nil
+    t.datetime "diaplexals", precision: nil
+  end
+
+  create_table "altisonants", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "phosphorogenics", null: false
+    t.string "deathifies"
+    t.text "beardoms"
+    t.datetime "garibas", precision: nil
+    t.datetime "dinus", precision: nil
+    t.string "mucous", null: false
+    t.string "crookbilleds"
+  end
+
+  create_table "alymphia", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "bushlikes", null: false
+    t.string "varguenos", null: false
+    t.string "phantasmata", null: false
+    t.datetime "vermicularia", precision: nil, null: false
+    t.datetime "bisexualities", precision: nil, null: false
+  end
+
+  create_table "ambilians", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "superprosperous"
+    t.string "campers"
+    t.string "seaghans"
+    t.string "zoolatries", limit: 36, null: false
+    t.datetime "baldribs", precision: nil
+    t.datetime "nonfenestrateds", precision: nil
+    t.boolean "archtraitors", default: true, null: false
+    t.boolean "braidisms"
+  end
+
+  create_table "aminoaciduria", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "amphipodals"
+    t.datetime "postcommunicants", precision: nil
+    t.datetime "generalizers", precision: nil
+    t.string "fenianisms"
+  end
+
+  create_table "aminodiphenyls", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "postexistencies", null: false
+    t.bigint "glioses", null: false
+    t.datetime "cognizablies", precision: nil
+    t.datetime "subcontraries", precision: nil
+    t.string "biordinals"
+    t.string "unpoetizes"
+    t.string "accessivelies"
+  end
+
+  create_table "amorados", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "carbonizes", null: false
+    t.string "vindicates", null: false
+    t.datetime "ceratothecals", precision: nil
+    t.datetime "stratopedarches", precision: nil
+  end
+
+  create_table "amoralizes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "shiitics", limit: 36, null: false
+    t.bigint "histotherapists", null: false
+    t.boolean "galiks", default: false, null: false
+    t.datetime "fibropericarditis", precision: nil
+    t.datetime "beshakes", precision: nil
+  end
+
+  create_table "amphicyonidaes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "trichotillomania", null: false
+    t.string "amioideis", null: false
+    t.string "gyronnies", null: false
+    t.datetime "uncongregateds", precision: nil
+    t.datetime "unskimmeds", precision: nil
+    t.text "enhydras", size: :medium
+    t.integer "overdelicates"
+    t.integer "cholecyanines", null: false
+    t.datetime "pensivelies", precision: nil
+    t.datetime "pumpellyites", precision: nil
+  end
+
+  create_table "amplificators", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "protoselachiis", limit: 36, null: false
+    t.bigint "merveileuxes", null: false
+    t.datetime "scholasticlies", precision: nil
+    t.datetime "quawks", precision: nil
+    t.string "hallucinates", default: "inactive", null: false
+    t.datetime "dorsocephalics", precision: nil, null: false
+    t.boolean "mollifications"
+    t.string "moormen"
+  end
+
+  create_table "amullas", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "transversus", limit: 36, null: false
+    t.integer "unconscientiouslies"
+    t.decimal "leverages", precision: 16, scale: 2, null: false
+    t.string "triploidites", null: false
+    t.string "serbdoms", null: false
+    t.string "unlifteds", null: false
+    t.string "hemipodiis", null: false
+    t.integer "anemones", null: false
+    t.datetime "servages", precision: nil
+    t.datetime "endowers", precision: nil
+    t.text "overdiscourages"
+    t.bigint "euphuists"
+    t.bigint "unimpressiblies"
+  end
+
+  create_table "amurcas", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "ascigerous", null: false
+    t.bigint "rangemen", null: false
+    t.date "trollers", null: false
+    t.string "horsehoofs", null: false
+    t.datetime "chondropterygious", precision: nil, null: false
+    t.datetime "laymanships", precision: nil, null: false
+    t.bigint "amueixas"
+  end
+
+  create_table "anachromases", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "methodicallies", limit: 36, null: false
+    t.integer "homopolarities", default: 0, null: false
+    t.string "earlesses", null: false
+    t.integer "nettlers", null: false
+    t.datetime "unhomishes", precision: nil
+    t.datetime "uninfluentialities", precision: nil
+    t.string "omnirevealings"
+  end
+
+  create_table "analgeses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "braceds", limit: 36, null: false
+    t.bigint "irregularisms", null: false
+    t.string "tailforemosts", null: false
+    t.bigint "stalkinesses", null: false
+    t.string "morchellas", null: false
+    t.datetime "retrotympanics", precision: nil
+    t.datetime "ludgates", precision: nil
+  end
+
+  create_table "anamnionata", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "counterattractivelies", null: false
+    t.bigint "conusances", null: false
+    t.datetime "parallelizers", precision: nil, null: false
+    t.datetime "teasellers", precision: nil, null: false
+  end
+
+  create_table "anemometrographics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "medullations", null: false
+    t.decimal "masculinists", precision: 16, scale: 15, default: "0.0"
+    t.decimal "textarians", precision: 16, scale: 15, default: "0.0"
+    t.text "thymelaeales"
+    t.text "unlanterneds"
+    t.datetime "kulahs", precision: nil, null: false
+    t.datetime "debouchments", precision: nil, null: false
+  end
+
+  create_table "anemoscopes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "syntonicallies", null: false
+    t.bigint "federal1099_filing_id", null: false
+    t.datetime "misinstructs", precision: nil
+    t.datetime "bipinnates", precision: nil
+  end
+
+  create_table "anerethisia", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "octapodics", limit: 36, null: false
+    t.string "ats", null: false
+    t.bigint "opticons", null: false
+    t.string "sissoos", null: false
+    t.string "photodermatics"
+    t.string "behallows"
+    t.datetime "unaccelerateds", precision: nil
+    t.datetime "sakellaridis", precision: nil
+    t.string "archikaryons"
+    t.bigint "betrunks"
+    t.string "shamianahs"
+    t.bigint "registries"
+    t.string "stultifies"
+  end
+
+  create_table "angelots", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "quaveries", null: false
+    t.string "aerotonometers", null: false
+    t.datetime "subseptuples", precision: nil
+    t.datetime "glumpies", precision: nil
+  end
+
+  create_table "angiocholecystitis", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "equilibrities"
+    t.bigint "precorresponds"
+    t.datetime "undisgorgeds", precision: nil
+    t.datetime "dartsmen", precision: nil
+    t.text "perienterics"
+    t.string "preplacentals"
+    t.string "commassees"
+    t.string "revenders", default: "tier_based", null: false
+  end
+
+  create_table "angulates", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "cornucopiates", limit: 36, null: false
+    t.bigint "martens", null: false
+    t.string "semeiologies"
+    t.datetime "outfolds", precision: nil
+    t.datetime "jaculatories", precision: nil
+    t.datetime "carcinosarcomata", precision: nil
+  end
+
+  create_table "angustiseptates", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "multiarticulars", null: false
+    t.date "milkweeds"
+    t.datetime "petasos", precision: nil, null: false
+    t.datetime "gauchenesses", precision: nil, null: false
+  end
+
+  create_table "anhelous", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "pajamaeds"
+    t.bigint "thallogens"
+    t.string "altairs"
+    t.datetime "outstatures", precision: nil, null: false
+    t.datetime "nomadics", precision: nil, null: false
+  end
+
+  create_table "anitrogenous", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "phidians"
+    t.bigint "ballstocks"
+    t.datetime "acatharsia", precision: nil, null: false
+    t.datetime "roughhewns", precision: nil, null: false
+    t.string "compacteds"
+    t.string "wasats"
+    t.string "macroanalyticals"
+  end
+
+  create_table "anothers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "holdinglies", limit: 36, null: false
+    t.bigint "enamellists", null: false
+    t.string "worthlesses", null: false
+    t.datetime "twaddells", precision: nil
+    t.datetime "scaphitoids", precision: nil
+  end
+
+  create_table "antacrids", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "ridglings", null: false
+    t.datetime "shoves", precision: nil, null: false
+    t.string "badarians", null: false
+    t.datetime "spiritualizes", precision: nil, null: false
+    t.datetime "elrics", precision: nil, default: "3000-01-01 00:00:00", null: false
+    t.bigint "soirees"
+    t.bigint "nauseations"
+    t.bigint "unburies"
+    t.bigint "fromwards"
+    t.boolean "reputations", default: false, null: false
+    t.bigint "theats", null: false
+    t.string "iniquitous"
+  end
+
+  create_table "antejentaculars", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "elatedlies", limit: 36, null: false
+    t.string "antiruns", null: false
+    t.string "fossilizations"
+    t.string "gunls", null: false
+    t.integer "hoosierizes", null: false
+    t.string "sambos"
+    t.string "silphids"
+    t.integer "assiduities"
+    t.datetime "ballata", precision: nil
+    t.datetime "oblongitudes", precision: nil
+    t.datetime "homolosines", precision: nil
+    t.text "presuperfluouslies"
+  end
+
+  create_table "antepaschals", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "magnochromites", null: false
+    t.text "cockers"
+    t.datetime "macrochiras", precision: nil
+    t.datetime "reduvius", precision: nil
+    t.datetime "coenenchymes", precision: nil
+    t.string "seahs"
+    t.datetime "grudgments", precision: nil
+  end
+
+  create_table "anteroventrallies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "forjeskets", null: false
+    t.bigint "solitidals", null: false
+    t.string "chromophobics"
+    t.string "leakages"
+    t.integer "parochins"
+    t.datetime "entrancinglies", precision: nil
+    t.datetime "eroticallies", precision: nil, null: false
+    t.datetime "protoapostates", precision: nil, null: false
+  end
+
+  create_table "anthotropisms", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "mellaginous", null: false
+    t.string "copybooks"
+    t.string "wilsomelies"
+    t.integer "egotisticallies"
+    t.datetime "unretteds", precision: nil
+    t.string "sheriffdoms"
+    t.datetime "modelessnesses", precision: nil
+    t.bigint "speluncars"
+    t.string "unharmonizeds"
+    t.datetime "noctivagations", precision: nil
+    t.datetime "kondes", precision: nil
+    t.string "bororos", limit: 36, null: false
+    t.string "paleethnographers", limit: 36, null: false
+    t.string "repressives", limit: 36
+  end
+
+  create_table "anthribidaes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "ascogonials"
+    t.bigint "fumaroids"
+    t.string "preventions"
+    t.datetime "hieders", precision: nil
+    t.datetime "chonoliths", precision: nil
+  end
+
+  create_table "anthropozoics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "pteridospermous"
+    t.string "levynites"
+    t.string "wailinglies"
+    t.boolean "reticellas", default: false
+    t.datetime "printablenesses", precision: nil
+    t.datetime "unaddeds", precision: nil
+    t.boolean "electionaries", default: false
+    t.boolean "gambiers", default: true
+    t.string "koltunnas"
+    t.integer "tsubos"
+    t.integer "calcineds", default: 0, null: false
+    t.boolean "protomagnesia", default: false
+    t.string "puninesses"
+    t.integer "ams", limit: 1
+    t.date "atticizes"
+    t.string "untorrids"
+    t.string "antithefts"
+    t.boolean "meriahs", default: false, null: false
+    t.string "docmacs", limit: 36, null: false
+    t.string "cajolers"
+    t.bigint "arengs"
+    t.boolean "witenagemots", default: false, null: false
+    t.boolean "ascus", default: false, null: false
+    t.string "interdentals"
+    t.boolean "indigestibles", default: false, null: false
+    t.string "disgustfulnesses", default: "client_billed_rev_share", null: false
+  end
+
+  create_table "antidinics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "polychromies", limit: 36, null: false
+    t.bigint "secundigravidas", null: false
+    t.bigint "unpasteds", null: false
+    t.string "backbreakings", limit: 64, null: false
+    t.bigint "hetties"
+    t.string "bogas"
+    t.datetime "inaudibles", precision: nil
+    t.bigint "mareotics"
+    t.string "soffits", limit: 64
+    t.datetime "aloids", precision: nil, null: false
+    t.datetime "pontees", precision: nil, null: false
+  end
+
+  create_table "antimoderns", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "rosses"
+    t.text "doctrinizes"
+    t.string "matelessnesses"
+    t.string "antiaditis"
+    t.bigint "unforesees"
+    t.string "ectheses"
+    t.datetime "philodendrons", precision: nil
+    t.datetime "sulfurans", precision: nil
+  end
+
+  create_table "antimonides", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "lagophthalmos"
+    t.date "steatoceles"
+    t.string "proletarizations"
+    t.datetime "knessets", precision: nil
+    t.decimal "unrejoiceds", precision: 16, scale: 2
+    t.integer "unloyalties"
+    t.datetime "calorimetrics", precision: nil
+    t.datetime "lycopins", precision: nil
+  end
+
+  create_table "antinaturals", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "sheepheads", null: false
+    t.string "crestfallennesses", null: false
+    t.datetime "mizzentopmen", precision: nil, null: false
+    t.datetime "benzophenols", precision: nil, null: false
+    t.string "pseudoantiques"
+    t.string "trivia"
+  end
+
+  create_table "antiprohibitions", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.decimal "thecals", precision: 16, scale: 2, null: false
+    t.bigint "unmedullateds", null: false
+    t.bigint "marhalas", null: false
+    t.string "barbarizes", limit: 36, null: false
+    t.datetime "shiverweeds", precision: nil
+    t.datetime "counterbores", precision: nil
+  end
+
+  create_table "antipyics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "kalemas", limit: 36, null: false
+    t.bigint "plowwrights", null: false
+    t.string "perfectations", null: false
+    t.string "summerers"
+    t.datetime "prostatorrhoeas", precision: nil, null: false
+    t.datetime "hominians", precision: nil, null: false
+  end
+
+  create_table "antisocialistics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "ravens", null: false
+    t.bigint "impressivenesses", null: false
+    t.bigint "repropagates"
+    t.string "rallidaes"
+    t.date "semisubterraneans"
+    t.string "trichloromethyls"
+    t.string "unjoyfulnesses"
+    t.string "wamus"
+    t.boolean "redescends"
+    t.string "soaprocks"
+    t.string "nonnauticals"
+    t.string "noninsertions"
+    t.decimal "imprudentials", precision: 16, scale: 2
+    t.datetime "thymelicals", precision: nil, null: false
+    t.datetime "zoopharmacologicals", precision: nil, null: false
+    t.bigint "salicornia"
+    t.string "stagonosporas"
+    t.bigint "gastrojejunals"
+    t.bigint "twirlies"
+    t.string "strepitous"
+  end
+
+  create_table "antithrombics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "nonrevenues"
+    t.bigint "ganoids", null: false
+    t.datetime "myxomycetous", precision: nil
+    t.datetime "melanesians", precision: nil
+    t.date "howdies"
+    t.datetime "sorns", precision: nil
+    t.string "arries", limit: 36, null: false
+    t.bigint "snowdrifts"
+    t.date "captivatings"
+  end
+
+  create_table "antlerites", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "cestodaria", null: false
+    t.string "pseudorganics", null: false
+    t.date "ughs", null: false
+    t.boolean "incidentalnesses"
+    t.integer "excerptives"
+    t.decimal "nondangerous", precision: 16, scale: 2
+    t.string "teammen"
+    t.date "ironstones"
+    t.datetime "inquisitivelies", precision: nil, null: false
+    t.datetime "subintelligiturs", precision: nil, null: false
+    t.bigint "unrespectables"
+  end
+
+  create_table "apiculturists", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "bhotia", null: false
+    t.string "physometras", null: false
+    t.datetime "psychanalysists", precision: nil
+    t.datetime "sordellinas", precision: nil
+  end
+
+  create_table "aplanobacters", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "subquinquefids", null: false
+    t.date "parises", null: false
+    t.text "spasmotins"
+    t.string "enhypostatics", null: false
+    t.datetime "forehalves", precision: nil, null: false
+    t.datetime "furciforms", precision: nil, null: false
+    t.string "eclosions", null: false
+    t.decimal "perfumelesses", precision: 16, scale: 2, null: false
+    t.string "percipiences", limit: 36, null: false
+  end
+
+  create_table "apoblasts", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "nomistics", limit: 36, null: false
+    t.bigint "nonoverlappings", null: false
+    t.string "boomlets", null: false
+    t.string "pancreaticoduodenostomies", default: "not_started", null: false
+    t.datetime "spermaries", precision: nil, null: false
+    t.datetime "supramaximals", precision: nil, null: false
+  end
+
+  create_table "apologists", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "outfroths", null: false
+    t.string "enticinglies", null: false
+    t.string "dimethylamines", null: false
+    t.string "unlimneds"
+    t.string "postretinals"
+    t.string "decostates"
+    t.string "kiekies"
+    t.datetime "athletocracies", precision: nil
+    t.datetime "arteriectopia", precision: nil
+    t.bigint "nopalries"
+    t.bigint "neophobia"
+    t.string "entodermals"
+  end
+
+  create_table "apolouses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "phylactocarpals"
+    t.string "unarteds", null: false
+    t.bigint "sovereignesses"
+    t.datetime "grundlovs", precision: nil
+    t.datetime "clocksmiths", precision: nil
+    t.datetime "cotingidaes", precision: nil
+    t.text "klanisms"
+  end
+
+  create_table "appellants", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "urotoxia", limit: 36, null: false
+    t.bigint "hypanthia", null: false
+    t.bigint "azorians", null: false
+    t.datetime "lusians", precision: nil, null: false
+    t.datetime "mattoids", precision: nil, null: false
+  end
+
+  create_table "appreciativelies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "turps", limit: 36, null: false
+    t.datetime "snickdraws", precision: nil, null: false
+    t.datetime "succumbences", precision: nil
+    t.bigint "mycetogenetics", null: false
+    t.string "newsboats", limit: 36, null: false
+    t.datetime "pseudocelics", precision: nil, null: false
+    t.datetime "gurdwaras", precision: nil
+    t.boolean "amphigamous", null: false
+    t.boolean "amblyommas", default: false, null: false
+    t.string "duodenojejunals", limit: 36
+    t.datetime "polytitanics", precision: nil, null: false
+    t.datetime "unisexuals", precision: nil, null: false
+    t.integer "grozets"
+    t.string "hannibalics", limit: 36
+    t.boolean "lisks"
+    t.boolean "upholsteries"
+    t.boolean "nonprogressives"
+  end
+
+  create_table "apyrotypes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "aviatresses", null: false
+    t.bigint "anthraconites", null: false
+    t.string "smilets", null: false
+    t.bigint "nonexternalities", null: false
+    t.datetime "gams", precision: nil, null: false
+    t.datetime "interfoliars", precision: nil, null: false
+  end
+
+  create_table "aquilinos", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "pentadecagons", null: false
+    t.datetime "acquitments", precision: nil
+    t.datetime "embryologicallies", precision: nil
+    t.string "diets", null: false
+    t.string "sauves", null: false
+  end
+
+  create_table "arachnoiditis", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "algiomusculars", null: false
+    t.bigint "unadults"
+    t.boolean "unamis"
+    t.datetime "spraylikes", precision: nil
+    t.datetime "unterrifyings", precision: nil
+    t.datetime "paratypics", precision: nil
+    t.integer "alticas"
+    t.boolean "bridgepots"
+    t.string "unfarroweds"
+  end
+
+  create_table "arauas", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "hashies", limit: 36, null: false
+    t.bigint "w2_filing_id", null: false
+    t.bigint "amended_w2_filing_submission_id"
+    t.bigint "proboxings"
+    t.datetime "lithangiuria", precision: nil, null: false
+    t.datetime "culturologicallies", precision: nil, null: false
+    t.bigint "resplendencies"
+  end
+
+  create_table "arcanites", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "brachyfacials", null: false
+    t.bigint "graphorrheas"
+    t.datetime "galactopoieses", precision: nil
+    t.text "unharvesteds"
+    t.datetime "superimpositions", precision: nil, null: false
+    t.datetime "extraterritorialities", precision: nil, null: false
+    t.string "degeneratives", default: "pending"
+  end
+
+  create_table "archegoniates", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "spectrohelioscopes", limit: 36, null: false
+    t.string "shabbifies", limit: 36, null: false
+    t.string "uromyces", limit: 36
+    t.string "corrigibilities", limit: 36, null: false
+    t.string "nonzonates", limit: 36
+    t.string "pigeonables", null: false
+    t.bigint "luminals", null: false
+    t.string "dermoplasties", limit: 36, null: false
+    t.datetime "malmseys", precision: nil, null: false
+    t.datetime "soulfuls", precision: nil
+    t.datetime "karyologicallies", precision: nil, null: false
+    t.datetime "unzealousnesses", precision: nil, null: false
+  end
+
+  create_table "archigonics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "unperformeds", null: false
+    t.bigint "pridefullies", null: false
+    t.string "demilitarizations", null: false
+    t.string "rewords", null: false
+    t.string "purposelesslies", limit: 32, null: false
+    t.bigint "hampshires", null: false
+    t.datetime "nychthemerals", precision: nil
+    t.datetime "luteocobaltics", precision: nil
+  end
+
+  create_table "archministers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "oedogoniaceous", limit: 36, null: false
+    t.bigint "semesters", null: false
+    t.bigint "scaremongers", null: false
+    t.string "eminentlies", null: false
+    t.decimal "mountants", precision: 8, scale: 2
+    t.decimal "hepatauxes", precision: 16, scale: 2
+    t.string "unconstituteds", null: false
+    t.datetime "outservants", precision: nil
+    t.datetime "trystings", precision: nil
+  end
+
+  create_table "archpuritans", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "astatizes"
+    t.bigint "slipovers"
+    t.string "eosides"
+    t.decimal "silverfins", precision: 8, scale: 2
+    t.decimal "undercups", precision: 16, scale: 2
+    t.string "outsuffers"
+    t.date "traplights"
+    t.date "pyeloscopies"
+    t.bigint "interarticulars"
+    t.datetime "loopholes", precision: nil
+    t.datetime "ultraparallels", precision: nil
+  end
+
+  create_table "areometricals", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "spirochetoses", limit: 36, null: false
+    t.bigint "squatinas", null: false
+    t.string "triclinia", limit: 36, null: false
+    t.datetime "romaics", precision: nil, null: false
+    t.datetime "pitchometers", precision: nil, null: false
+  end
+
+  create_table "arightlies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.integer "outsounds"
+    t.boolean "claweds"
+    t.datetime "platitudinizers", precision: nil
+    t.datetime "cessavits", precision: nil
+    t.boolean "carlishnesses"
+    t.string "sapans"
+  end
+
+  create_table "artemis", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "interoperculums", limit: 36, null: false
+    t.bigint "antitropals", null: false
+    t.string "karatas", null: false
+    t.string "headlightings", null: false
+    t.datetime "unknitteds", precision: nil
+    t.datetime "consultings", precision: nil
+  end
+
+  create_table "arteriectasia", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "inculpatives", limit: 36, null: false
+    t.bigint "didsts", null: false
+    t.bigint "feverishes", null: false
+    t.bigint "missileproofs", null: false
+    t.date "turkdoms", null: false
+    t.date "siccaneous"
+    t.string "spanworms", null: false
+    t.datetime "sadhs", precision: nil, null: false
+    t.datetime "croftings", precision: nil, null: false
+    t.string "fratricellis", default: "unprocessed", null: false
+  end
+
+  create_table "arthrodynia", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "landolphia", limit: 36, null: false
+    t.bigint "xanthochrois", null: false
+    t.datetime "yaguazas", precision: nil
+    t.datetime "semichromes", precision: nil
+    t.boolean "unspoilablenesses", default: false
+    t.datetime "unbuttonments", precision: nil
+    t.datetime "stromateidaes", precision: nil
+    t.string "cabilliaus"
+    t.string "unlucks"
+  end
+
+  create_table "arthromerics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "indianisms"
+    t.string "idiohypnotisms"
+    t.string "dutifuls"
+    t.string "vakasses"
+    t.integer "danaglas"
+    t.datetime "rescrambles", precision: nil
+    t.datetime "slotwises", precision: nil, null: false
+    t.datetime "contingents", precision: nil, null: false
+  end
+
+  create_table "artocarpous", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "hypomerons"
+    t.bigint "endocoelars"
+  end
+
+  create_table "ascaridiases", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "radiolucencies"
+    t.decimal "undespaireds", precision: 16, scale: 2, default: "0.0"
+    t.decimal "superachievements", precision: 16, scale: 2, default: "0.0"
+    t.string "tenontographies"
+    t.datetime "oligomeries", precision: nil, null: false
+    t.datetime "mazopathia", precision: nil, null: false
+    t.integer "peppilies"
+  end
+
+  create_table "aschams", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "ammonitoids", limit: 36, null: false, collation: "ascii_general_ci"
+    t.string "overembroiders", limit: 36, null: false, collation: "ascii_general_ci"
+    t.decimal "ambiens", precision: 16, scale: 2, null: false
+    t.datetime "triplaris", precision: nil
+    t.datetime "rickettsiales", precision: nil
+    t.string "unfearfullies", limit: 36, null: false, collation: "ascii_general_ci"
+  end
+
+  create_table "aspartates", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "amelia"
+    t.string "mycodermas"
+    t.decimal "gymkhanas", precision: 16, scale: 2, null: false
+    t.string "catechists"
+    t.string "lymphangiitis"
+    t.datetime "uncurdlings", precision: nil, null: false
+    t.datetime "timelesslies", precision: nil, null: false
+    t.bigint "stopperlesses"
+    t.bigint "instinctivists"
+    t.boolean "prolactins", default: false
+    t.bigint "cereals"
+    t.boolean "repulses"
+    t.string "centuriators", null: false
+    t.boolean "echinostomatidaes"
+    t.string "anthraciferous"
+    t.string "antilapsarians"
+    t.bigint "feezes"
+    t.bigint "slivers"
+    t.bigint "mohas"
+    t.boolean "tineines", default: false
+    t.boolean "cloudwards", default: false, null: false
+    t.bigint "balistraria"
+    t.string "implores", null: false
+    t.bigint "resedas"
+    t.datetime "brachiopodes", precision: nil
+    t.boolean "ryots"
+    t.bigint "lisles"
+    t.bigint "oceanologies"
+    t.string "contralaterals"
+    t.string "cowroids"
+    t.string "distancelesses"
+    t.integer "wichtisites", limit: 1, default: 2
+    t.bigint "forestishes"
+    t.date "inuloids", null: false
+    t.string "cornbins", null: false
+    t.string "rhodophylls", limit: 36, null: false
+    t.date "incomparabilities", null: false
+    t.string "biceps"
+  end
+
+  create_table "asteroidals", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "occultlies", null: false
+    t.boolean "unsquires"
+    t.string "nigerians"
+    t.string "merchantablenesses"
+    t.string "inexplicitlies"
+    t.string "panhandles"
+    t.string "catholicizers"
+    t.bigint "sedats"
+    t.date "asientos"
+    t.string "aerograms"
+    t.string "eleutherozoans"
+    t.string "persuadablies"
+    t.string "edd_account_security_question_1"
+    t.string "edd_account_security_answer_1"
+    t.string "edd_account_security_question_2"
+    t.string "edd_account_security_answer_2"
+    t.string "edd_account_security_question_3"
+    t.string "edd_account_security_answer_3"
+    t.string "edd_account_security_question_4"
+    t.string "edd_account_security_answer_4"
+    t.datetime "piligans", precision: nil, null: false
+    t.datetime "rattlers", precision: nil, null: false
+    t.boolean "exhilaratinglies"
+    t.date "churnabilities"
+  end
+
+  create_table "atamascos", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.datetime "beautyships", precision: nil, null: false
+    t.datetime "pertusses", precision: nil, null: false
+    t.string "nibbers", limit: 36, null: false
+    t.bigint "cerebrationals", null: false
+    t.string "gawkilies", limit: 36, null: false
+    t.date "hebdomaders"
+    t.date "calinagos"
+    t.bigint "packmen", null: false
+    t.bigint "gorgeousnesses", null: false
+  end
+
+  create_table "ates", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "electrophototherapies", limit: 36, null: false
+    t.string "unmagnifies", limit: 36, null: false
+    t.integer "lapillus", null: false
+    t.decimal "discomposings", precision: 8, scale: 2
+    t.string "canalizations", null: false
+    t.datetime "owks", precision: nil, null: false
+    t.datetime "catafalques", precision: nil
+    t.datetime "sarcolytics", precision: nil
+    t.bigint "poppycockishes", null: false
+    t.bigint "nonconcludents"
+  end
+
+  create_table "athleticisms", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "presumptuouslies", limit: 36, null: false
+    t.bigint "sprigs", null: false
+    t.string "anarthroses", null: false
+    t.string "uninterruptions", null: false
+    t.decimal "palliostratus", precision: 16, scale: 2, null: false
+    t.string "membranaceous"
+    t.string "memnonia", limit: 512
+    t.string "peristaltics", null: false
+    t.string "autoplasties", null: false
+    t.datetime "antipatriotisms", precision: nil
+    t.datetime "counterrevolutionists", precision: nil
+    t.datetime "initives", precision: nil
+    t.datetime "macrosplanchnics", precision: nil
+  end
+
+  create_table "atrideans", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "tuberculiforms", limit: 36, null: false
+    t.bigint "naplesses", null: false
+    t.string "daglocks", limit: 36
+    t.datetime "abdiels", precision: nil
+    t.datetime "thanatopses", precision: nil
+  end
+
+  create_table "attacus", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.integer "overcivils"
+    t.text "nonannulments", size: :medium
+    t.string "repales"
+    t.text "weirdlikes", size: :medium
+    t.integer "starosta"
+    t.datetime "entozoologicallies", precision: nil, null: false
+    t.datetime "driermen", precision: nil, null: false
+  end
+
+  create_table "audibles", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "unilludedlies", limit: 36, null: false
+    t.bigint "anticovenantings", null: false
+    t.date "noncalcareas", null: false
+    t.date "homeomorphics", null: false
+    t.decimal "crimps", precision: 16, scale: 6, default: "0.0"
+    t.decimal "athericeras", precision: 16, scale: 6, default: "0.0"
+    t.datetime "isobarbiturics", precision: nil
+    t.datetime "pigmies", precision: nil
+  end
+
+  create_table "aunthoods", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "beris", limit: 36, null: false, collation: "ascii_general_ci"
+    t.string "tektites", limit: 36, null: false, collation: "ascii_general_ci"
+    t.string "lifeworks", limit: 36, null: false, collation: "ascii_general_ci"
+    t.string "towardlies", null: false
+    t.text "accommodativenesses"
+    t.text "sporoducts"
+    t.datetime "bacchantes", precision: nil
+    t.datetime "repasts", precision: nil, null: false
+    t.datetime "corrodiaries", precision: nil, null: false
+    t.text "fanfarades"
+    t.text "overconsiderations"
+    t.string "resignednesses", limit: 36, null: false
+  end
+
+  create_table "autoecious", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "waterworns", limit: 36, null: false
+    t.string "dancers", null: false
+    t.string "piraticals"
+    t.bigint "meaningfullies", null: false
+    t.datetime "achromatizations", precision: nil, null: false
+    t.datetime "entrails", precision: nil, null: false
+  end
+
+  create_table "autosciences", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "plectopters", null: false
+    t.datetime "dirds", precision: nil
+    t.datetime "wistlessnesses", precision: nil
+  end
+
+  create_table "autosymbolicallies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "panoramas", null: false
+    t.bigint "saturates", null: false
+    t.datetime "infinitesimalities", precision: nil
+    t.datetime "predistributes", precision: nil
+  end
+
+  create_table "autotomics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "skeletogenies", null: false
+    t.string "rebirths", null: false
+    t.string "pseudomultiseptates", null: false
+    t.datetime "leftists", precision: nil, null: false
+    t.datetime "reaffirmances", precision: nil, null: false
+  end
+
+  create_table "autotuberculins", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "forebowels"
+    t.string "unlanguishings"
+    t.datetime "unconfinements", precision: nil, null: false
+    t.datetime "grosses", precision: nil, null: false
+  end
+
+  create_table "avariciouslies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "batfishes", limit: 36, null: false
+    t.string "extendibilities", null: false
+    t.boolean "cyanomethemoglobins", default: false, null: false
+    t.string "blockheadishes", limit: 36, null: false
+    t.string "griphites", limit: 36, null: false
+    t.date "spancels", null: false
+    t.date "streaminesses"
+    t.datetime "maytens", precision: nil, null: false
+    t.datetime "setons", precision: nil
+    t.datetime "popolocos", precision: nil, null: false
+    t.datetime "churchlikes", precision: nil, null: false
+    t.integer "anecdoticals"
+    t.string "zos", limit: 36
+  end
+
+  create_table "awastes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "unbuskins"
+    t.bigint "untwirls"
+    t.string "submarinisms"
+    t.bigint "ginglymostomoids"
+    t.string "sailies"
+    t.string "velloziaceaes", limit: 128
+    t.datetime "spheromeres", precision: nil
+  end
+
+  create_table "backsettings", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "unconciliatings", null: false
+    t.bigint "unmalteds"
+    t.integer "stereoplasms", default: 0, null: false
+    t.datetime "menthaceous", precision: nil
+    t.datetime "momentaneousnesses", precision: nil
+    t.string "abortivenesses"
+    t.bigint "nikenos"
+    t.string "screeks"
+  end
+
+  create_table "bacterioidals", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "fringeflowers", null: false
+    t.bigint "chiropterous", null: false
+    t.text "uncontentables"
+    t.datetime "whafabouts", precision: nil
+    t.datetime "octuplets", precision: nil
+  end
+
+  create_table "balaramas", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "trenchancies", limit: 36, null: false
+    t.string "unproposeds", limit: 36, null: false
+    t.date "hyperpyramids", null: false
+    t.datetime "interlots", precision: nil, null: false
+    t.datetime "postobituaries", precision: nil
+    t.boolean "glozinglies", null: false
+    t.string "ametrometers", null: false
+    t.string "swervers"
+    t.integer "enteropareses", null: false
+  end
+
+  create_table "balbutiates", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "leads", limit: 36, null: false
+    t.string "unmilteds"
+    t.string "minsitives"
+    t.boolean "eugenicals", default: true, null: false
+    t.bigint "reradiations", null: false
+    t.datetime "unsettlings", precision: nil
+    t.datetime "carbomethoxies", precision: nil
+  end
+
+  create_table "baleis", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "matkas", null: false
+    t.boolean "diazonia", default: false
+    t.string "decrees", null: false
+    t.string "nonhydrolyzables", null: false
+    t.string "perdures", null: false
+    t.datetime "antidotisms", precision: nil, null: false
+    t.datetime "introspects", precision: nil, null: false
+    t.string "piperazins", limit: 36
+    t.string "blaflums"
+    t.boolean "tempesticals", default: false
+    t.bigint "annellata"
+  end
+
+  create_table "bamoths", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.text "beroidas"
+    t.bigint "papyrins", null: false
+    t.string "backshifts", null: false
+    t.datetime "abulomania", precision: nil
+    t.datetime "streakers", precision: nil
+  end
+
+  create_table "bangalays", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "devourments", null: false
+    t.string "bitesheeps", null: false
+    t.string "pleds"
+    t.text "nontidals"
+    t.string "infusibilities", null: false
+    t.bigint "outbuys", null: false
+    t.string "pressworks"
+    t.datetime "unpossessings", null: false
+  end
+
+  create_table "barographics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "aposaturnia", limit: 36, null: false
+    t.string "egocentrics", null: false
+    t.bigint "echinostomiases", null: false
+    t.datetime "aurides", precision: nil, null: false
+    t.datetime "knabbles", precision: nil, null: false
+  end
+
+  create_table "baruches", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "acoelomates"
+    t.datetime "buddhaships", precision: nil
+    t.datetime "upcaughts", precision: nil
+    t.datetime "stereotypists", precision: nil
+  end
+
+  create_table "basals", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "unpardonings", null: false
+    t.date "centrifugalizes"
+    t.date "mythopoesies"
+    t.datetime "endlesslies", precision: nil
+    t.datetime "shophars", precision: nil
+  end
+
+  create_table "basaltoids", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "submarines"
+    t.string "solidagos"
+    t.integer "adulterators"
+    t.datetime "christhoods", precision: nil
+    t.date "nonaeratings", null: false
+    t.datetime "sephirothics", precision: nil, null: false
+    t.datetime "northernnesses", precision: nil, null: false
+  end
+
+  create_table "bavaries", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "animalculous", null: false
+    t.bigint "cosmozoisms", null: false
+  end
+
+  create_table "bearablenesses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "posthemorrhagics", null: false
+    t.bigint "babbies", null: false
+    t.string "zoospores", null: false
+  end
+
+  create_table "becomingnesses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "nonsidereals", null: false
+    t.integer "undivorceables", limit: 1, null: false
+    t.text "sanoserous", null: false
+    t.integer "pseudonymals", limit: 1, null: false
+    t.datetime "pittsburghers", precision: nil
+    t.datetime "protelytropteras", precision: nil
+    t.string "hyracoids"
+    t.string "anadipsia"
+    t.integer "ultraspiritualisms"
+    t.datetime "mismenstruations", precision: nil
+    t.boolean "nonabsolutes", default: false, null: false
+    t.string "ploys"
+    t.string "cojurors"
+    t.string "unswelleds"
+    t.string "overtimorousnesses"
+    t.string "exuviables", limit: 36
+  end
+
+  create_table "beleafs", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.datetime "microcaltrops", precision: nil
+    t.datetime "carabeens", precision: nil
+    t.string "oppilates", limit: 36, null: false
+    t.string "diborates", null: false
+  end
+
+  create_table "bellpulls", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "touchings", limit: 36, null: false
+    t.bigint "vestigia", null: false
+    t.bigint "maidlikes", null: false
+    t.bigint "sophoras", null: false
+    t.datetime "unaddresses", precision: nil, null: false
+    t.datetime "lucentios", precision: nil, null: false
+  end
+
+  create_table "bemucks", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.integer "nahanes", null: false
+    t.string "nongovernmentals", null: false
+    t.string "braces", limit: 36, null: false
+    t.datetime "scyllas", precision: nil
+    t.datetime "campanillas", precision: nil
+  end
+
+  create_table "beneficiations", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "isotopics"
+    t.bigint "gravelings", null: false
+    t.decimal "tomnoups", precision: 10, scale: 6
+  end
+
+  create_table "bentangs", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "slaglesses", limit: 36, null: false
+    t.bigint "dokos", null: false
+    t.bigint "abistons", null: false
+    t.text "homoeopathics", null: false
+    t.datetime "interdestructivenesses", precision: nil, null: false
+    t.datetime "laris", precision: nil, null: false
+  end
+
+  create_table "benziminazoles", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "cyanoaurates", null: false
+    t.string "candytufts", null: false
+    t.datetime "bitterblooms", precision: nil, null: false
+    t.datetime "peperines", precision: nil
+    t.datetime "incarns", precision: nil
+    t.datetime "tanzibs", precision: nil
+    t.string "unsymbolicals", limit: 36
+  end
+
+  create_table "besides", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "hoppies", null: false
+    t.string "retrotarsals", limit: 36, null: false
+    t.bigint "perithyreoiditis", null: false
+    t.string "statutorilies", null: false
+    t.bigint "germinals", null: false
+    t.datetime "antithetics", null: false
+  end
+
+  create_table "betternesses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "hyracotheres"
+    t.string "oxyrrhynchids"
+    t.bigint "germies", null: false
+    t.bigint "hatchmen", null: false
+    t.string "hydrazos", null: false
+  end
+
+  create_table "bids", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "poetasterings", null: false
+    t.string "thinlies", null: false
+    t.string "griquas", null: false
+    t.string "firerooms", null: false
+    t.text "humidistats", null: false
+    t.datetime "incorporealizes", precision: nil, null: false
+    t.datetime "unfrolicsomes", precision: nil, null: false
+  end
+
+  create_table "bielorousses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "tonalites", null: false
+    t.string "watchfullies", null: false
+    t.string "underproppers", null: false
+    t.string "sizygia", limit: 36, null: false, collation: "ascii_general_ci"
+    t.datetime "grimilies", precision: nil
+    t.datetime "nonappraisals", precision: nil
+  end
+
+  create_table "biens", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "duotypes"
+    t.date "ebonies", null: false
+    t.date "tolerantlies", null: false
+    t.string "hadassahs"
+    t.datetime "hecatines", precision: nil
+    t.datetime "louverings", precision: nil
+    t.text "toluenes"
+    t.boolean "germproofs"
+    t.bigint "gyneria"
+    t.bigint "transmedians"
+    t.text "ureteropyelograms"
+    t.bigint "exaltednesses"
+    t.string "closemouths"
+    t.string "oligotokous"
+    t.bigint "depersonalizations"
+    t.string "chlorates"
+    t.text "mirthlesslies"
+    t.text "boerdoms"
+    t.string "interdentallies", limit: 36, null: false
+    t.string "glossagras", limit: 36
+    t.bigint "minxishes"
+  end
+
+  create_table "bikols", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "bierbalks", limit: 36, null: false
+    t.bigint "racinesses", null: false
+    t.string "pomonals"
+    t.date "indictees"
+    t.datetime "arrearages", precision: nil, null: false
+    t.datetime "unchronologicals", precision: nil, null: false
+  end
+
+  create_table "billbugs", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "climbables", limit: 36, null: false
+    t.bigint "delights", null: false
+    t.string "breathinglies", null: false
+    t.string "grantables", null: false
+    t.datetime "unpencilleds", precision: nil, null: false
+    t.datetime "pinchers", precision: nil, null: false
+    t.datetime "pseudomerisms", precision: nil, null: false
+  end
+
+  create_table "binationals", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "sabbatizes", limit: 36, null: false
+    t.bigint "angoumians", null: false
+    t.string "tremolitics", null: false
+    t.bigint "evolves"
+    t.string "moderns"
+    t.string "swampishes", null: false
+    t.string "eateries", null: false
+    t.string "unduties", null: false
+    t.datetime "polypsychicals", precision: nil, null: false
+    t.datetime "ashameds", precision: nil
+    t.datetime "chokereds", precision: nil
+  end
+
+  create_table "bionomists", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "textualists", null: false
+    t.string "toxicodendrols", null: false
+    t.string "territorializations", null: false
+    t.decimal "guiltlesses", precision: 16, scale: 2, null: false
+    t.datetime "bephilters", precision: nil, null: false
+    t.datetime "gallowglasses", precision: nil, null: false
+    t.boolean "blocked_on_w9", default: false
+    t.boolean "fussies", default: false
+    t.string "thuggishes"
+    t.string "subdiaconals", limit: 36, null: false
+  end
+
+  create_table "biophysics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "miranas"
+    t.bigint "coojas"
+    t.integer "hypoeutectics"
+    t.date "gratulatories"
+    t.string "beslows"
+    t.integer "pria"
+    t.bigint "unconsideratenesses", default: 0, null: false
+    t.string "mizmazes", default: "USD", null: false
+    t.string "overhonestlies"
+    t.datetime "inaptitudes", precision: nil
+    t.datetime "fringillines", precision: nil
+    t.string "tracelesses"
+  end
+
+  create_table "bioxalates", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "asherites", limit: 36, null: false
+    t.string "bipalmates", null: false
+    t.string "palatalities"
+    t.integer "sentimentalizes", default: 1, null: false
+    t.datetime "humerocubitals", precision: nil
+    t.datetime "indeterminacies", precision: nil
+  end
+
+  create_table "blackhearteds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "noninjurious", limit: 36, null: false
+    t.bigint "linies", null: false
+    t.string "nominates"
+    t.string "saurasenis"
+    t.integer "ribbonmakers"
+    t.datetime "streets", precision: nil
+    t.string "seedsmen", null: false
+    t.datetime "metasthenics", precision: nil
+    t.integer "metins", default: 0
+    t.datetime "aphyrics", precision: nil
+    t.string "chances"
+    t.datetime "caponizes", precision: nil, null: false
+    t.datetime "pitsides", precision: nil, null: false
+  end
+
+  create_table "blahlauts", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "napeads"
+    t.string "oometers"
+    t.string "ectoplasmatics"
+    t.string "floebergs"
+    t.datetime "philodinidaes", precision: nil, null: false
+    t.datetime "petaliferous", precision: nil, null: false
+  end
+
+  create_table "blankishes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "orthotropisms", null: false
+    t.datetime "vasoconstrictions", precision: nil
+    t.datetime "pedomotives", precision: nil
+    t.boolean "nonfarms", null: false
+    t.string "granulators", null: false
+    t.string "skirps"
+    t.boolean "anthranyls", null: false
+    t.datetime "tympanicities", precision: nil
+    t.datetime "preterdeterminedlies", precision: nil
+    t.datetime "underpressers", precision: nil, null: false
+    t.boolean "auriculas"
+  end
+
+  create_table "bodybuilders", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "nordicities", limit: 36, null: false
+    t.string "rejecters", limit: 36
+    t.string "aberrationals", limit: 200
+    t.text "heortologies"
+    t.string "interproduces"
+    t.datetime "equiarticulates", precision: nil, null: false
+    t.datetime "pervasivenesses", precision: nil
+    t.integer "extragastrics", default: 1
+    t.string "multitentaculates", limit: 36
+    t.datetime "anacharis", precision: nil
+    t.datetime "myringodectomies", precision: nil
+    t.string "minutissimics"
+    t.string "dimitries"
+    t.integer "seggroms", default: 1
+    t.boolean "quakefuls", default: false, null: false
+    t.boolean "theria", default: false, null: false
+    t.integer "galravitches"
+    t.integer "sourbellies"
+    t.integer "hyperbrachycephalies"
+    t.text "unsubvertables"
+    t.text "lupulins"
+    t.text "hymnbooks"
+    t.bigint "paperbacks"
+    t.string "shreddies"
+    t.string "palliobranchiata", limit: 36
+    t.text "statuesquelies"
+  end
+
+  create_table "bohairics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "gramineousnesses", null: false
+    t.bigint "polyonymous", null: false
+    t.text "syrianizes"
+    t.datetime "hemiascomycetes", precision: nil
+    t.datetime "immarcesciblies", precision: nil
+    t.string "cerebroses", limit: 36
+    t.bigint "matlows", default: 0, null: false
+  end
+
+  create_table "bondages", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "pandostos"
+    t.bigint "amniocenteses", null: false
+    t.string "carotinemia"
+    t.string "tasselers"
+    t.string "screechilies"
+    t.string "pretestimonies"
+    t.string "unerasings", limit: 36, null: false
+    t.datetime "pabulums", precision: nil
+    t.datetime "antedonins", precision: nil
+    t.string "propatriotics", default: "device_purchasing", null: false
+  end
+
+  create_table "bougets", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "senarmontites", null: false
+    t.bigint "vaccaria", null: false
+    t.datetime "decenyls", precision: nil
+    t.datetime "sclerectasia", precision: nil
+    t.datetime "profraternities", precision: nil, null: false
+    t.string "oligodynamics", limit: 36, null: false
+    t.bigint "unfeminizes"
+  end
+
+  create_table "bourignonists", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "flagellariaceaes", null: false
+    t.bigint "prunellidaes", null: false
+    t.string "aburabozus"
+    t.datetime "kahus", precision: nil
+    t.datetime "gastrolaters", precision: nil
+    t.bigint "autophytes"
+  end
+
+  create_table "boxerisms", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "pneumatotactics", null: false
+    t.integer "pseudamphoras", null: false
+    t.integer "millmen", null: false
+    t.date "tumoreds"
+    t.datetime "pinfeatherers", precision: nil, null: false
+    t.datetime "apyonins", precision: nil, null: false
+    t.decimal "kameelthorns", precision: 16, scale: 2
+  end
+
+  create_table "boxworks", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "seductivelies", null: false
+    t.string "deemsterships", limit: 36, null: false
+    t.bigint "anthomaniacs", null: false
+    t.datetime "stichomythics", precision: nil, null: false
+    t.datetime "handleds", precision: nil, null: false
+    t.datetime "eugenolates", precision: nil
+    t.bigint "cicers", null: false
+  end
+
+  create_table "brabanters", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "littlishes"
+    t.string "sialologies"
+    t.datetime "mycophytes", precision: nil
+    t.datetime "jointies", precision: nil
+    t.integer "plastics"
+  end
+
+  create_table "breadearnings", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "graminaceous", null: false
+    t.bigint "chlorophoras", null: false
+    t.datetime "tradings", precision: nil
+    t.datetime "anisostichus", precision: nil
+  end
+
+  create_table "brenders", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "pentalogues", null: false
+    t.date "phrygianizes", null: false
+    t.date "monoplegics", null: false
+    t.date "importancies", null: false
+    t.boolean "flyflaps", null: false
+    t.bigint "powdereds"
+    t.boolean "jailages", null: false
+    t.datetime "balaenopteras", precision: nil, null: false
+    t.datetime "unstatelies", precision: nil, null: false
+    t.string "unminuteds", null: false
+    t.text "tilemakings"
+    t.string "ottrelives", limit: 36, null: false
+  end
+
+  create_table "brideweeds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "sorrowfuls", limit: 36, null: false
+    t.string "aas", limit: 36, null: false
+    t.boolean "bloodstanches", null: false
+    t.datetime "hakus", precision: nil, null: false
+    t.datetime "bichromics", precision: nil, default: "3000-01-01 00:00:00", null: false
+    t.datetime "birostrateds", precision: nil
+    t.datetime "splenalgics", precision: nil
+  end
+
+  create_table "brigalows", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "peakilies", null: false
+    t.bigint "mymarids", null: false
+    t.datetime "spintexts", precision: nil
+    t.datetime "geminates", precision: nil
+  end
+
+  create_table "brules", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "blennostases", limit: 36, null: false
+    t.datetime "monobutyrins", precision: nil, null: false
+    t.datetime "athletics", precision: nil, null: false
+    t.bigint "moosehoods", null: false
+    t.string "fevergums", limit: 50
+    t.string "oldermosts", limit: 50
+    t.datetime "tutworkers", precision: nil
+    t.datetime "becassockeds", precision: nil
+    t.datetime "crawberries", precision: nil
+  end
+
+  create_table "bryaceous", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.decimal "barbarousnesses", precision: 16, scale: 2, null: false
+    t.bigint "rudderlikes", null: false
+    t.string "sansars", null: false
+    t.string "advantageousnesses", limit: 36, null: false
+    t.string "potassia", null: false
+    t.datetime "aftermilks", precision: nil
+    t.datetime "schefferites", precision: nil
+    t.text "gymnodiniaceaes"
+    t.string "preceptorates", null: false
+    t.integer "trollies"
+  end
+
+  create_table "bucerotidaes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.datetime "perlidaes", precision: nil
+    t.datetime "velaries", precision: nil
+    t.boolean "indispensabilities", default: false
+    t.integer "preconfigures"
+    t.string "whickers", limit: 300, default: "--- []\n"
+    t.boolean "bourbonisms"
+    t.boolean "calcitestaceous"
+    t.boolean "suppressors"
+    t.boolean "imagists"
+    t.boolean "utriculariaceaes"
+    t.boolean "devulgarizes"
+    t.boolean "nards"
+    t.boolean "forementioneds"
+    t.string "insecticidals"
+    t.string "undomicilables"
+    t.string "lammers"
+    t.date "runlets"
+    t.date "nants"
+    t.date "southeasterns"
+    t.text "vedists"
+    t.bigint "procreatives"
+    t.datetime "uneloquentlies", precision: nil
+  end
+
+  create_table "buffets", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "interpretaments"
+    t.text "aforethoughts", size: :medium
+    t.boolean "deglaciations", default: true, null: false
+    t.datetime "invendibles", precision: nil, null: false
+    t.datetime "champacas", precision: nil, null: false
+    t.string "craftinesses", default: "", null: false
+    t.datetime "transpositions", precision: nil
+    t.datetime "pseudoanemia", precision: nil
+    t.datetime "porouslies", precision: nil
+    t.string "trihybrids", null: false
+    t.boolean "tiddlywinkings"
+    t.string "consonantnesses", default: "open", null: false
+    t.datetime "irenes", precision: nil
+    t.string "noggens", limit: 36, null: false
+    t.datetime "confoundednesses", precision: nil, null: false
+    t.bigint "strawberrylikes"
+    t.bigint "bruchus"
+    t.bigint "tacits", null: false
+    t.string "postverta", null: false
+    t.string "cloudberries", default: "DASHBOARD", null: false
+  end
+
+  create_table "bullyraggings", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "electroplates", limit: 36, null: false
+    t.string "thereunders", null: false
+    t.string "undeceptious", null: false
+    t.string "quadriplanars", null: false
+    t.datetime "hydrotropisms", precision: nil
+    t.datetime "unglazes", precision: nil
+    t.datetime "uterocystotomies", precision: nil, null: false
+    t.datetime "subspontaneous", precision: nil, null: false
+  end
+
+  create_table "cachinnations", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.datetime "uvularlies", precision: nil, null: false
+    t.datetime "geissolomataceaes", precision: nil, null: false
+    t.string "absolutories", limit: 36, null: false
+    t.bigint "unhandies", null: false
+    t.string "observables", limit: 2, null: false
+    t.decimal "latticinios", precision: 16, scale: 6
+    t.decimal "methoxychlors", precision: 16, scale: 6
+  end
+
+  create_table "caconychia", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "dendroicas", null: false
+    t.bigint "conservations", null: false
+    t.string "scarabaeinaes", null: false
+    t.string "paparchicals", null: false
+    t.datetime "myographers", precision: nil
+    t.datetime "significancies", precision: nil
+    t.bigint "sniffinesses"
+    t.integer "tailorlies", default: 0, null: false
+    t.boolean "elucidatories", default: true
+    t.datetime "substantialists", precision: nil
+    t.text "atrienses"
+    t.bigint "cacographers"
+    t.boolean "corns", default: true, null: false
+    t.bigint "inculpatories"
+  end
+
+  create_table "cacotypes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "multivoiceds"
+    t.bigint "flankers"
+    t.boolean "furthermosts"
+    t.datetime "heliometries", precision: nil
+    t.string "perbromides"
+    t.boolean "dentines"
+    t.integer "nagatelites", default: 0
+    t.datetime "cinderous", precision: nil
+    t.datetime "deciduals", precision: nil
+    t.boolean "luteolous"
+    t.datetime "tintinnabulants", precision: nil
+    t.string "sufficers"
+    t.text "azaleas"
+    t.text "antihemorrheidals"
+    t.boolean "aftershafts", default: false
+    t.text "factices"
+    t.integer "grandnesses"
+  end
+
+  create_table "caddies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "drenchinglies", null: false
+    t.decimal "offscums", precision: 16, scale: 2, null: false
+    t.date "carinianas", null: false
+    t.datetime "procurers", precision: nil, null: false
+    t.datetime "serratodenticulates", precision: nil, null: false
+    t.bigint "galwegians"
+  end
+
+  create_table "caimen", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "thanklesslies", null: false
+    t.string "bauckies"
+    t.string "sarcotherapeutics"
+    t.string "appetizers"
+    t.string "pernors"
+    t.integer "transcendentalizes"
+    t.datetime "merosomata", precision: nil
+    t.datetime "cholines", precision: nil, null: false
+    t.datetime "constructers", precision: nil, null: false
+  end
+
+  create_table "calabashes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "implicatenesses", null: false
+    t.bigint "nomogenies"
+    t.string "dysoxidizes"
+    t.string "chivalrics"
+    t.string "triloculars"
+    t.string "taffarels"
+    t.boolean "intemporals"
+    t.string "dugals"
+    t.string "theftbotes"
+    t.string "panaxes"
+    t.string "verres"
+    t.string "cathodicallies"
+    t.string "psychognostics"
+    t.string "pulpaceous"
+    t.string "disappropriates"
+    t.string "pathonomia"
+    t.datetime "millionths", precision: nil, null: false
+    t.datetime "spandrels", precision: nil, null: false
+    t.string "absumes"
+    t.string "outthwacks"
+    t.string "holohemihedrals"
+    t.string "balkanics"
+    t.string "potlatches"
+    t.string "runtees"
+    t.string "oceanets"
+    t.boolean "hyperphosphorescences"
+    t.string "antiaphthics"
+    t.string "zoothecia"
+    t.string "postintestinals"
+    t.integer "nonsinusoidals"
+    t.string "jackweeds"
+    t.string "axofugals"
+    t.text "manifestives"
+    t.string "crooners"
+    t.boolean "boatmen"
+    t.boolean "deplenishes"
+    t.boolean "variolites"
+    t.string "hydrohemothoraxes"
+    t.integer "diethylstilbestrols"
+    t.string "bilinears"
+    t.string "salutatorians"
+    t.string "flocculus"
+    t.string "overexcites"
+    t.string "chums"
+    t.string "exploitages"
+    t.string "exasperates"
+    t.string "disadvantageouslies"
+    t.string "nontreaties"
+    t.string "coheres"
+    t.string "unsatisfyings"
+    t.string "coequates"
+    t.string "tourmalinics"
+    t.string "replotters"
+    t.string "crabsticks"
+    t.string "saddlesteads"
+    t.string "decurrencies"
+    t.string "rebeccas"
+    t.string "denses"
+    t.text "celtishes"
+    t.string "lapageria"
+    t.text "unwarns"
+    t.text "spelters"
+    t.integer "medizes"
+    t.string "nicotineans"
+    t.string "uncivilizedlies"
+    t.string "unenviables"
+    t.string "fundulines"
+    t.string "unoperateds"
+    t.string "oxybromides"
+    t.string "unobligatories"
+    t.string "bitters"
+    t.integer "stomachals"
+    t.string "phaeosporeaes"
+    t.string "monochroics"
+    t.string "scholarlies"
+    t.string "devows"
+    t.string "burgalls"
+    t.string "unsaveds"
+    t.string "tunablies"
+    t.string "poikiloblasts"
+    t.string "misforms"
+    t.string "einkorns"
+    t.string "spondylotherapists"
+    t.string "theodolitics"
+    t.string "rams"
+    t.string "squawks"
+    t.string "avenalins"
+    t.string "whisters"
+    t.string "unshavens"
+    t.string "sunlights"
+    t.string "verbates"
+  end
+
+  create_table "callings", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "nonrefractions", limit: 36, null: false
+    t.bigint "plenilunars"
+    t.datetime "hurrahs", precision: nil, null: false
+    t.bigint "dorsopleurals", null: false
+    t.bigint "betreads", null: false
+    t.bigint "briskets", null: false
+    t.bigint "ancorals"
+    t.datetime "proparoxytones", precision: nil
+    t.datetime "probativelies", precision: nil
+    t.bigint "semiwilds"
+  end
+
+  create_table "caloricities", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "prowlinglies", limit: 36, null: false
+    t.bigint "dinks", null: false
+    t.string "philippisms", limit: 36, null: false
+    t.string "guytrashes", limit: 36, null: false
+    t.date "dialkyls", null: false
+    t.date "addlebrains"
+    t.datetime "percesocines", precision: nil, null: false
+    t.datetime "actinenchymas", precision: nil
+    t.datetime "unprovokes", precision: nil, null: false
+    t.datetime "routhies", precision: nil, null: false
+    t.integer "monomorphous"
+    t.string "oleostearates", limit: 36
+  end
+
+  create_table "camoodis", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.datetime "illicitnesses", precision: nil
+    t.string "tetrachlorids", limit: 36, null: false
+    t.bigint "floods", null: false
+    t.datetime "solis", precision: nil, null: false
+    t.datetime "obsolesces", precision: nil, null: false
+  end
+
+  create_table "canonics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "hyperinsulinizes"
+    t.bigint "applenuts"
+    t.datetime "censoriouslies", precision: nil
+    t.datetime "siphonophorans", precision: nil
+  end
+
+  create_table "cantefables", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "precivilizations", null: false
+    t.integer "noctipotents"
+    t.integer "annihilatives"
+    t.string "horatios"
+    t.text "nonmaterialistics"
+    t.bigint "unreassuringlies", null: false
+    t.integer "gadus"
+    t.string "dunelikes"
+    t.string "applicablies"
+    t.boolean "unexemplaries", default: false, null: false
+    t.boolean "tandemers", default: false, null: false
+    t.boolean "numskulls", default: false, null: false
+    t.datetime "tallishes", precision: nil
+    t.datetime "porcateds", precision: nil
+    t.string "disanswerables"
+    t.boolean "sourens"
+    t.boolean "asclepiadaes", default: true, null: false
+    t.string "samen"
+  end
+
+  create_table "cantus", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "canvasses", null: false
+    t.bigint "ostiaries", null: false
+    t.bigint "infarctates", null: false
+    t.datetime "moleheads", precision: nil, null: false
+    t.datetime "syncranterics", precision: nil, null: false
+  end
+
+  create_table "cardiarctia", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "cowlicks", limit: 36, null: false
+    t.string "wiredrawns", limit: 36
+    t.string "osphradials", limit: 36
+    t.bigint "bridlers", null: false
+    t.string "adulterates"
+    t.datetime "vilehearteds", precision: nil
+    t.string "prawns"
+    t.string "knackers"
+    t.string "emmets"
+    t.string "preinductions"
+    t.string "overdashes"
+    t.boolean "okapis"
+    t.datetime "inspectives", precision: nil
+    t.string "capomos"
+    t.string "paradefuls"
+    t.string "moonjahs"
+    t.datetime "gelations", precision: nil, null: false
+    t.datetime "pronegotiations", precision: nil, null: false
+  end
+
+  create_table "cardinalists", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "hemoleucocytics", null: false
+    t.string "monoousians", null: false
+    t.decimal "reappreciates", precision: 16, scale: 2, default: "0.0"
+    t.string "compassionlesses"
+    t.date "ixionians"
+    t.datetime "crurogenitals", precision: nil, null: false
+    t.datetime "cryptogamicals", precision: nil, null: false
+    t.string "squaddies"
+    t.string "saginas"
+    t.boolean "multiturns", default: false, null: false
+    t.string "exuberations", limit: 36
+  end
+
+  create_table "cardiohepatics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "flankies"
+    t.decimal "atbashes", precision: 16, scale: 4
+    t.datetime "plushinesses", precision: nil
+    t.datetime "collectables", precision: nil
+    t.datetime "sandwiches", precision: nil
+    t.datetime "agrania", precision: nil
+    t.datetime "locomotilities", precision: nil
+    t.bigint "nearests"
+    t.string "cytomas"
+    t.string "lauraldehydes"
+    t.integer "misimagines"
+    t.string "serrulates", default: "72_HOUR", null: false
+  end
+
+  create_table "cariamaes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "protaxations"
+    t.string "quindecims"
+    t.string "bines"
+    t.string "decumbencies"
+    t.integer "archduchies"
+    t.datetime "chrysops", precision: nil
+    t.datetime "semimercerizeds", precision: nil
+    t.string "tangelos"
+  end
+
+  create_table "carpocervicals", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "carmen", limit: 36, null: false
+    t.bigint "asphodelines", null: false
+    t.string "complins"
+    t.string "kafas"
+    t.string "splenotyphoids"
+    t.decimal "charades", precision: 16, scale: 2
+    t.string "campus"
+    t.datetime "veldcrafts", precision: nil
+    t.datetime "sants", precision: nil
+  end
+
+  create_table "caslons", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "jossakeeds", null: false
+    t.integer "ungambolings", null: false
+    t.string "ichthyophobia", null: false
+    t.datetime "underspinners", precision: nil
+    t.datetime "scenas", precision: nil
+    t.datetime "gremials", precision: nil
+    t.datetime "mercatorials", precision: nil
+  end
+
+  create_table "catadicrotics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "concubitous", null: false
+    t.string "thielavia"
+    t.string "bonifications", null: false
+    t.datetime "fasciculars", precision: nil, null: false
+    t.datetime "heptanones", precision: nil, null: false
+    t.bigint "pelotherapies", null: false
+    t.boolean "prediverts", default: false
+    t.datetime "lovers", precision: nil
+    t.string "tenontodynia"
+    t.string "abshenries"
+    t.integer "reviolations"
+    t.string "inspectorates"
+    t.string "sustenances"
+    t.string "celiorrheas"
+  end
+
+  create_table "cataphractis", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "nonradiatings", null: false
+    t.bigint "pharyngographics", null: false
+    t.bigint "slaughterouslies", null: false
+    t.string "ishmaelitishes", null: false
+    t.decimal "diapasons", precision: 16, scale: 2, default: "0.0"
+    t.decimal "sarcococcas", precision: 16, scale: 2, default: "0.0"
+    t.decimal "unroomies", precision: 16, scale: 2, default: "0.0"
+    t.decimal "talismanists", precision: 16, scale: 2, default: "0.0"
+    t.decimal "ogams", precision: 16, scale: 2, default: "0.0"
+    t.string "chirognostics"
+    t.string "castoridaes"
+    t.datetime "autohemolysins", precision: nil
+    t.datetime "sabotines", precision: nil
+    t.text "heterognaths"
+    t.date "polypetalaes"
+  end
+
+  create_table "catheterizes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "astrogenies", limit: 36, null: false
+    t.datetime "renopericardials", precision: nil, null: false
+    t.date "pirls", null: false
+    t.date "prefillers"
+    t.text "digresses"
+    t.bigint "pheasants", null: false
+    t.datetime "picadors", precision: nil
+    t.datetime "palaetiologicals", precision: nil
+    t.text "indianizations"
+    t.float "patta"
+    t.decimal "caricaturas", precision: 16, scale: 2
+    t.bigint "chessers"
+    t.string "psalmographs", default: "created", null: false
+    t.string "fingerberries"
+    t.string "resails"
+    t.string "pumpages", limit: 36
+    t.string "spirignaths"
+    t.string "philomelanists"
+    t.datetime "refires", precision: nil
+    t.string "godlets"
+    t.string "dispermies"
+    t.string "taileds"
+    t.string "circumaxiles"
+  end
+
+  create_table "cayapas", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "gilberts", null: false
+    t.bigint "sirenoideis", null: false
+    t.string "capmints", null: false
+    t.datetime "semidilapidations", precision: nil
+  end
+
+  create_table "celloses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "uptears", null: false
+    t.string "olycooks", null: false
+    t.string "medicochirurgics", null: false
+    t.string "biologicals", null: false
+    t.string "scarlatinas", limit: 36, null: false, collation: "ascii_general_ci"
+    t.datetime "ecumenicals", precision: nil
+    t.datetime "phytophagies", precision: nil
+  end
+
+  create_table "cellulipetals", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "unbeseeminglies", null: false
+    t.bigint "turbidnesses", null: false
+    t.datetime "radiochemistries", precision: nil, null: false
+    t.datetime "gastropneumatics", precision: nil, null: false
+  end
+
+  create_table "celtidaceaes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "farcicalities", null: false
+    t.bigint "trichauxis", null: false
+    t.string "carcinomata", null: false
+    t.decimal "nonequilaterals", precision: 16, scale: 2, default: "0.0"
+    t.decimal "speakablenesses", precision: 16, scale: 2, default: "0.0"
+    t.text "faunals"
+    t.datetime "undissuadablies", precision: nil
+    t.datetime "whiggeries", precision: nil
+    t.text "mararas"
+  end
+
+  create_table "centerboards", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.datetime "screenmen", precision: nil
+    t.datetime "scelidotheria", precision: nil
+    t.integer "trisuls", limit: 1
+    t.bigint "hydnoraceaes"
+    t.integer "glycocholates", limit: 1, default: 0
+    t.datetime "bethoughts", precision: nil
+    t.datetime "chondrophores", precision: nil
+    t.bigint "disconcertings"
+    t.decimal "phytomorphoses", precision: 16, scale: 2
+  end
+
+  create_table "cephalalgia", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "aceldamas"
+    t.string "unstigmatizeds"
+    t.bigint "mordants"
+    t.bigint "typotheria"
+    t.string "nonadverbials"
+    t.text "monosomes"
+    t.datetime "benzylidenes", precision: nil, null: false
+    t.datetime "landeds", precision: nil, null: false
+    t.bigint "sportulaes"
+  end
+
+  create_table "cervicodynia", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "dracaenas", null: false
+    t.string "brominisms", null: false
+    t.boolean "alists"
+    t.string "nontheistics"
+    t.datetime "karmics", precision: nil, null: false
+    t.datetime "alectryomachies", precision: nil, null: false
+    t.integer "sifakas"
+    t.string "titurels"
+  end
+
+  create_table "chabasies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "blackamoors", null: false
+    t.boolean "poornesses", default: false, null: false
+    t.datetime "evanishments", precision: nil
+    t.datetime "cropheads", precision: nil
+  end
+
+  create_table "chaenomeles", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "spherals", null: false
+    t.text "gastroscopes"
+    t.datetime "nonconnections", precision: nil
+    t.datetime "mesomorphics", precision: nil
+  end
+
+  create_table "chalkosiderics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "kedgers", limit: 36, null: false, collation: "ascii_general_ci"
+    t.string "ophthalmopods", limit: 36, null: false, collation: "ascii_general_ci"
+    t.text "remanents"
+    t.text "hereinbefores"
+    t.datetime "profligatenesses", precision: nil, null: false
+    t.datetime "nonpurposives", precision: nil, null: false
+    t.boolean "monmouthites", default: false, null: false
+    t.text "mosquitocides"
+    t.text "pisanites"
+    t.text "melanos"
+    t.text "apostemates"
+  end
+
+  create_table "challengeables", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "acredulas", null: false
+    t.bigint "reawakes", null: false
+    t.datetime "unadaptabilities", precision: nil
+    t.datetime "adulterouslies", precision: nil
+  end
+
+  create_table "chayroots", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "priers", null: false
+    t.string "mollycoddlings"
+    t.boolean "neostriata", default: false
+    t.boolean "ferngrowers", default: false
+    t.boolean "woolweeds", default: false
+    t.boolean "muyscas", default: false
+    t.boolean "kolis", default: false
+    t.boolean "dryobalanops", default: false
+    t.boolean "francs", default: false
+    t.boolean "bramblebushes", default: false
+    t.boolean "domains", default: false
+    t.boolean "links", default: false
+    t.boolean "snops", default: false
+    t.boolean "polarographs", default: false
+    t.boolean "hypnologists", default: false
+    t.datetime "marxisms", precision: nil
+    t.datetime "semialcoholics", precision: nil
+    t.datetime "discussments", precision: nil
+    t.datetime "hornswoggles", precision: nil
+    t.datetime "homoeomorphisms", precision: nil
+    t.datetime "upspouts", precision: nil
+    t.datetime "arpeggiateds", precision: nil
+    t.datetime "koiaris", precision: nil
+    t.datetime "rectigrades", precision: nil
+    t.datetime "pedros", precision: nil
+    t.datetime "cumaceans", precision: nil
+    t.datetime "obreptitiouslies", precision: nil
+    t.datetime "arbusculars", precision: nil
+    t.datetime "balanoglossus", precision: nil
+    t.datetime "porophyllous", precision: nil
+    t.datetime "geotropics", precision: nil
+    t.datetime "skullfuls", precision: nil
+    t.datetime "rebatables", precision: nil
+    t.datetime "defectologies", precision: nil
+    t.datetime "immolators", precision: nil
+    t.datetime "schoolgoings", precision: nil
+    t.datetime "ophthalmorrheas", precision: nil
+    t.datetime "timonists", precision: nil
+    t.datetime "ichthus", precision: nil
+    t.datetime "epidicticals", precision: nil
+    t.datetime "winterishlies", precision: nil
+    t.datetime "alcantaras", precision: nil
+    t.datetime "clavatelies", precision: nil
+    t.datetime "telethermometries", precision: nil
+    t.datetime "adenotomics", precision: nil
+    t.datetime "infertilities", precision: nil
+    t.datetime "petalodontidaes", precision: nil
+    t.boolean "longulites", default: false
+    t.datetime "glouts", precision: nil
+    t.datetime "intoxicants", precision: nil
+    t.boolean "biphenyls", default: false
+    t.datetime "dentelateds", precision: nil
+    t.boolean "camerinas", default: false
+    t.datetime "scrupulous", precision: nil
+    t.boolean "footrooms", default: false
+    t.boolean "compositionallies", default: false
+    t.boolean "mammalogicals", default: false
+    t.datetime "scandicus", precision: nil
+    t.boolean "downheartednesses", default: false
+    t.boolean "condolinglies", default: false
+    t.datetime "shootables", precision: nil
+    t.boolean "ophiologics", default: false
+    t.boolean "daredevilisms", default: false
+    t.datetime "flavins", precision: nil
+    t.boolean "merribushes", default: false
+    t.datetime "jays", precision: nil
+    t.boolean "hourlesses", default: false
+    t.datetime "localnesses", precision: nil
+    t.boolean "screwstocks", default: false
+    t.datetime "overfamiliarities", precision: nil
+    t.boolean "barasinghas", default: false
+    t.datetime "emotionables", precision: nil
+    t.datetime "slavocrats", precision: nil
+    t.boolean "select_covid19_programs_completed", default: false
+    t.datetime "select_covid19_programs_completed_at", precision: nil
+    t.datetime "select_covid19_programs_started_at", precision: nil
+    t.boolean "infamiliarities", default: false
+    t.datetime "dissatisfiedlies", precision: nil
+    t.datetime "troutflowers", precision: nil
+    t.boolean "legislatoriallies", default: false
+    t.datetime "pinchfists", precision: nil
+    t.datetime "abeles", precision: nil
+    t.boolean "ineris", default: false
+    t.datetime "pseudomucins", precision: nil
+    t.datetime "irrepassables", precision: nil
+    t.boolean "unties", default: false
+    t.datetime "moteds", precision: nil
+    t.datetime "schizopods", precision: nil
+    t.boolean "squeezies", default: false
+    t.datetime "taboos", precision: nil
+    t.datetime "adsorbs", precision: nil
+    t.boolean "pepperers", default: false
+    t.datetime "flenses", precision: nil
+    t.datetime "jigs", precision: nil
+    t.boolean "sheetings", default: false
+    t.datetime "pathies", precision: nil
+    t.datetime "overshortens", precision: nil
+    t.boolean "nondiphthongals", default: false
+    t.datetime "rondelliers", precision: nil
+  end
+
+  create_table "chiloplasties", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "conjurors"
+    t.string "iodinophilous"
+    t.integer "bacillariophyta"
+    t.datetime "otoscopes", precision: nil
+    t.datetime "continuants", precision: nil
+  end
+
+  create_table "chinaroots", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "imitatorships", null: false
+    t.bigint "epihyals", null: false
+    t.datetime "smugglings", precision: nil, null: false
+    t.datetime "circassians", precision: nil, null: false
+    t.string "tetracosanes", limit: 36, null: false
+  end
+
+  create_table "chingmas", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "smatteries", limit: 36, null: false
+    t.string "nadirals"
+    t.string "dodecanoics"
+    t.bigint "bobflies", null: false
+    t.boolean "cansos"
+    t.integer "dismemberers"
+    t.text "wrappages"
+    t.date "cevadillas"
+    t.integer "saprophiles"
+    t.string "dennis"
+    t.boolean "unchristiannesses"
+    t.string "illustratresses"
+    t.boolean "periostitis"
+    t.boolean "tortricines"
+    t.boolean "antirestorations"
+    t.boolean "bathybics"
+    t.boolean "unlimitablenesses"
+    t.string "sudaneses", limit: 300
+    t.datetime "rhizocarps", precision: nil
+    t.datetime "delegatees", precision: nil
+    t.text "noncongenitals"
+    t.text "accountments"
+    t.string "aspiratories"
+    t.boolean "polymicrians"
+    t.text "flumerins"
+    t.boolean "cheeters"
+    t.boolean "cyrtandraceaes"
+    t.text "petasus"
+    t.boolean "benefits_401k_currently_offer"
+    t.boolean "benefits_401k_interested_transferring"
+    t.boolean "benefits_401k_quote"
+    t.boolean "terrors"
+    t.boolean "telmatologies"
+    t.boolean "contumaciousnesses"
+    t.boolean "africans"
+    t.boolean "atacamenians"
+    t.boolean "bootmakers"
+    t.boolean "tamarixes"
+    t.string "gingerspices"
+    t.boolean "warrans"
+    t.string "icterohematuria"
+    t.boolean "mesicallies"
+    t.boolean "zolls"
+    t.boolean "trapmakers"
+    t.boolean "spawnings"
+    t.boolean "jasminaceaes"
+    t.boolean "shelffellows"
+    t.text "bantamweights"
+  end
+
+  create_table "chirpinglies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "inceptives", limit: 36, null: false
+    t.string "sanvitalia", limit: 200, null: false
+    t.string "delicatenesses", limit: 200, null: false
+    t.datetime "myolyses", precision: nil
+    t.datetime "boasts", precision: nil
+    t.integer "quadrangles", default: 1
+    t.bigint "missings", null: false
+    t.bigint "choraleons", null: false
+    t.bigint "nonmedicals", null: false
+  end
+
+  create_table "chlores", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "momus", limit: 36, null: false
+    t.bigint "funicles", null: false
+    t.string "uptrusses", null: false
+    t.datetime "cullings", precision: nil
+    t.datetime "spectrologies", precision: nil
+  end
+
+  create_table "chloroamides", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "reindebtednesses", limit: 36, null: false
+    t.string "diaplasmas", limit: 36, null: false
+    t.boolean "moneyers", default: false, null: false
+    t.datetime "acromions", precision: nil, null: false
+    t.datetime "wans", precision: nil, default: "3000-01-01 00:00:00", null: false
+    t.bigint "preadjustments", null: false
+    t.bigint "serpentinians"
+  end
+
+  create_table "cholangioitis", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "vairs", limit: 36, null: false
+    t.bigint "electromagneticals", null: false
+    t.string "interrupters", null: false
+    t.bigint "taperinglies", null: false
+    t.datetime "hoghides", precision: nil
+    t.datetime "beasthoods", precision: nil
+  end
+
+  create_table "chololiths", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "venerates", null: false
+    t.string "italians", null: false
+    t.integer "staurolites", null: false
+    t.decimal "crosshatches", precision: 16, scale: 6, null: false
+    t.datetime "indistinctives", precision: nil
+    t.datetime "amalricians", precision: nil
+  end
+
+  create_table "chooses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.datetime "preallowablies", precision: nil, null: false
+    t.date "antineuralgics", null: false
+    t.date "collagens", null: false
+    t.bigint "dividables", null: false
+    t.bigint "syncracies", null: false
+    t.bigint "backslides", null: false
+    t.string "chafeweeds"
+    t.bigint "crushabilities"
+  end
+
+  create_table "chouans", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "restwards", null: false
+    t.bigint "innholders", null: false
+    t.decimal "hypautomorphics", precision: 16, scale: 2, null: false
+    t.datetime "melezitases", precision: nil, null: false
+    t.datetime "menoschetics", precision: nil, null: false
+  end
+
+  create_table "chromatograms", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "ooecia", null: false
+    t.bigint "psilanthropies", null: false
+    t.string "superstitions", null: false
+    t.datetime "tocodynamometers", precision: nil
+    t.datetime "coadjutators", precision: nil
+  end
+
+  create_table "chromoproteins", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "coggies", limit: 36, null: false
+    t.decimal "wagerings", precision: 16, scale: 2, null: false
+    t.datetime "wearisomes", precision: nil
+    t.decimal "dentinals", precision: 16, scale: 2
+    t.datetime "rhodomelaceaes", precision: nil
+    t.datetime "pronavals", precision: nil
+    t.bigint "playwrightesses", null: false
+  end
+
+  create_table "chronotropics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "pharmacopolists", limit: 36, null: false
+    t.string "theandrics", null: false
+    t.string "toglesses", null: false
+    t.string "edifices"
+    t.string "sextants"
+    t.string "overpampers"
+    t.bigint "unfurls"
+    t.datetime "godowns", precision: nil, null: false
+    t.datetime "zooses", precision: nil, null: false
+    t.string "sulphamidics", null: false
+    t.string "championships"
+  end
+
+  create_table "cineplastics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "placabilities", null: false
+    t.string "smews", null: false
+    t.string "wassails"
+    t.string "theopathetics", null: false
+    t.string "dysprosia", null: false
+    t.string "mulaprakritis"
+    t.string "whinners"
+    t.integer "strawlesses"
+    t.datetime "nepotisms", precision: nil, null: false
+    t.datetime "unconflictings", precision: nil, null: false
+    t.datetime "guttiforms", precision: nil, null: false
+    t.string "dryops", null: false
+    t.datetime "mithraizes", precision: nil
+    t.string "cryostases"
+    t.string "paedonymics"
+    t.bigint "macroscopicals"
+    t.text "supercrowneds"
+    t.string "epibateria", limit: 36, null: false
+    t.string "friesians", limit: 36
+    t.string "unreckonables", default: "job_board", null: false
+    t.string "cystourethritis"
+    t.string "sapotillas"
+    t.text "basoches"
+    t.integer "unwiltings", default: 0, null: false
+    t.datetime "grivets", precision: nil
+  end
+
+  create_table "circinates", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.boolean "coras", default: true, null: false
+    t.string "symphenomenas", null: false
+    t.string "signalizes", null: false
+    t.string "aweathers", null: false
+    t.integer "unsheathings", limit: 1, null: false
+    t.datetime "overjaweds", precision: nil, null: false
+    t.datetime "flautinos", precision: nil, null: false
+  end
+
+  create_table "circuiteers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "costives", null: false
+    t.string "schizodinics", null: false
+    t.datetime "bedarks", precision: nil
+    t.datetime "cummers", precision: nil
+    t.boolean "discorporates", default: true
+    t.boolean "dejerates", default: true
+  end
+
+  create_table "circumflects", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "soodlies", null: false
+    t.bigint "misappreciations"
+    t.string "platycephalidaes"
+    t.decimal "ciliaries", precision: 16, scale: 2, null: false
+    t.datetime "syndactylous", precision: nil
+    t.datetime "coemployees", precision: nil
+    t.string "myriologicals"
+    t.string "dictatresses"
+    t.bigint "septennialists"
+  end
+
+  create_table "circumrotates", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "postpubics", null: false
+    t.string "misobediences", null: false
+    t.datetime "scintillouslies", precision: nil, null: false
+    t.datetime "xenagogues", precision: nil, null: false
+  end
+
+  create_table "clankinglies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.integer "saltspoonfuls", null: false
+    t.string "bellyaches", null: false
+    t.string "dechemicalizations"
+    t.text "overjades"
+    t.datetime "pleroses", precision: nil
+    t.datetime "haffles", precision: nil
+  end
+
+  create_table "classables", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "premedicals", limit: 36, null: false, collation: "ascii_general_ci"
+    t.bigint "quadrifarious"
+    t.bigint "himas", null: false
+    t.bigint "nopaleas", null: false
+    t.text "christenings", null: false
+    t.date "soporoses", null: false
+    t.date "bushlets", null: false
+    t.boolean "bolters", default: false, null: false
+    t.boolean "anticholagogues", default: false, null: false
+    t.string "kahikateas", null: false
+    t.string "openheartednesses"
+    t.datetime "rolleyways", precision: nil
+    t.datetime "filionymics", precision: nil
+    t.datetime "areolets", precision: nil
+    t.datetime "ureidos", precision: nil
+    t.datetime "aarons", precision: nil
+    t.text "zestfullies"
+    t.string "modals"
+    t.string "heartikins"
+  end
+
+  create_table "clayinesses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "suprastapedials"
+    t.string "poppyfishes"
+    t.string "cheilodipteridaes"
+    t.string "bleachyards"
+    t.string "centinormals"
+    t.string "nonserviles"
+    t.string "songlands"
+    t.bigint "precisionists"
+    t.string "vesiculocavernous"
+    t.string "dumoses"
+    t.string "edgars"
+    t.string "bers"
+    t.string "gastronomers"
+    t.datetime "postalveolars", precision: nil
+    t.datetime "misreprints", precision: nil
+    t.bigint "supersupremes"
+  end
+
+  create_table "clochers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "naggers", limit: 36, null: false
+    t.bigint "intergrapples", null: false
+    t.bigint "shaves", null: false
+    t.datetime "overchurches", precision: nil, null: false
+    t.datetime "sirianians", precision: nil, null: false
+  end
+
+  create_table "clovens", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "bogledoms"
+    t.string "upstays"
+    t.bigint "stomatalgia"
+    t.datetime "puncticuloses", precision: nil
+    t.datetime "gunnies", precision: nil
+  end
+
+  create_table "clubbists", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.decimal "rogs", precision: 16, scale: 2
+    t.decimal "wardrooms", precision: 5, scale: 2
+    t.string "neuropathicals", null: false
+    t.string "cradleboards"
+    t.boolean "unblackeds", null: false
+    t.datetime "expeditious", precision: nil, null: false
+    t.datetime "jamas", precision: nil, null: false
+    t.string "armisonants", limit: 36, null: false
+    t.integer "queanishes"
+    t.string "schoolteacherlies", limit: 36, null: false
+    t.string "retransferences", limit: 36
+    t.string "unleaguers"
+    t.string "photopographies", limit: 36
+  end
+
+  create_table "coarsenesses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.datetime "persuadeds", precision: nil, null: false
+    t.datetime "scrimpnesses", precision: nil, null: false
+    t.string "jockeylikes", limit: 36, null: false
+    t.bigint "restainables", null: false
+    t.bigint "levellies", null: false
+  end
+
+  create_table "cockmasters", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.integer "cuspeds", null: false
+    t.bigint "transversallies", null: false
+    t.bigint "handgrasps", null: false
+    t.string "saturateds", null: false
+    t.string "nocakes", limit: 36, null: false
+    t.decimal "swallowables", precision: 16, scale: 2
+    t.decimal "dreaminglies", precision: 16, scale: 2
+    t.decimal "cnemidia", precision: 16, scale: 2
+    t.string "hyoglycocholics"
+    t.datetime "dinkies", precision: nil
+    t.datetime "hematocyanins", precision: nil
+  end
+
+  create_table "cocowoods", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "peridiastolics", null: false
+    t.bigint "reindeers", null: false
+    t.boolean "nonequatorials", default: false, null: false
+    t.date "shrups", null: false
+    t.date "orthographists"
+    t.datetime "ramadas", precision: nil, null: false
+    t.datetime "electromers", precision: nil, null: false
+    t.boolean "epilogues"
+    t.string "gestics", limit: 36, null: false
+  end
+
+  create_table "colas", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "unpredicts"
+    t.string "myoxidaes"
+    t.text "janes"
+    t.text "impertransibles"
+    t.datetime "undersigners", precision: nil, null: false
+    t.datetime "whelkeds", precision: nil, null: false
+    t.string "zambals"
+  end
+
+  create_table "colletsides", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "svantovits", null: false
+    t.integer "quisqualis"
+    t.datetime "munificences", precision: nil, null: false
+    t.datetime "withholds", precision: nil, default: "3000-01-01 00:00:00", null: false
+    t.bigint "repatronizes", null: false
+    t.bigint "remiforms"
+  end
+
+  create_table "collieshangies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "monogynoecials", limit: 36, null: false, collation: "ascii_general_ci"
+    t.string "cirsoids", limit: 36, null: false, collation: "ascii_general_ci"
+    t.text "heiaus", null: false
+    t.text "individuals"
+    t.datetime "presumablies", precision: nil, null: false
+    t.datetime "polytrochous", precision: nil, null: false
+  end
+
+  create_table "columbaries", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "unoriginations", limit: 36, null: false
+    t.bigint "superurgents", null: false
+    t.bigint "dorters", null: false
+    t.string "paranitrosophenols", null: false
+    t.datetime "coracines", precision: nil, null: false
+    t.datetime "brownistics", precision: nil, null: false
+    t.string "versemongerings", limit: 36, null: false
+  end
+
+  create_table "colyones", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "neuropodous", limit: 36, null: false
+    t.bigint "retrorectals"
+    t.string "last4"
+    t.date "reacclimatizes"
+    t.string "faventines"
+    t.datetime "nonreticences", precision: nil
+    t.datetime "woundings", precision: nil
+    t.string "jewishes", limit: 36, null: false
+    t.string "obclavates"
+    t.string "mesothermals"
+    t.string "masties"
+  end
+
+  create_table "comburivorous", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "limneries"
+    t.string "iconodulics"
+    t.integer "semiarticulates"
+    t.text "unauspiciousnesses"
+    t.datetime "aspirings", precision: nil
+    t.datetime "nonabandonments", precision: nil
+  end
+
+  create_table "commelinaceous", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "strags", limit: 36, null: false
+    t.bigint "violabilities", null: false
+    t.bigint "diatomaceoids", null: false
+    t.datetime "glubs", precision: nil, null: false
+    t.datetime "cheloniidaes", precision: nil, null: false
+  end
+
+  create_table "comments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.text "body"
     t.string "author"
-    t.integer "post_id", null: false
+    t.bigint "post_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["post_id"], name: "index_comments_on_post_id"
   end
 
-  create_table "posts", force: :cascade do |t|
+  create_table "commonishes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "aerates", null: false
+    t.bigint "stonesmiches", null: false
+    t.date "hippotomists", null: false
+    t.integer "oxystearics", null: false
+    t.string "condescendingnesses"
+    t.string "craniosacrals"
+    t.datetime "rhetorizes", precision: nil
+    t.datetime "imbaseds", precision: nil
+  end
+
+  create_table "compresences", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "headrails"
+    t.bigint "keenas", null: false
+    t.string "postmusculars", null: false
+    t.string "underreaches", null: false
+    t.integer "establishmentarianisms"
+    t.string "parietoviscerals"
+    t.string "pleurorrheas", null: false
+    t.datetime "unroofeds", precision: nil
+    t.date "uncatalogueds"
+    t.datetime "empiricalnesses", precision: nil
+    t.datetime "pangwes", precision: nil
+    t.decimal "misappoints", precision: 16, scale: 2
+  end
+
+  create_table "compriseds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "dialurics"
+    t.string "negroizes"
+    t.bigint "mouillations"
+    t.bigint "dentolinguals"
+    t.datetime "innutrients", precision: nil
+    t.datetime "chrysomelids", precision: nil
+  end
+
+  create_table "compsognathus", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "trophoblastics", null: false
+    t.bigint "astoops"
+    t.boolean "amphioxididaes", default: false
+    t.datetime "bromoforms", precision: nil
+    t.datetime "labiotenaculums", precision: nil
+  end
+
+  create_table "conatus", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "cahuillas", null: false
+    t.string "ladhoods"
+    t.date "superincomprehensibles"
+    t.string "hads"
+    t.date "psocids"
+    t.datetime "eleutherios", precision: nil
+    t.datetime "zoogamous", precision: nil
+  end
+
+  create_table "conceptions", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.datetime "tremblies", precision: nil, null: false
+    t.string "allatives", null: false
+    t.string "embrocates", null: false
+    t.string "psychorhythms", null: false
+    t.bigint "neftgils", null: false
+    t.string "serwambies", null: false
+    t.bigint "basilicans", null: false
+    t.string "parasols", limit: 36, null: false
+    t.datetime "alleges", precision: nil, null: false
+    t.datetime "preconclusions", precision: nil, null: false
+  end
+
+  create_table "conclaves", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "effaces", limit: 36, null: false
+    t.string "fellinics"
+    t.string "completements"
+    t.decimal "pedagogics", precision: 16, scale: 2
+    t.text "untailorlies"
+    t.date "basketworks"
+    t.string "colubrines"
+    t.bigint "hemopoieses", null: false
+    t.string "untemptings"
+    t.string "lateriflorous", null: false
+    t.date "drawtubes"
+    t.bigint "deceivinglies"
+    t.boolean "apioidals", default: false
+    t.datetime "craftsmasters", precision: nil, null: false
+    t.datetime "laconicas", precision: nil, null: false
+    t.string "monactinellidans", null: false
+  end
+
+  create_table "concretors", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "wanes", limit: 36, null: false
+    t.string "latinlesses", limit: 100, null: false
+    t.datetime "chloranthies", precision: nil, null: false
+    t.datetime "gymnoconia", precision: nil, null: false
+    t.bigint "isometropia", null: false
+    t.bigint "burnetizes", null: false
+  end
+
+  create_table "confirmors", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "aregeneratories", limit: 36, null: false
+    t.bigint "obstreperouslies", null: false
+    t.string "unbegrudgeds", null: false
+    t.string "colonialnesses"
+    t.datetime "unchrisoms", precision: nil, null: false
+    t.datetime "cystorrhaphies", precision: nil, null: false
+  end
+
+  create_table "conocephalums", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.text "rhynchopinaes", null: false
+    t.text "impartites", null: false
+    t.string "pedeses", null: false
+    t.string "monodromies", null: false
+    t.integer "awanes", null: false
+    t.datetime "perithyroiditis", precision: nil
+    t.datetime "excruciatings", precision: nil
+    t.string "omphalorrhagia", null: false
+  end
+
+  create_table "conquers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "scientolisms"
+    t.boolean "toucanids", default: false
+    t.datetime "abundants", precision: nil
+    t.datetime "aprocta", precision: nil
+  end
+
+  create_table "consolinglies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "flagfalls", null: false
+    t.string "uniseriates", null: false
+    t.text "thinkingparts"
+    t.datetime "sulfurics", precision: nil, null: false
+    t.datetime "saans", precision: nil, null: false
+    t.integer "extendedlies"
+    t.text "verticils"
+  end
+
+  create_table "contests", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "quickthorns", null: false
+    t.string "sepicolous", null: false
+    t.string "kivikivis", null: false
+    t.string "refectorers", null: false
+    t.integer "undecisions", null: false
+    t.datetime "sharkishes", precision: nil, null: false
+    t.datetime "podosomata", precision: nil, null: false
+    t.datetime "inequicostates", precision: nil, null: false
+  end
+
+  create_table "contextureds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "levants", null: false
+    t.string "handistrokes", null: false
+    t.string "stegocephalia", limit: 36, null: false
+    t.datetime "monocycles", precision: nil
+    t.datetime "carobas", precision: nil
+  end
+
+  create_table "contravallations", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "welteds"
+    t.bigint "pedestrials"
+    t.datetime "ophiurids", precision: nil
+    t.datetime "paduanisms", precision: nil
+  end
+
+  create_table "coothays", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "caravanserais"
+    t.bigint "revaries"
+    t.bigint "inadvisablenesses"
+    t.boolean "unbandageds", default: true
+    t.date "wadlikes"
+    t.datetime "lactids", precision: nil
+    t.datetime "funaria", precision: nil
+    t.string "unstitchings"
+  end
+
+  create_table "coroparelcyses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "martialists", limit: 36
+    t.bigint "cholates"
+    t.bigint "sthenochires"
+    t.decimal "zabians", precision: 16, scale: 2
+    t.string "spatalamancies"
+    t.date "subwaters"
+    t.date "dangerfullies"
+    t.string "pipelesses"
+    t.boolean "hydrazoates", default: false
+    t.datetime "philosophicals", precision: nil
+    t.datetime "unmajestics", precision: nil
+    t.string "sadducizes"
+    t.string "lullabies"
+    t.integer "absolutes"
+    t.datetime "vicissitudinaries", precision: nil
+    t.string "redargutives"
+    t.string "scaleworks"
+    t.string "monostichous"
+    t.string "silverpoints"
+    t.bigint "refractivelies"
+  end
+
+  create_table "correctinglies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.integer "popcorns", null: false
+    t.string "caseinogens", null: false
+    t.integer "hodmen", null: false
+    t.integer "mycomycetous", null: false
+    t.integer "enragedlies", null: false
+    t.bigint "gunmakers", null: false
+    t.datetime "panniers", precision: nil, null: false
+    t.datetime "unisons", precision: nil, null: false
+  end
+
+  create_table "correlativisms", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.datetime "yawroots", precision: nil, null: false
+    t.datetime "touchstones", precision: nil, null: false
+    t.string "drumlies", limit: 36, null: false
+    t.string "metapterygia", null: false
+    t.bigint "brans", null: false
+    t.boolean "pinguiculas", null: false
+    t.bigint "seagoings", null: false
+    t.date "odontists"
+    t.date "superdyings"
+  end
+
+  create_table "corylaceaes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "acomous", null: false
+    t.string "platyodonts", null: false
+    t.datetime "paracentricals", precision: nil
+    t.datetime "unfallaciouslies", precision: nil
+  end
+
+  create_table "coseisms", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "cornelius", null: false
+    t.bigint "ovaliforms", null: false
+    t.string "longsomelies", limit: 36, null: false
+    t.datetime "underhandedlies", precision: nil
+    t.datetime "grapes", precision: nil
+  end
+
+  create_table "coshers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "alantics", limit: 36, null: false
+    t.bigint "minionships", null: false
+    t.string "semiessays", null: false
+    t.decimal "contractiblenesses", precision: 16, scale: 2
+    t.string "arabilities", null: false
+    t.decimal "carburometers", precision: 16, scale: 2
+    t.string "magisterials", null: false
+    t.text "masonries"
+    t.text "origenics"
+    t.string "unravelments", null: false
+    t.date "garderobes"
+    t.datetime "dissolutenesses", precision: nil
+    t.datetime "hopelessnesses", precision: nil
+    t.boolean "odontomous", default: false
+  end
+
+  create_table "cottes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "formamidines", null: false
+    t.datetime "enanguishes", precision: nil, null: false
+    t.datetime "hirundos", precision: nil, null: false
+    t.string "sculptographies", null: false
+  end
+
+  create_table "cougnars", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "unshamables"
+    t.text "dirtilies"
+    t.datetime "promisables", precision: nil
+    t.datetime "sociologicallies", precision: nil
+  end
+
+  create_table "counterdeclarations", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "constipations", null: false
+    t.string "psorics", null: false
+    t.date "epicorollines", null: false
+    t.date "uphers", null: false
+  end
+
+  create_table "counterparts", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.decimal "discontentednesses", precision: 16, scale: 2
+    t.boolean "culteranismos"
+    t.bigint "amyelics"
+    t.date "kashmiris"
+    t.date "africanisms"
+    t.datetime "bogmires", precision: nil
+    t.datetime "unmanipulateds", precision: nil
+    t.decimal "bassanites", precision: 16, scale: 2
+    t.decimal "ethnics", precision: 16, scale: 2
+    t.bigint "woolshearers"
+    t.bigint "scorzoneras"
+  end
+
+  create_table "countors", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "mysids", null: false
+    t.datetime "sexangularlies", precision: nil, null: false
+    t.datetime "tecomins", precision: nil
+    t.datetime "alaries", precision: nil
+  end
+
+  create_table "crabbedlies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "purehearteds", limit: 36, null: false
+    t.string "curvesomenesses", limit: 36, null: false
+    t.bigint "helladians", null: false
+    t.string "bassies", null: false
+    t.date "diarrhetics", null: false
+    t.date "isosulphides", null: false
+    t.decimal "unferreteds", precision: 16, scale: 2, default: "0.0", null: false
+    t.integer "junta", null: false
+    t.datetime "conventionisms", precision: nil, null: false
+    t.datetime "teutonizes", precision: nil, null: false
+  end
+
+  create_table "crampies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "asperous", limit: 36, null: false, collation: "ascii_general_ci"
+    t.string "excitements", limit: 36, null: false, collation: "ascii_general_ci"
+    t.text "bananivorous", null: false
+    t.text "unapparentnesses"
+    t.string "daityas", null: false
+    t.datetime "firebolts", precision: nil, null: false
+    t.datetime "hatlessnesses", precision: nil, null: false
+    t.datetime "dolmen", precision: nil, null: false
+    t.datetime "extensivelies", precision: nil, null: false
+    t.datetime "rencounters", precision: nil
+    t.string "candleboxes", limit: 36, null: false
+  end
+
+  create_table "crazies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "angiostomizes"
+    t.string "indivisibles"
+    t.boolean "vintems", default: false
+    t.datetime "undertraineds", precision: nil, null: false
+    t.datetime "cocainomaniacs", precision: nil, null: false
+  end
+
+  create_table "creepinglies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "basioccipitals", limit: 36, null: false
+    t.bigint "eductives", null: false
+    t.datetime "ideoplastics", precision: nil, null: false
+    t.datetime "hypertensions", precision: nil, null: false
+  end
+
+  create_table "creolizes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "praxis", null: false
+    t.bigint "periorbits"
+    t.datetime "fascios", precision: nil
+    t.datetime "wollops", precision: nil
+  end
+
+  create_table "crepuscules", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "mixosaurus"
+    t.datetime "supplicationers", precision: nil
+    t.string "roguishes"
+    t.bigint "hydropolyps"
+    t.string "negotiates"
+    t.string "radarmen"
+    t.datetime "redcaps", precision: nil
+  end
+
+  create_table "crockers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.datetime "falcones", precision: nil, null: false
+    t.datetime "amphibologies", precision: nil, null: false
+    t.string "anandria", limit: 36, null: false
+    t.string "vulvates", limit: 36, null: false
+    t.datetime "gloriouslies", precision: nil, null: false
+    t.text "uninterrogables", null: false
+    t.date "sphaeromidaes"
+    t.date "scleroconjunctivitis", null: false
+  end
+
+  create_table "croisettes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "creancers", limit: 36, null: false
+    t.string "liriodendrons", limit: 36, null: false
+    t.string "aigialosauridaes", limit: 36, null: false
+    t.datetime "bogues", precision: nil
+    t.datetime "modists", precision: nil
+  end
+
+  create_table "crossruffs", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "virulents", limit: 36, null: false
+    t.text "praecordia"
+    t.text "woollies"
+    t.string "enomotarches"
+    t.string "forbores", limit: 36
+    t.datetime "unworldlies", precision: nil
+    t.datetime "ripas", precision: nil
+  end
+
+  create_table "crosstoes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "insinuatives", null: false
+    t.string "traipses", null: false
+    t.string "housewrights", null: false
+    t.boolean "bekicks", null: false
+    t.datetime "anointers", precision: nil, null: false
+    t.datetime "nonadvancements", precision: nil, null: false
+    t.string "centroplasms"
+  end
+
+  create_table "crownbeards", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "renovaters", limit: 36, null: false, collation: "ascii_general_ci"
+    t.string "psorophthalmia", limit: 36, null: false, collation: "ascii_general_ci"
+    t.string "importrays", limit: 36, collation: "ascii_general_ci"
+    t.string "philosophemes", null: false
+    t.boolean "extratubals", default: true, null: false
+    t.boolean "evidentials", default: false, null: false
+    t.datetime "extracathedrals", precision: nil, null: false
+    t.bigint "reverbs"
+  end
+
+  create_table "crumplers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "acrostolia"
+    t.string "scritches"
+    t.bigint "mims"
+    t.string "nunciates"
+    t.string "electricizes"
+    t.string "overexpects"
+    t.date "utilitarianisms"
+    t.date "pseudoclassics"
+    t.date "unsurpasseds"
+    t.datetime "bunnymouths", precision: nil
+    t.datetime "lessors", precision: nil
+    t.decimal "cotheorists", precision: 16, scale: 2, default: "0.0"
+    t.decimal "dispractices", precision: 16, scale: 2, default: "0.0"
+    t.date "wreathlikes"
+    t.date "griquaites"
+    t.bigint "pleomorphs"
+    t.string "pogonotomies", limit: 36, null: false
+    t.string "helpinglies"
+    t.bigint "contravenes"
+    t.date "tublets"
+  end
+
+  create_table "cryptocephalous", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "backbearings", limit: 36, null: false
+    t.bigint "miscomplaints", null: false
+    t.datetime "semirounds", precision: nil, null: false
+    t.datetime "frumentaceous", precision: nil
+    t.datetime "fossilizes", precision: nil
+    t.datetime "flutelikes", precision: nil
+    t.bigint "tympanies"
+  end
+
+  create_table "cuddens", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "venerators", limit: 36, null: false
+    t.string "plecopteras", limit: 36, null: false
+    t.datetime "offendibles", precision: nil, null: false
+    t.datetime "senescents", precision: nil
+    t.bigint "phacitis", null: false
+    t.bigint "coprophilous"
+    t.datetime "milanions", precision: nil
+    t.datetime "tarsitis", precision: nil
+  end
+
+  create_table "cuddlies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "insectiferous", limit: 36, null: false, collation: "ascii_general_ci"
+    t.string "miscarriages", limit: 36, null: false, collation: "ascii_general_ci"
+    t.boolean "excursories", null: false
+    t.text "cryptologies"
+    t.datetime "pasteurelleaes", precision: nil
+    t.datetime "unexplainings", precision: nil
+    t.string "crocuseds", default: "monthly", null: false
+  end
+
+  create_table "cultirostres", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "dentiloquists", limit: 36, null: false
+    t.string "microspherics"
+    t.string "leanders"
+    t.string "dibenzyls"
+    t.string "cetonia"
+    t.string "unfactious"
+    t.string "business_address_1"
+    t.string "business_address_2"
+    t.string "oysterlings"
+    t.string "consequencies"
+    t.string "continualnesses"
+    t.string "finitelies"
+    t.string "semipurulents"
+    t.string "etudes"
+    t.string "ruttishlies"
+    t.string "gudgeons"
+    t.string "linkedIn_url"
+    t.string "provings"
+    t.string "niccoliferous"
+    t.string "lurdanisms"
+    t.integer "antisyndicalisms"
+    t.boolean "lemoniidaes"
+    t.string "unessentialnesses"
+    t.string "pansophies"
+    t.string "ronsdorfers"
+    t.boolean "obsesses"
+    t.string "membranelesses"
+    t.string "nabobships"
+    t.boolean "smoothens"
+    t.datetime "salmoniforms", precision: nil, null: false
+    t.datetime "fattilies", precision: nil, null: false
+    t.string "khokas"
+    t.boolean "osteitics"
+  end
+
+  create_table "cunjers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "requalifies", limit: 36, null: false
+    t.boolean "gladsomes", default: false, null: false
+    t.datetime "retraverses", precision: nil, null: false
+    t.datetime "submerses", precision: nil, null: false
+    t.string "analkalinities", limit: 36, null: false
+  end
+
+  create_table "curies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "wenchoweses", null: false
+    t.string "photoelasticities", null: false
+    t.datetime "weathereds", precision: nil, null: false
+    t.datetime "misappearances", precision: nil, null: false
+  end
+
+  create_table "curlies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "culicides"
+    t.string "intrafissurals"
+    t.boolean "unentertaininglies", null: false
+    t.boolean "subconvolutes", null: false
+    t.string "visceropleurals", limit: 36, null: false
+    t.datetime "imperates", precision: nil, null: false
+    t.datetime "formernesses", precision: nil, null: false
+    t.boolean "homoeophyllous", default: false, null: false
+    t.boolean "wolverines", default: false, null: false
+    t.text "mycosins"
+    t.decimal "orbicularities", precision: 16, scale: 2
+    t.bigint "cyanomaclurins"
+    t.bigint "fisherwomen"
+    t.string "thingishes"
+  end
+
+  create_table "curvicaudates", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "preregulates", limit: 36, null: false
+    t.string "omnipotents", limit: 36, null: false
+    t.boolean "philoprogenitives", null: false
+    t.string "polymerizations", default: "active", null: false
+    t.integer "pilferinglies", null: false
+    t.string "anutraminosas", null: false
+    t.text "twitterations", null: false
+    t.datetime "alpasotes", precision: nil
+    t.datetime "upblasts", precision: nil
+    t.string "onopordons", default: "optional", null: false
+    t.string "unpreachings", limit: 36
+    t.string "gadolinites", limit: 36
+  end
+
+  create_table "cutweeds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "elissas", null: false
+    t.string "seeders", limit: 36, null: false
+    t.datetime "subdepositories", precision: nil, null: false
+    t.datetime "unenthroneds", precision: nil, null: false
+  end
+
+  create_table "cyanoacetates", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "yankeeizes", null: false
+    t.bigint "wennies", null: false
+    t.text "beadrolls", null: false
+    t.datetime "hematotherapies", precision: nil
+    t.datetime "crinicultures", precision: nil
+  end
+
+  create_table "cyanochlorous", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "caproates", null: false
+    t.bigint "chalcedonians", null: false
+    t.string "ulorrheas", null: false
+    t.string "adactylia", null: false
+    t.datetime "passives", precision: nil, null: false
+    t.datetime "serpulaes", precision: nil, null: false
+  end
+
+  create_table "cyanurics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "epikleses", limit: 36, null: false
+    t.string "disasters"
+    t.integer "townishnesses"
+    t.string "effranchisements"
+    t.integer "stillmen"
+    t.string "ramisectomies"
+    t.string "lonks"
+    t.datetime "devilries", precision: nil
+    t.datetime "taps", precision: nil
+    t.string "unvigorous"
+  end
+
+  create_table "cymoids", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "reabsorptions", null: false
+    t.bigint "redues", null: false
+    t.datetime "merismoids", precision: nil, null: false
+    t.datetime "joylesses", precision: nil, null: false
+  end
+
+  create_table "cyperus", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "spadiceous"
+    t.bigint "theriomaniacs"
+    t.boolean "flunkyisms", default: false, null: false
+    t.datetime "isophenomenals", precision: nil
+    t.datetime "destructivelies", precision: nil
+  end
+
+  create_table "cypraeidaes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "criteriologies"
+    t.bigint "tylopodas"
+    t.string "dirhems"
+    t.datetime "metoposcopics", precision: nil
+    t.datetime "anthoxanthums", precision: nil
+  end
+
+  create_table "cystines", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "oosperms", limit: 36, null: false
+    t.string "featlinesses", null: false
+    t.string "scammonies", null: false
+    t.string "philistinizes", null: false
+    t.string "seerfishes", null: false
+    t.integer "bamboozlers"
+    t.boolean "haploidics", default: true, null: false
+    t.datetime "unafeards", precision: nil
+    t.datetime "beauishes", precision: nil
+    t.string "unobtainables"
+  end
+
+  create_table "cystopteris", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "waises"
+    t.bigint "oldhamites"
+    t.decimal "unadapteds", precision: 16, scale: 2, default: "0.0", null: false
+    t.datetime "slopenesses", precision: nil, null: false
+    t.datetime "tereus", precision: nil, null: false
+  end
+
+  create_table "danaids", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "warbles", limit: 36, null: false
+    t.boolean "outsteams"
+    t.bigint "eonisms", null: false
+    t.datetime "outplaces", precision: nil
+    t.datetime "perniciouslies", precision: nil
+  end
+
+  create_table "darsts", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "yawners", null: false
+    t.bigint "tephrites"
+    t.datetime "hygeists", precision: nil, null: false
+    t.datetime "playas", precision: nil, null: false
+  end
+
+  create_table "dasypaedics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "unimplorables", null: false
+    t.bigint "cockboats"
+    t.string "inhumen"
+    t.decimal "gunneras", precision: 16, scale: 2, null: false
+    t.string "peakers", null: false
+    t.datetime "uramilics", precision: nil
+    t.datetime "disestablishes", precision: nil
+    t.string "mortlings"
+    t.string "dephosphorizes"
+    t.bigint "dishonorablies"
+  end
+
+  create_table "daunts", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "pauropodous"
+    t.bigint "underqueens"
+    t.string "asporogenics"
+    t.string "reburnishes"
+    t.datetime "syndicalizes", precision: nil
+    t.datetime "favorites", precision: nil
+  end
+
+  create_table "dayblushes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.decimal "waisters", precision: 16, scale: 2, default: "0.0"
+    t.string "nonarsenicals", null: false
+    t.datetime "placodus", precision: nil
+    t.bigint "goshes", null: false
+    t.bigint "scratchings"
+    t.string "zygosporics"
+    t.bigint "therevidaes"
+    t.string "unsunks"
+    t.string "unconcurrings", null: false
+    t.datetime "hylics", precision: nil, null: false
+    t.datetime "lustratories", precision: nil, null: false
+    t.bigint "theetsees", null: false
+    t.string "diademas", null: false
+  end
+
+  create_table "daygoings", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "remixtures"
+    t.string "abneurals"
+    t.string "baskers"
+    t.bigint "sialosemeiologies"
+    t.string "comenics"
+    t.string "folds"
+    t.boolean "maggotpies"
+    t.boolean "cuddies"
+    t.boolean "pyrheliometrics"
+    t.boolean "rebids"
+    t.text "blithenesses"
+    t.datetime "heteroclitous", precision: nil
+    t.datetime "dangerlesses", precision: nil
+    t.boolean "waysiders"
+    t.datetime "beaverkills", precision: nil
+    t.string "abhorrings"
+    t.datetime "shimmers", precision: nil
+  end
+
+  create_table "dazzlers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "aporobranchiata"
+    t.bigint "nyoros"
+    t.date "addictednesses"
+    t.datetime "unemploys", precision: nil
+    t.datetime "overtedious", precision: nil
+    t.date "nongeologicals"
+    t.string "enmosses"
+  end
+
+  create_table "deairs", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "quintus", limit: 36, null: false
+    t.bigint "independencies", null: false
+    t.string "proudishes", null: false
+    t.datetime "bryophyta", precision: nil, null: false
+    t.datetime "chidinglies", precision: nil, null: false
+  end
+
+  create_table "deathdays", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "alveolectomies", limit: 36, null: false
+    t.string "expurgations", null: false
+    t.datetime "limpnesses", precision: nil
+    t.datetime "superfluousnesses", precision: nil
+    t.string "prediminishments", limit: 36
+  end
+
+  create_table "deathweeds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.datetime "undercoaters", precision: nil, null: false
+    t.datetime "trasteverines", precision: nil, null: false
+    t.bigint "languidnesses"
+    t.string "acatalepsia"
+    t.bigint "organums"
+    t.bigint "uneffuseds"
+    t.bigint "noncomplaisances"
+  end
+
+  create_table "debunkers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.date "hydrodynamicals"
+    t.string "syracusans"
+    t.datetime "subanniversaries", precision: nil, null: false
+    t.datetime "paeonia", precision: nil, null: false
+    t.decimal "chiragras", precision: 16, scale: 2
+    t.decimal "caffetannins", precision: 16, scale: 2
+    t.integer "noncoagulables"
+    t.datetime "kishons", precision: nil
+    t.date "pinics"
+    t.string "voltaplasts"
+    t.string "hefties"
+    t.datetime "beeheadeds", precision: nil
+    t.bigint "bridgeboards"
+    t.string "droiturals"
+    t.boolean "nonpresences"
+    t.bigint "unsingleds", null: false
+    t.string "dissimilations"
+    t.date "demimen", null: false
+  end
+
+  create_table "decadarchies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "formalizations", limit: 36, null: false, collation: "ascii_general_ci"
+    t.string "cloits", limit: 36, null: false, collation: "ascii_general_ci"
+    t.string "battalions", limit: 36, collation: "ascii_general_ci"
+    t.string "sparrowgrasses", null: false
+    t.boolean "ketapangs", default: false, null: false
+    t.datetime "oxybenzoics", precision: nil, null: false
+    t.bigint "emporia"
+  end
+
+  create_table "decamerous", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "livistonas", null: false
+    t.string "factionaries", null: false
+    t.datetime "subsorters", precision: nil
+    t.datetime "rhinophis", precision: nil
+    t.boolean "waesucks"
+    t.string "karyogamies"
+  end
+
+  create_table "decimosextos", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.decimal "acetous", precision: 16, scale: 2, null: false
+    t.decimal "preacherlesses", precision: 16, scale: 2, null: false
+    t.string "ameliorablenesses", default: "unpaid", null: false
+    t.datetime "semidressies", precision: nil
+    t.datetime "tympaniforms", precision: nil
+    t.bigint "outfigures", null: false
+    t.bigint "enneasyllabics"
+    t.bigint "putages", null: false
+    t.string "porridgelikes", null: false
+    t.date "gorsedds"
+    t.date "abstinencies"
+  end
+
+  create_table "decolorations", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "redwoods"
+    t.string "islamizations"
+    t.boolean "conchuelas", default: true
+    t.bigint "unorganizeds"
+    t.datetime "redeemablies", precision: nil, null: false
+    t.datetime "nephrons", precision: nil, null: false
+    t.bigint "isokeraunographics"
+    t.boolean "barts", default: true
+    t.string "antiwarlikes"
+    t.bigint "immunogens"
+    t.datetime "mesoplasts", precision: nil
+    t.string "gloria"
+    t.string "furrowlikes"
+  end
+
+  create_table "decumanus", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "dyewares", limit: 36, null: false
+    t.bigint "electropathologies", null: false
+    t.string "spurwingeds", null: false
+    t.string "merwomen", null: false
+    t.string "socialites"
+    t.text "interagrees"
+    t.decimal "eskimoics", precision: 16, scale: 2
+    t.decimal "chaulmoogras", precision: 16, scale: 2
+    t.decimal "computations", precision: 16, scale: 2
+    t.decimal "coxcomicallies", precision: 16, scale: 2
+    t.integer "liltingnesses"
+    t.boolean "bulrushies"
+    t.datetime "indigoids", precision: nil
+    t.datetime "cixos", precision: nil
+    t.string "inflationisms"
+  end
+
+  create_table "deflationists", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "stationmen", null: false
+    t.bigint "soohongs", null: false
+    t.datetime "gonidia", precision: nil
+    t.datetime "milliamps", precision: nil
+  end
+
+  create_table "defouls", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "nonasphalts", limit: 36, null: false
+    t.string "psychoclinicals", limit: 36, null: false
+    t.string "aspidiotus", null: false
+    t.string "satyrinaes"
+    t.string "phraseographics"
+    t.integer "moneygrubbers"
+    t.datetime "vitascopics", precision: nil
+    t.datetime "nonarmigerous", precision: nil, null: false
+    t.datetime "trophoneuroses", precision: nil, null: false
+  end
+
+  create_table "degausses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "trentines", null: false
+    t.bigint "reinserts", null: false
+    t.datetime "polydemics", precision: nil, null: false
+    t.datetime "germanhoods", precision: nil, null: false
+  end
+
+  create_table "deglutitories", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "unmitigatives", null: false
+    t.string "inanimatelies", null: false
+    t.bigint "hornfuls"
+    t.text "gownlets"
+    t.datetime "ficklehearteds", precision: nil, null: false
+    t.string "reservefuls", null: false
+    t.string "dissolutionists"
+    t.string "moorflowers"
+    t.text "unpostmarkeds", null: false
+    t.bigint "inferns"
+    t.datetime "lacewoods", precision: nil
+    t.datetime "ginglymodians", precision: nil
+  end
+
+  create_table "demandings", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "pseudomorphics", limit: 36, null: false
+    t.bigint "lachrymators", null: false
+    t.string "catagenetics", null: false
+    t.date "jettyheads", null: false
+    t.string "gabriels", null: false
+    t.datetime "quebrachamines", precision: nil
+    t.datetime "busbies", precision: nil
+  end
+
+  create_table "demiseasons", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "unpockets"
+    t.bigint "jabots", null: false
+    t.datetime "needlewoods", precision: nil
+    t.datetime "subterfluents", precision: nil
+  end
+
+  create_table "demonesses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "someways", limit: 36, null: false
+    t.string "scleroskeletals", limit: 36, null: false
+    t.string "payings", limit: 36
+    t.datetime "shortlies", precision: nil, null: false
+    t.integer "duodramas", null: false
+    t.string "poltroonisms", limit: 36
+    t.string "bathorses", limit: 36
+    t.datetime "lateropositions", precision: nil, null: false
+    t.datetime "pluckeds", precision: nil
+    t.boolean "candieds", null: false
+    t.bigint "caimacams", null: false
+    t.bigint "chiropodicals"
+  end
+
+  create_table "dentatocrenates", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "bewingeds", limit: 36, null: false
+    t.string "samsonesses", limit: 36, null: false
+    t.datetime "relasters", precision: nil
+    t.datetime "threaders", precision: nil
+    t.datetime "pneumatologists", precision: nil
+    t.datetime "mesodisilicics", precision: nil
+  end
+
+  create_table "dentistries", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "carrotwoods"
+    t.datetime "schizophragmas", precision: nil, null: false
+    t.datetime "obelizes", precision: nil, null: false
+    t.boolean "naywords", default: false, null: false
+    t.string "ammiaceous"
+    t.string "portoises"
+    t.string "cyanics", default: "payroll only", null: false
+    t.string "antihemorrhagics", limit: 36
+  end
+
+  create_table "devilmen", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "bashawships", null: false
+    t.bigint "seepies", null: false
+    t.string "bavarians", null: false
+    t.string "antiannexationists", null: false
+    t.string "proamendments", limit: 500, default: "[]", null: false
+    t.datetime "vetivenols", precision: nil, null: false
+    t.datetime "thankworthies", precision: nil, null: false
+    t.string "polts", null: false
+  end
+
+  create_table "diaphanousnesses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "petroxolins", limit: 36, null: false
+    t.string "anticastes", limit: 36, null: false
+    t.datetime "noncontradictories", precision: nil, null: false
+    t.bigint "oakesia", null: false
+    t.string "rubbleworks", limit: 50
+    t.string "zermahbubs", limit: 50
+    t.datetime "blattariaes", precision: nil
+    t.datetime "bushmasters", precision: nil
+    t.datetime "auditions", precision: nil
+  end
+
+  create_table "dichromatics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "sobersideds", limit: 36, null: false
+    t.bigint "marks", null: false
+    t.bigint "idiomatics"
+    t.datetime "sublates", precision: nil
+    t.datetime "sublumbars", precision: nil, null: false
+    t.datetime "underditches", precision: nil, null: false
+    t.datetime "inshaves", precision: nil
+  end
+
+  create_table "dictyogens", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "mechanizations", null: false
+    t.date "laryngoscopies", null: false
+    t.bigint "pretannages"
+    t.datetime "ergamines", precision: nil
+    t.datetime "hypoantimonates", precision: nil
+    t.string "ascaricides"
+  end
+
+  create_table "dictyosiphonaceous", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "inexpugnables", null: false
+    t.bigint "marmosas", null: false
+    t.string "songs", null: false
+    t.datetime "nasalis", precision: nil
+    t.datetime "copus", precision: nil
+  end
+
+  create_table "dilatories", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "unincumbereds", limit: 36, null: false
+    t.string "disoperculates", limit: 36, null: false
+    t.integer "matriculables", null: false
+    t.text "juramentals", null: false
+    t.datetime "molestfuls", precision: nil
+    t.datetime "overrigids", precision: nil
+  end
+
+  create_table "dinginesses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "someones", null: false
+    t.datetime "inaurations", precision: nil
+    t.datetime "noncontrolleds", precision: nil
+    t.string "parsonages"
+    t.bigint "muscovites"
+    t.date "unfranchiseds"
+    t.string "marches"
+  end
+
+  create_table "dipodies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "screvers", null: false
+    t.string "decigrammes", null: false
+    t.bigint "cladonia", null: false
+    t.string "contraclockwises", null: false
+    t.datetime "droopers", precision: nil
+    t.datetime "whussles", precision: nil
+    t.string "antidiphtherics"
+    t.text "generallies", null: false
+    t.string "insultproofs", limit: 36
+  end
+
+  create_table "dipterous", charset: "utf8mb3", force: :cascade do |t|
+    t.bigint "gesnings"
+    t.bigint "wordlikes"
+    t.datetime "blackberries", precision: nil
+    t.datetime "glarilies", precision: nil
+    t.bigint "flutters"
+  end
+
+  create_table "directoires", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "afernans"
+    t.bigint "curators"
+    t.boolean "unspoilablies"
+    t.decimal "yelloches", precision: 16, scale: 2
+    t.decimal "aphlastons", precision: 16, scale: 2
+    t.decimal "contenders", precision: 16, scale: 2
+    t.decimal "candlelights", precision: 16, scale: 2
+    t.decimal "papilloretinitis", precision: 16, scale: 2
+    t.bigint "woofers"
+    t.datetime "xerostomas", precision: nil
+    t.datetime "ashurs", precision: nil
+  end
+
+  create_table "direfulnesses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "semiarchitecturals", null: false
+    t.float "cardioviscerals", null: false
+    t.float "exhortators", null: false
+    t.date "tummers", null: false
+    t.bigint "ventriloquals", null: false
+    t.datetime "lictors", precision: nil, null: false
+    t.datetime "daneworts", precision: nil, null: false
+    t.float "variolitics"
+  end
+
+  create_table "disciplinablenesses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "unincubateds", null: false
+    t.bigint "destructuralizes", null: false
+    t.datetime "hists", precision: nil
+    t.datetime "vaporousnesses", precision: nil
+    t.datetime "priorals", precision: nil
+  end
+
+  create_table "discocarps", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "ectrodactylies"
+    t.string "myosynizeses"
+    t.bigint "dengues"
+    t.bigint "souchets"
+    t.decimal "hyperdelicates", precision: 8, scale: 2
+    t.decimal "mellisonants", precision: 16, scale: 2
+    t.string "decohesions"
+    t.string "unsummarizeds"
+    t.text "wulfenites"
+    t.bigint "moorpans"
+    t.datetime "spatteds", precision: nil
+    t.datetime "lights", precision: nil
+  end
+
+  create_table "discoglossoids", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "previsiblies", limit: 36, null: false
+    t.bigint "undersluices", null: false
+    t.string "treadles", null: false
+    t.datetime "fremontodendrons", precision: nil
+    t.datetime "orycteropus", precision: nil
+    t.string "unpremonisheds"
+    t.string "aurivorous"
+    t.string "anthropomorphas"
+  end
+
+  create_table "disenthrallments", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "tashies", limit: 36, null: false
+    t.bigint "hameils", null: false
+    t.datetime "daredeviltries", precision: nil
+    t.datetime "dolefuls", precision: nil
+  end
+
+  create_table "dishpanfuls", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "eremologies", limit: 36, null: false
+    t.string "brimborions", null: false
+    t.datetime "budgers", precision: nil, null: false
+    t.datetime "metallines", precision: nil, null: false
+    t.datetime "squidges", precision: nil, null: false
+    t.bigint "skimpilies"
+    t.bigint "hydronephelites"
+  end
+
+  create_table "disinfectants", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "pharmakos"
+    t.date "cylindrocylindrics"
+    t.decimal "unshadoweds", precision: 16, scale: 2, default: "0.0"
+    t.decimal "papists", precision: 16, scale: 2, default: "0.0"
+    t.decimal "cartridges", precision: 16, scale: 2, default: "0.0"
+    t.decimal "eggplants", precision: 16, scale: 2, default: "0.0"
+    t.decimal "twangs", precision: 16, scale: 2, default: "0.0"
+    t.decimal "microphthalmus", precision: 16, scale: 2, default: "0.0"
+    t.date "unkingers"
+    t.string "preanticipates"
+    t.bigint "interseminals"
+    t.text "baas"
+    t.datetime "arthrosporous", precision: nil
+    t.datetime "sluggardings", precision: nil
+    t.string "ousts"
+    t.text "palladianisms"
+    t.string "aluminates"
+    t.string "awashes"
+    t.string "bulkheadeds"
+    t.date "mustermasters"
+    t.datetime "grits", precision: nil
+    t.decimal "dancings", precision: 16, scale: 2, default: "0.0"
+    t.string "geissorhizas"
+  end
+
+  create_table "disomatous", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.datetime "physiopathologicals", precision: nil, null: false
+    t.datetime "errorists", precision: nil, null: false
+    t.date "tetrastylics", null: false
+    t.date "alpids", null: false
+    t.string "windinesses", limit: 60, null: false
+    t.bigint "zyzzogetons", null: false
+    t.bigint "fremescents"
+    t.boolean "pharyngopneusta", null: false
+  end
+
+  create_table "dokmaroks", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "unmannerlies"
+    t.string "technicons"
+    t.integer "martyresses"
+    t.datetime "onagras", precision: nil
+    t.datetime "overspeeds", precision: nil, null: false
+    t.datetime "kathies", precision: nil, null: false
+  end
+
+  create_table "dolichocephalies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "missummations", null: false
+    t.string "employabilities", null: false
+    t.string "nonstatics", null: false
+    t.integer "achenials", null: false
+    t.datetime "unlordlies", precision: nil, null: false
+    t.string "janitorships", limit: 36, null: false
+    t.datetime "prescapulas", precision: nil
+    t.datetime "planiscopics", precision: nil
+  end
+
+  create_table "dollinesses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "scaglia", limit: 36, null: false
+    t.bigint "palatoalveolars", null: false
+    t.string "combures", limit: 64, null: false
+    t.bigint "podiatrists"
+    t.string "unparticularizeds"
+    t.text "kishes", null: false
+    t.datetime "vinciblies", precision: nil, null: false
+    t.datetime "underpriors", precision: nil, null: false
+    t.boolean "anathematizers", default: true, null: false
+  end
+
+  create_table "domiciliates", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "requotations"
+    t.string "preobliges"
+    t.string "aircraftmen"
+    t.string "supersentimentals"
+    t.text "beechwoods"
+    t.string "contemptuouslies"
+    t.text "cosherers"
+    t.datetime "dermatonosus", precision: nil, null: false
+    t.datetime "phigalians", precision: nil, null: false
+    t.string "clatches"
+    t.bigint "papyrotypes", null: false
+  end
+
+  create_table "doughlikes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.integer "polymyariis"
+    t.string "gasconisms"
+    t.string "street_1"
+    t.string "street_2"
+    t.string "polybunies"
+    t.string "reticulovenoses"
+    t.string "polyphonicals"
+    t.string "cheirologies"
+    t.date "toskishes"
+    t.datetime "fulgentlies", precision: nil
+    t.datetime "calkins", precision: nil
+  end
+
+  create_table "dovetailers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "bonyfishes", null: false
+    t.string "japanesques", null: false
+    t.string "cedrirets", null: false
+    t.datetime "hoppities", precision: nil, null: false
+    t.datetime "inepts", precision: nil, null: false
+    t.string "stogas"
+    t.string "preobservances"
+    t.string "cerianthus"
+  end
+
+  create_table "downingia", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.datetime "taenials", precision: nil, null: false
+    t.datetime "vanelesses", precision: nil, null: false
+    t.string "quadrienniumutiles", limit: 36, null: false
+    t.string "sells", null: false
+    t.boolean "oxygas", default: true, null: false
+  end
+
+  create_table "dreads", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "demologies", limit: 36, null: false
+    t.bigint "nidamentals", null: false
+    t.date "lents", null: false
+    t.datetime "perisarcs", precision: nil, null: false
+    t.datetime "formablies", precision: nil, null: false
+  end
+
+  create_table "dreamts", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "ofttimes", null: false
+    t.string "phytomonadinas", null: false
+    t.text "inessentials"
+    t.datetime "overexertions", precision: nil
+    t.datetime "antelucans", precision: nil
+  end
+
+  create_table "dredgings", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "infatuatedlies", limit: 36, null: false
+    t.bigint "supratropicals", null: false
+    t.integer "kinkhabs", limit: 1, null: false
+    t.string "tannineds"
+    t.datetime "oldsters", precision: nil
+    t.datetime "cliacks", precision: nil
+  end
+
+  create_table "droits", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "trichotomists", null: false
+    t.datetime "interplicals", precision: nil, null: false
+    t.datetime "deuteromyosinoses", precision: nil
+    t.datetime "funoris", precision: nil
+  end
+
+  create_table "drummies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.integer "lyreflowers", null: false
+    t.string "multisegmentates", null: false
+    t.string "hysterolaparotomies", null: false
+    t.string "popularists", null: false
+    t.text "beaglings"
+    t.text "spindrifts", null: false
+    t.text "obsequiences"
+    t.datetime "doctrinisms", precision: nil, null: false
+    t.datetime "trousereds", precision: nil, null: false
+    t.text "goldenperts"
+  end
+
+  create_table "duals", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "boylas", limit: 36, null: false
+    t.string "naturisms", limit: 36, null: false
+    t.string "corrigiolas", limit: 36, null: false
+    t.datetime "reflexives", precision: nil
+    t.datetime "diageneses", precision: nil
+  end
+
+  create_table "dubiousnesses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "forepasts"
+    t.string "chickarees"
+    t.bigint "flannels", null: false
+    t.datetime "unempoisoneds", precision: nil, null: false
+    t.datetime "shopfolks", precision: nil, null: false
+  end
+
+  create_table "ductiles", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "sapphirines"
+    t.decimal "corymbiateds", precision: 16, scale: 15
+    t.datetime "petticoatisms", precision: nil
+    t.datetime "oryssids", precision: nil
+    t.integer "rocklings", limit: 1
+    t.decimal "fouds", precision: 16, scale: 15
+  end
+
+  create_table "dungeoners", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "overtreatments", null: false
+    t.string "theokrasia", null: false
+    t.float "neuromatoses", null: false
+    t.boolean "corders", default: false, null: false
+    t.boolean "slicklies", default: false, null: false
+    t.boolean "preparietals", default: false, null: false
+    t.boolean "solicitous", default: false, null: false
+    t.boolean "carps", default: false, null: false
+    t.boolean "dewaters", default: false, null: false
+    t.datetime "broches", precision: nil
+    t.datetime "laggens", precision: nil
+  end
+
+  create_table "dynamometrics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "maxillaries"
+    t.decimal "prehends", precision: 16, scale: 2
+    t.date "angelus"
+    t.datetime "guillemots", precision: nil
+    t.datetime "infractions", precision: nil
+    t.integer "jebusis", limit: 1, default: 0
+    t.bigint "pleurolyses"
+    t.bigint "anchoritishes"
+  end
+
+  create_table "dysanalytes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "unsparses", limit: 36, null: false
+    t.date "grittles"
+    t.string "unempties"
+    t.string "aves"
+    t.string "furunculoses"
+    t.string "balistes"
+    t.string "prosopalgia"
+    t.bigint "ulcerations", null: false
+    t.bigint "selenates", null: false
+    t.datetime "overgenerallies", precision: nil
+    t.datetime "gonals", precision: nil
+  end
+
+  create_table "dyscrasials", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "mushheadednesses", null: false
+    t.bigint "unguiculars", null: false
+    t.datetime "comestibles", precision: nil, null: false
+    t.datetime "neurogastrics", precision: nil, default: "3000-01-01 00:00:00", null: false
+    t.bigint "rockinesses", null: false
+    t.bigint "berobeds"
+  end
+
+  create_table "dysergasia", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "sporophytes", limit: 36, null: false
+    t.string "sakeens", null: false
+    t.bigint "pictavis", null: false
+    t.datetime "weepables", precision: nil
+    t.datetime "panamen", precision: nil
+  end
+
+  create_table "ecchymoses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "viddhals", null: false
+    t.decimal "unindulgents", precision: 16, scale: 2, null: false
+    t.decimal "tunbellies", precision: 16, scale: 2, null: false
+    t.decimal "seders", precision: 16, scale: 2, null: false
+    t.decimal "unsatedlies", precision: 16, scale: 2
+    t.decimal "infestives", precision: 16, scale: 2
+    t.string "guanajuatites"
+    t.decimal "shillets", precision: 16, scale: 2
+    t.integer "testamentallies"
+    t.boolean "precanonicals", default: false
+    t.integer "searcloths", limit: 1
+    t.string "predelinquents"
+    t.datetime "brains", precision: nil
+    t.datetime "cocklights", precision: nil
+    t.string "prewashes"
+    t.string "synostoticals"
+  end
+
+  create_table "egols", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "focaloids", null: false
+    t.bigint "catchflies", null: false
+    t.string "noncapsizables", null: false
+    t.integer "cyrillics", default: 0, null: false
+    t.datetime "polynucleolars", precision: nil, null: false
+    t.datetime "unforgivings", precision: nil, null: false
+  end
+
+  create_table "ehlites", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "nexums", null: false
+    t.string "plangs", null: false
+    t.string "hereditaments", null: false
+    t.string "illiteratures", null: false
+    t.string "dementednesses", null: false
+    t.string "babbittries", null: false
+    t.string "boreals", limit: 36, null: false, collation: "ascii_general_ci"
+    t.datetime "backslappers", precision: nil
+    t.datetime "heathenesses", precision: nil
+  end
+
+  create_table "elaborations", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "nisperos"
+  end
+
+  create_table "elastometers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "graveships"
+    t.bigint "exscutellates"
+    t.datetime "pinnitentaculates", precision: nil, null: false
+    t.datetime "imponderablenesses", precision: nil, null: false
+  end
+
+  create_table "electrocardiographs", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "elanets", limit: 36, null: false
+    t.bigint "trulls", null: false
+    t.string "forehills", null: false
+    t.date "inexpiables"
+    t.date "unpolishes"
+    t.date "driftwinds"
+    t.datetime "sprawls", precision: nil, null: false
+    t.datetime "altarwises", precision: nil, null: false
+    t.integer "nightingales", null: false
+    t.string "booklands", null: false
+    t.string "justiciars", null: false
+  end
+
+  create_table "elementalisms", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "outlanders", limit: 36, null: false
+    t.text "humanizers", size: :long
+    t.integer "arbalesters"
+    t.datetime "zoolitics", precision: nil
+    t.datetime "lepidoids", precision: nil
+  end
+
+  create_table "embargoists", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "embeds", limit: 36, null: false
+    t.string "lackadays", null: false
+    t.datetime "catbirds", precision: nil
+    t.datetime "omenologies", precision: nil
+    t.datetime "preamalgamations", precision: nil
+  end
+
+  create_table "embeggars", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "dowlas", limit: 36, null: false, collation: "ascii_general_ci"
+    t.bigint "alliaceaes", null: false
+    t.integer "micturitions", null: false
+    t.string "palpis", limit: 36, collation: "ascii_general_ci"
+    t.string "joltinglies", limit: 36, collation: "ascii_general_ci"
+    t.datetime "dextraurals", precision: nil
+    t.datetime "operatizes", precision: nil
+  end
+
+  create_table "embodies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "races", limit: 36, null: false
+    t.string "unsmackeds", limit: 36, null: false
+    t.string "overcondensations", limit: 36, null: false
+    t.datetime "otherwhiles", precision: nil, null: false
+    t.datetime "misinstructions", precision: nil, null: false
+    t.string "spindles", default: "active", null: false
+  end
+
+  create_table "embolismics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "circumventions", limit: 36, null: false
+    t.string "ablates", limit: 1024, null: false
+    t.string "postoperatives", null: false
+    t.bigint "sheargrasses", null: false
+    t.string "consecrations", null: false
+    t.datetime "cedulas", precision: nil
+    t.datetime "groanfuls", precision: nil
+  end
+
+  create_table "enantiomorphouslies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "admins", null: false
+    t.bigint "injuriouslies"
+    t.datetime "olds", precision: nil
+    t.string "ingoings"
+    t.string "consentfuls"
+    t.integer "menyanthaceous"
+    t.string "tristichics"
+    t.string "limericks"
+    t.datetime "accipients", precision: nil, null: false
+    t.string "unicelleds", null: false
+    t.datetime "pliohippus", precision: nil
+    t.datetime "fumarates", precision: nil
+  end
+
+  create_table "enarthrodials", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "arrives", limit: 36, null: false
+    t.string "coinclines", null: false
+    t.string "seaweedies", null: false
+    t.string "volatilizations", null: false
+    t.string "exceedinglies", null: false
+    t.datetime "snaffs", precision: nil, null: false
+    t.datetime "gentianworts", precision: nil
+    t.datetime "rompers", precision: nil
+    t.string "wheeleds", limit: 36, null: false
+    t.boolean "kinoplasms", null: false
+    t.boolean "saddleries", null: false
+    t.boolean "animastics", null: false
+  end
+
+  create_table "enchains", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "gulflikes", limit: 36, null: false
+    t.bigint "shirlcocks"
+    t.bigint "mensurals"
+    t.datetime "supervisionaries", precision: nil
+    t.datetime "sabals", precision: nil
+  end
+
+  create_table "endlessnesses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "nonminerals", limit: 36, null: false
+    t.string "darings"
+    t.text "burghs"
+    t.text "fakies"
+    t.datetime "tetartosymmetries", precision: nil
+    t.datetime "unloathsomes", precision: nil
+    t.string "facsimilizes", limit: 36
+  end
+
+  create_table "endmosts", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "interjaculates", null: false
+    t.bigint "hyperdactylia", null: false
+    t.integer "bacillites", null: false
+    t.decimal "unostentatious", precision: 16, scale: 2, null: false
+    t.text "ostiolars", null: false
+    t.datetime "sabaisms", precision: nil, null: false
+    t.datetime "dithions", precision: nil, null: false
+  end
+
+  create_table "endoplasmas", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.integer "polyscopics", null: false
+    t.bigint "esmeraldites", null: false
+    t.string "mulses", null: false
+    t.integer "afterspeeches", null: false
+    t.string "austerelies", limit: 36, null: false
+    t.datetime "emends", precision: nil
+    t.datetime "viticulturers", precision: nil
+  end
+
+  create_table "endosiphonals", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.integer "bioclimatics", default: 1, null: false
+    t.string "psychograms", null: false
+    t.string "cryptobranchus", null: false
+    t.text "anecdotals", null: false
+    t.datetime "rhapsodomancies", precision: nil
+    t.datetime "antesignanus", precision: nil
+  end
+
+  create_table "enigmatists", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "olympics", limit: 36, null: false
+    t.bigint "congos", null: false
+    t.string "clanneds"
+    t.datetime "palingenesia", precision: nil
+    t.datetime "sympathisms", precision: nil
+    t.integer "rhipidopterous"
+    t.integer "infralapsarians"
+    t.text "semipolars"
+    t.string "reciprocallies", null: false
+  end
+
+  create_table "ens", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "nidicolous", limit: 50, null: false
+    t.string "taimen", limit: 25
+    t.datetime "patrices", precision: nil
+    t.datetime "glycerates", precision: nil, null: false
+    t.datetime "novemlobates", precision: nil, null: false
+    t.boolean "parcellations", default: true
+    t.string "inhabitivenesses", default: "zenpayroll", null: false
+    t.string "impoliticlies", limit: 36
+    t.string "protectographs"
+    t.string "epigeans"
+    t.boolean "broozleds", default: false
+  end
+
+  create_table "ensepulchers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "superessentiallies", limit: 36, null: false
+    t.bigint "syssarcoses", null: false
+    t.string "geisotherms", null: false
+    t.string "lairs", null: false
+    t.datetime "worriables", precision: nil, null: false
+    t.datetime "fonticulus", precision: nil, null: false
+    t.datetime "culvertages", precision: nil, null: false
+    t.string "hoolocks"
+    t.string "bonteboks"
+  end
+
+  create_table "enteromyiases", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "globals", limit: 36, null: false
+    t.bigint "katabellas", null: false
+    t.bigint "trainmen", null: false
+    t.string "podilegous"
+    t.string "bedchambers"
+    t.string "sturks"
+    t.string "barramundis"
+    t.datetime "frications", precision: nil, null: false
+    t.datetime "lugs", precision: nil, null: false
+    t.boolean "lyoneses", default: false
+  end
+
+  create_table "enteroneuritis", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "undefameds"
+    t.string "unrobusts"
+    t.string "carboniferous"
+    t.datetime "dacryosolenitis", precision: nil, null: false
+    t.datetime "thelodontidaes", precision: nil, null: false
+    t.text "morenesses"
+    t.text "genarchships"
+    t.string "connochaetes"
+    t.text "cordialities"
+    t.bigint "unhopefuls"
+    t.string "harmproofs"
+  end
+
+  create_table "ependymals", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "squamatines"
+    t.bigint "prasophagies", null: false
+    t.bigint "hangabilities"
+    t.string "cerebromas", null: false
+    t.string "intercastes"
+    t.string "sirships"
+    t.boolean "imploringnesses", default: false
+    t.string "necrotizations"
+    t.string "dactyls"
+    t.string "unsparables"
+    t.boolean "tidefuls"
+    t.datetime "piarhemia", precision: nil
+    t.string "unsuspiciousnesses", limit: 36
+    t.datetime "untrustings", precision: nil
+    t.datetime "halohydrins", precision: nil
+  end
+
+  create_table "epinicians", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "melatopes"
+    t.bigint "strabismometers"
+    t.string "electrophrenics"
+    t.datetime "listeria", precision: nil, null: false
+    t.datetime "olomaos", precision: nil, null: false
+  end
+
+  create_table "epiphyllous", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "nonisotropics", null: false
+    t.datetime "spongilies", precision: nil
+    t.datetime "amphimorulas", precision: nil
+    t.integer "uprushes", default: 1, null: false
+    t.datetime "ipomeas", precision: nil
+    t.datetime "pinnatilobates", precision: nil
+  end
+
+  create_table "epithalamizes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "legatorials", null: false
+    t.decimal "teetings", precision: 16, scale: 2, null: false
+    t.datetime "zoanthids", precision: nil, null: false
+    t.datetime "larnaxes", precision: nil, null: false
+  end
+
+  create_table "epitheliolytics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "anorthoscopes"
+    t.string "enantiopathics", null: false
+    t.string "contections"
+    t.string "boidaes"
+    t.bigint "odontoscopes"
+    t.bigint "homoiousianisms"
+    t.bigint "nudates"
+    t.bigint "atellans"
+    t.string "psellisms"
+    t.datetime "vogesites", precision: nil, null: false
+    t.datetime "frontotemporals", precision: nil, null: false
+    t.bigint "hadramautians"
+    t.bigint "leporines"
+    t.bigint "lyonnais"
+  end
+
+  create_table "epurations", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "thereons"
+    t.bigint "daftnesses"
+    t.datetime "neurals", precision: nil, null: false
+    t.datetime "ohia", precision: nil, null: false
+    t.boolean "mosslesses", default: false
+    t.string "hexadactylisms"
+    t.string "farmerlikes"
+    t.string "belliferous"
+  end
+
+  create_table "equationists", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.boolean "vacuefies", default: false, null: false
+    t.string "epithelioids", null: false
+    t.datetime "karyolymphs", precision: nil
+    t.datetime "slaggabilities", precision: nil
+  end
+
+  create_table "erasmians", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "distomes", null: false
+    t.string "goodyeras"
+    t.bigint "haves"
+    t.string "azoxytoluidines", null: false
+    t.datetime "vertebraes", precision: nil, null: false
+    t.datetime "goldlikes", precision: nil, null: false
+    t.datetime "leans", precision: nil, null: false
+    t.datetime "bicyclists", precision: nil, null: false
+  end
+
+  create_table "eriogonums", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "gravics", limit: 36, null: false, collation: "ascii_general_ci"
+    t.integer "longobardics", null: false
+    t.string "plurifies", limit: 36, null: false, collation: "ascii_general_ci"
+    t.string "hymeneallies", null: false
+    t.datetime "scyphostomas", precision: nil, null: false
+    t.datetime "overglasses", precision: nil
+    t.datetime "overmellows", precision: nil
+    t.string "primarieds"
+    t.string "pyropes"
+  end
+
+  create_table "errables", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "coniogrammes"
+    t.decimal "salubrifies", precision: 16, scale: 15
+    t.datetime "stallments", precision: nil
+    t.datetime "tylostylotes", precision: nil
+    t.decimal "spermines", precision: 16, scale: 15
+  end
+
+  create_table "eryngia", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "allegorics"
+    t.string "stonecrafts"
+    t.string "frondigerous"
+    t.string "embastioneds"
+    t.datetime "detruncates", precision: nil
+    t.datetime "mindfullies", precision: nil
+  end
+
+  create_table "escapelesses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.decimal "chrysopoetics", precision: 16, scale: 2, null: false
+    t.bigint "unalleviateds", null: false
+    t.bigint "brawns"
+    t.datetime "byronics", precision: nil
+    t.datetime "gradals", precision: nil
+    t.bigint "hemiglossals"
+    t.bigint "sarcoids"
+    t.integer "jabberwockians", limit: 1, default: 1
+    t.string "fibrinogenics"
+  end
+
+  create_table "esquilines", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "nonpaids"
+    t.datetime "superstrains", precision: nil
+    t.datetime "sevenbarks", precision: nil
+  end
+
+  create_table "ethmomaxillaries", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "pholas", null: false
+    t.string "resents", null: false
+    t.decimal "sublimators", precision: 16, scale: 2, null: false
+    t.decimal "wiltons", precision: 16, scale: 2, null: false
+    t.decimal "multijets", precision: 16, scale: 2
+    t.decimal "fanfoots", precision: 16, scale: 2
+    t.text "delightings"
+    t.text "cochurchwardens"
+    t.text "miners"
+    t.boolean "unnecessarinesses", default: false
+    t.datetime "erotetics", precision: nil
+    t.datetime "plesiomorphous", precision: nil
+    t.boolean "timorous", default: false
+    t.decimal "duers", precision: 16, scale: 2
+    t.boolean "empathizes", default: false, null: false
+    t.bigint "earners"
+    t.string "preconsonantals", limit: 64
+    t.string "parsonishes", limit: 64
+    t.string "cauterizes", limit: 36
+    t.text "promemorials"
+    t.text "pyraustinaes"
+    t.boolean "abromas"
+    t.datetime "corallus", precision: nil
+    t.text "vasifactives"
+    t.bigint "saturnalia"
+    t.bigint "drapes"
+  end
+
+  create_table "ethnologicallies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "subhumen", limit: 36, null: false
+    t.date "malignants", null: false
+    t.bigint "thoroughgoinglies", null: false
+    t.datetime "cons", precision: nil, null: false
+    t.datetime "carports", precision: nil, null: false
+    t.bigint "reiters", null: false
+    t.string "splatterworks", null: false
+    t.string "diversifoliates", null: false
+    t.integer "antichronicals", null: false
+    t.datetime "virginitis", precision: nil, null: false
+    t.boolean "unprints", null: false
+    t.bigint "inventaries", null: false
+  end
+
+  create_table "etiotropics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "fathomages", null: false
+    t.text "aeromantics"
+    t.datetime "aporphines", precision: nil
+    t.datetime "conveyances", precision: nil
+  end
+
+  create_table "euphonetics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "pillarists", null: false
+    t.date "fumaria", null: false
+    t.boolean "earthshakers", default: true, null: false
+    t.integer "oppositivenesses", limit: 1, default: 0, null: false
+    t.datetime "visionics", precision: nil, null: false
+    t.datetime "rhizocephalas", precision: nil, null: false
+  end
+
+  create_table "eutychians", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "aspergations"
+    t.bigint "steerageways"
+    t.decimal "cursas", precision: 16, scale: 2, default: "0.0", null: false
+    t.datetime "nonwastings", precision: nil, null: false
+    t.datetime "uncinates", precision: nil, null: false
+    t.integer "bombers", default: 0
+  end
+
+  create_table "evangelicalisms", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "unembarrasseds", limit: 36, null: false
+    t.bigint "coelelminthes", null: false
+    t.boolean "etherisms", default: false, null: false
+    t.date "pishquows", null: false
+    t.string "fleshings"
+    t.datetime "bridegrooms", precision: nil
+    t.datetime "nonsludgings", precision: nil
+  end
+
+  create_table "excavators", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "persistencies", null: false
+    t.string "polyphobics", null: false
+    t.string "extrastomachals", limit: 36, null: false
+    t.integer "unavengeables", null: false
+    t.string "synodontids", null: false
+    t.string "mucinogens", null: false
+    t.string "literators", null: false
+    t.datetime "unsheetings", precision: nil
+    t.datetime "spinks", precision: nil
+    t.string "isopolities", limit: 32
+  end
+
+  create_table "exhilarants", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "jussives", null: false
+    t.string "anisamides", null: false
+    t.integer "seringals", null: false
+    t.integer "techniques", null: false
+    t.datetime "amphicribrals", precision: nil
+    t.datetime "coreligionists", precision: nil
+  end
+
+  create_table "expeditates", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "ileus", limit: 36, null: false
+    t.string "triggereds", limit: 36, null: false
+    t.datetime "picos", precision: nil, null: false
+    t.datetime "cervisia", precision: nil, null: false
+  end
+
+  create_table "expirates", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "psychopompos", null: false
+    t.datetime "spectrous", precision: nil, null: false
+    t.integer "psychicisms", null: false
+    t.integer "necessitous", limit: 1, null: false
+    t.string "milleds", null: false
+    t.boolean "pigheads"
+    t.boolean "filipunctures"
+    t.boolean "unconcreteds"
+    t.datetime "annihilatories", precision: nil, null: false
+    t.datetime "polychromics", precision: nil, null: false
+    t.boolean "carpospores"
+  end
+
+  create_table "exprobrations", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.text "triradiations", null: false
+    t.text "celiogastrotomies", null: false
+    t.string "miracles", null: false
+    t.string "fusoids", limit: 36, null: false
+    t.bigint "lampooneries"
+    t.string "garths"
+    t.datetime "emotionlesses", precision: nil, null: false
+    t.datetime "baramikas", precision: nil, null: false
+    t.datetime "sequestratrixes", precision: nil, null: false
+  end
+
+  create_table "extemporaneous", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "gonophorics"
+    t.string "feckfullies"
+    t.datetime "airstrips", precision: nil
+    t.datetime "rapscallionlies", precision: nil
+    t.string "offendedlies"
+  end
+
+  create_table "extramorainals", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "perfectionistics", null: false
+    t.bigint "hatchels"
+    t.datetime "necropsies", precision: nil
+    t.datetime "homefarers", precision: nil
+    t.string "inspiringlies", null: false
+  end
+
+  create_table "extraparietals", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "mensks", null: false
+    t.integer "hyperphoria"
+    t.datetime "resiliences", precision: nil
+    t.datetime "myologies", precision: nil
+    t.datetime "globulicidals", precision: nil
+    t.string "gelatinoids"
+    t.string "interminables"
+    t.string "dionymals"
+    t.bigint "tachardia"
+    t.integer "terrorists"
+    t.string "nosetiologies"
+    t.string "sacrums"
+    t.string "undistantlies"
+    t.boolean "penetrologies", default: false
+    t.datetime "talckies", precision: nil
+  end
+
+  create_table "extrapulmonaries", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "cerebrasthenics", null: false
+    t.string "peppins", null: false
+    t.string "underhangings", null: false
+    t.string "impoundments", null: false
+    t.boolean "enterosepses", null: false
+    t.datetime "unafflictings", precision: nil, null: false
+    t.datetime "reallocates", precision: nil, default: "3000-01-01 00:00:00", null: false
+    t.bigint "felinaes", null: false
+    t.bigint "threadmakings"
+  end
+
+  create_table "faithworthies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "provostships", null: false
+    t.string "misunderstandinglies", null: false
+    t.datetime "unipolarities", precision: nil
+    t.datetime "launches", precision: nil
+    t.string "familiarizers", null: false
+    t.text "catocalids"
+  end
+
+  create_table "fanons", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "somacules", null: false
+    t.boolean "oversweeps"
+    t.text "strata"
+    t.datetime "nonautomotives", precision: nil
+    t.datetime "antheriforms", precision: nil
+    t.boolean "basiscopics", default: false
+    t.integer "chorographics", default: 0
+    t.boolean "superindulgences", default: false
+  end
+
+  create_table "fatbraineds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.text "fits"
+    t.datetime "hypnogeneses", precision: nil
+    t.datetime "outcapers", precision: nil, null: false
+    t.datetime "prochromosomes", precision: nil, null: false
+    t.text "pedodontologies"
+    t.text "washers"
+  end
+
+  create_table "fatidicallies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "fumisteries"
+    t.bigint "stridhanums", null: false
+    t.datetime "electrometricallies", precision: nil, null: false
+    t.datetime "hierarchics", precision: nil, null: false
+  end
+
+  create_table "favorings", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "recommences"
+    t.bigint "bioecologicallies"
+    t.string "runaways"
+    t.datetime "synoviparous", precision: nil
+    t.datetime "tendosynovitis", precision: nil
+  end
+
+  create_table "fencelets", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "croquets"
+    t.bigint "invests"
+  end
+
+  create_table "fermentatives", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "coobas", null: false
+    t.bigint "intercondyloids", null: false
+    t.datetime "fondaks", precision: nil, null: false
+    t.datetime "bumblebees", precision: nil, null: false
+    t.datetime "footsores", precision: nil
+    t.datetime "loses", precision: nil
+  end
+
+  create_table "ferociousnesses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "wheelinglies"
+    t.datetime "thievings", precision: nil
+    t.string "oologizes"
+    t.boolean "omenta", default: false, null: false
+    t.datetime "physiogenetics", precision: nil
+    t.datetime "unethicalnesses", precision: nil
+    t.string "rensselaerites"
+    t.string "overfactious"
+    t.string "underbitteds"
+  end
+
+  create_table "filarious", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "gutturonasals", null: false
+    t.bigint "straylings", null: false
+    t.bigint "preguesses", null: false
+    t.datetime "embryonateds", precision: nil, null: false
+    t.datetime "overlanders", precision: nil, null: false
+  end
+
+  create_table "finials", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.datetime "standardizeds", precision: nil
+    t.datetime "transfiltrations", precision: nil
+    t.boolean "quartfuls", default: true, null: false
+    t.bigint "viles", null: false
+    t.string "mazdaists", null: false
+    t.bigint "graphiolas", null: false
+    t.string "centroclinals", limit: 36
+  end
+
+  create_table "finitudes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "squareheads", null: false
+    t.datetime "aggressions", precision: nil, null: false
+    t.datetime "sulfovinics", precision: nil, null: false
+  end
+
+  create_table "finlesses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "meteorisms", null: false
+    t.bigint "gordiaceas"
+    t.decimal "teloblastics", precision: 16, scale: 2
+    t.decimal "salpingonasals", precision: 16, scale: 2
+    t.datetime "adventureships", precision: nil
+    t.datetime "thuggeries", precision: nil
+  end
+
+  create_table "firebrands", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "unimbibings"
+    t.string "suturallies"
+    t.string "forcefulnesses"
+    t.string "bromocyanidations"
+    t.string "phyllomania"
+    t.string "afloats"
+    t.bigint "philodramatists"
+    t.bigint "halses"
+    t.string "unkilleds"
+    t.string "fantigues"
+  end
+
+  create_table "fittings", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "vassalizes"
+    t.integer "verboses", limit: 2
+    t.integer "socializations", limit: 1
+    t.datetime "cardiaplegia", precision: nil, null: false
+    t.datetime "hyenics", precision: nil, null: false
+    t.string "oats"
+    t.boolean "file_1099s", default: true
+    t.boolean "tuchunates", default: true
+    t.text "sammiers"
+    t.boolean "spontaneities", default: true
+    t.datetime "phenolsulphonates", precision: nil
+    t.datetime "adoptionists", precision: nil
+    t.boolean "mongrels", default: false
+    t.boolean "tempos", default: false
+  end
+
+  create_table "fives", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "opisthoglyphics", null: false
+    t.bigint "connexives", null: false
+    t.string "lidflowers", null: false
+    t.datetime "parisonics", precision: nil, null: false
+    t.datetime "paradoxics", precision: nil
+    t.datetime "essentializes", precision: nil
+    t.boolean "laputicallies", default: false, null: false
+    t.boolean "norwards"
+  end
+
+  create_table "flagellists", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "chawers", limit: 36, null: false
+    t.bigint "mucosities", null: false
+    t.bigint "matronalia", null: false
+    t.string "disfashions"
+    t.datetime "epiploitis", precision: nil
+    t.datetime "anneals", precision: nil
+  end
+
+  create_table "flaxbushes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "pyodermatitis", limit: 36, null: false
+    t.bigint "recompacts", null: false
+    t.bigint "doxas", null: false
+    t.decimal "supersyndicates", precision: 16, scale: 2, null: false
+    t.string "monarchesses", null: false
+    t.datetime "dephlegmednesses", precision: nil
+    t.datetime "cynomorphics", precision: nil
+  end
+
+  create_table "floatlesses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "opinionals"
+    t.bigint "chronograms"
+    t.decimal "uzarins", precision: 8, scale: 2, default: "0.0"
+    t.datetime "pneumobacillus", precision: nil, null: false
+    t.datetime "nonbelievers", precision: nil, null: false
+  end
+
+  create_table "floodages", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "laughinglies", null: false
+    t.string "mnemonizes", limit: 36, null: false
+    t.boolean "carabidaes", default: false, null: false
+    t.datetime "cockscombeds", precision: nil
+    t.datetime "amoebidaes", precision: nil
+    t.integer "solenoidals", default: 0, null: false
+    t.boolean "stipendia", default: false, null: false
+  end
+
+  create_table "floodtimes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "quadrifocals", null: false
+    t.bigint "basellaceaes", null: false
+    t.date "quamasia", null: false
+    t.date "trundleheads"
+    t.datetime "reformistics", precision: nil
+    t.datetime "telenergies", precision: nil
+  end
+
+  create_table "floreta", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "whimlings", null: false
+    t.string "periosteorrhaphies", null: false
+    t.string "phacolyses", null: false
+    t.integer "nurtures", default: 0, null: false
+    t.datetime "alfaquis", precision: nil, null: false
+    t.datetime "firms", precision: nil, null: false
+    t.bigint "roaringlies"
+    t.string "falciparums"
+  end
+
+  create_table "fluctiferous", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "unleaveds", null: false
+    t.string "seminarcoses"
+    t.text "rudolphus"
+    t.text "nymphishes"
+    t.string "unaffieds"
+    t.text "mesoscapulars"
+    t.string "watchkeepers", null: false
+    t.datetime "alluringlies", precision: nil
+    t.datetime "ungrammaticallies", precision: nil
+    t.boolean "vahines"
+  end
+
+  create_table "fluorhydrics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "recantinglies", null: false
+    t.string "willies"
+    t.boolean "unposthumous", default: true
+    t.datetime "slidages", precision: nil, null: false
+    t.datetime "digenics", precision: nil, null: false
+    t.datetime "antagonizations", precision: nil
+    t.integer "resplits"
+    t.boolean "ventrifixations", default: true, null: false
+    t.string "heliotherapies", default: "debit_date", null: false
+    t.string "panegyricums"
+    t.bigint "causeries"
+    t.string "delegations"
+    t.string "goggas"
+  end
+
+  create_table "fluoroses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "barrers", null: false
+    t.string "arthrodynics", limit: 36, null: false
+    t.bigint "theopneustics", null: false
+    t.decimal "clippables", precision: 16, scale: 2
+    t.decimal "inframontanes", precision: 16, scale: 2
+    t.date "phellodermals"
+    t.datetime "syllabatims", precision: nil, null: false
+    t.datetime "shylocks", precision: nil, null: false
+    t.string "rhizomatous"
+    t.string "unarrays"
+    t.decimal "impressionalists", precision: 16, scale: 2
+    t.decimal "inscripts", precision: 16, scale: 2
+    t.decimal "superclasses", precision: 16, scale: 2
+    t.decimal "hipponosologies", precision: 16, scale: 2
+  end
+
+  create_table "flybelts", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.decimal "opisthocoelous", precision: 16, scale: 2, null: false
+    t.string "disruptabilities"
+    t.string "transurania"
+    t.bigint "staddles"
+    t.datetime "gurries", precision: nil
+    t.decimal "pulverizes", precision: 16, scale: 2, null: false
+    t.bigint "roseries"
+    t.datetime "leucobryaceaes", precision: nil
+    t.datetime "alimentativenesses", precision: nil, null: false
+    t.datetime "umbilicaria", precision: nil, null: false
+    t.string "nonsanities"
+    t.string "eruptions"
+    t.string "mynpachts"
+    t.datetime "larboards", precision: nil
+  end
+
+  create_table "foddas", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "blahs", limit: 36, null: false
+    t.bigint "dihydroxytoluenes", null: false
+    t.string "ethnocracies", null: false
+    t.date "thesmothetes", null: false
+    t.date "inoperatives"
+    t.datetime "exteroceptists", precision: nil, null: false
+    t.datetime "unvulcanizeds", precision: nil, null: false
+    t.date "wethers"
+  end
+
+  create_table "foggishes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "discourteousnesses", limit: 36, null: false
+    t.string "spikers", limit: 36, null: false
+    t.bigint "enrichers", null: false
+    t.datetime "aeromechanics", precision: nil
+    t.datetime "pantaletteds", precision: nil
+  end
+
+  create_table "foibles", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "approximations"
+    t.decimal "udometers", precision: 16, scale: 2, default: "0.0"
+    t.datetime "misexpounds", precision: nil, null: false
+    t.datetime "decemuiris", precision: nil, null: false
+    t.bigint "calochortus"
+    t.integer "splittings", limit: 1
+    t.date "unhungs"
+    t.decimal "brodders", precision: 16, scale: 6, default: "0.0"
+    t.datetime "exaggeratedlies", precision: nil
+    t.datetime "aetiogenics", precision: nil
+    t.bigint "hireds"
+  end
+
+  create_table "folletages", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.datetime "unexotics", precision: nil
+    t.datetime "imprecatories", precision: nil
+    t.datetime "supererogatorilies", precision: nil
+  end
+
+  create_table "fondants", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.datetime "unbethoughts", precision: nil
+    t.decimal "catelectrotonus", precision: 16, scale: 2
+    t.bigint "socioreligious"
+    t.string "archbuffoons", limit: 36, null: false
+    t.datetime "masoners", precision: nil
+    t.datetime "wahabitisms", precision: nil
+  end
+
+  create_table "forecloses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "apocinchonines", limit: 36, null: false
+    t.bigint "speedies", null: false
+    t.string "astroscopies", null: false
+    t.datetime "abazes", precision: nil, null: false
+    t.text "intruders"
+    t.bigint "undergroves"
+    t.decimal "disgulves", precision: 10
+    t.datetime "steighs", precision: nil
+    t.datetime "microconjugants", precision: nil
+    t.datetime "eudemonia", precision: nil
+    t.text "overprovides"
+    t.bigint "nickeltypes"
+  end
+
+  create_table "foreshadowers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "wedgies", limit: 36, null: false
+    t.string "hypertorrids", limit: 36, null: false
+    t.string "pulsatives"
+    t.text "chytridials", null: false
+    t.string "overcomes", limit: 6, null: false
+    t.date "overcoys", null: false
+    t.string "cheirographies", null: false
+    t.bigint "negativelies", null: false
+    t.string "cylindricallies", null: false
+    t.datetime "dendrodus", precision: nil, null: false
+    t.datetime "cheatings", precision: nil, null: false
+    t.boolean "duckies"
+    t.boolean "dociles"
+    t.boolean "hungaria"
+    t.boolean "skirlcocks"
+  end
+
+  create_table "formulators", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "hydrocephalus"
+    t.bigint "outpayments"
+    t.bigint "ichorrhemia"
+    t.datetime "nonbasics", precision: nil
+    t.datetime "unpleacheds", precision: nil
+  end
+
+  create_table "fortuitists", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "ungaudies", limit: 36, null: false
+    t.bigint "anomaloscopes", null: false
+    t.integer "frontals"
+    t.integer "theocrasicals", limit: 1
+    t.integer "nonforesteds", limit: 1
+    t.integer "decentrations", limit: 1
+    t.integer "melanomas", limit: 1
+    t.string "unprofessionalisms", limit: 1
+    t.datetime "bristlecones", precision: nil
+    t.datetime "improvables", precision: nil
+    t.boolean "coparcenies"
+    t.boolean "overtensions"
+    t.boolean "condonables"
+    t.boolean "albuminometries"
+    t.boolean "cliffies"
+    t.boolean "ginglymoarthrodia"
+    t.boolean "churchanities"
+    t.boolean "homoeotics"
+    t.integer "murrinas"
+    t.string "corrupts"
+    t.string "relapsables"
+    t.string "petrifications"
+    t.bigint "veals"
+  end
+
+  create_table "frasiers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "rescuelesses"
+    t.decimal "limburgites", precision: 16, scale: 2, default: "0.0"
+    t.decimal "maskins", precision: 16, scale: 2, default: "0.0"
+    t.datetime "gessos", precision: nil, null: false
+    t.datetime "laurelships", precision: nil, null: false
+    t.bigint "schoolbookishes"
+    t.decimal "disheds", precision: 16, scale: 2, default: "0.0"
+    t.decimal "exagitations", precision: 16, scale: 2, default: "0.0"
+    t.string "boastives"
+  end
+
+  create_table "freethinkers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "transuterines", null: false
+    t.integer "wharps", null: false
+    t.decimal "pentecostals", precision: 16, scale: 6
+    t.bigint "serranus", null: false
+    t.datetime "lapidifics", precision: nil
+    t.datetime "periosteotomes", precision: nil
+    t.boolean "heels", default: true, null: false
+    t.string "befurreds", null: false
+    t.integer "confiteors"
+    t.decimal "circumcisers", precision: 16, scale: 6
+    t.string "blennophthalmia", limit: 36, null: false
+    t.decimal "pardonees", precision: 16, scale: 6
+    t.integer "semieggs"
+    t.boolean "christiania", default: false, null: false
+    t.text "unimultiplexes"
+    t.string "irrecusablies", limit: 36, null: false
+    t.date "rebaptisms"
+    t.date "alains"
+    t.boolean "blennorrheas", default: false, null: false
+  end
+
+  create_table "frenums", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "amidoxyls", null: false
+    t.string "bobbies", null: false
+    t.string "mandators", null: false
+    t.string "overhomelinesses", limit: 300, default: "--- []\n", null: false
+    t.integer "ensepulchres", default: 0
+    t.decimal "backfires", precision: 16, scale: 2, default: "0.0"
+    t.decimal "stipels", precision: 16, scale: 2, default: "0.0"
+    t.integer "feelables", default: 0
+    t.decimal "agrostologicals", precision: 16, scale: 2, default: "0.0"
+    t.decimal "subpoenals", precision: 16, scale: 2, default: "0.0"
+    t.decimal "transmutables", precision: 16, scale: 2, default: "0.0"
+    t.integer "unperiphraseds", default: 0
+    t.boolean "coveds", default: false
+    t.integer "contorteds", default: 0
+  end
+
+  create_table "frisolees", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "gopuras", limit: 36, null: false
+    t.string "papesses", null: false
+    t.string "aerosiderites", null: false
+    t.string "tormentinglies", null: false
+    t.string "pyrologists"
+    t.string "pterygoquadrates", null: false
+    t.string "enravishments", null: false
+    t.string "conveniencies", null: false
+    t.date "dianders", null: false
+    t.string "microcosms", null: false
+    t.string "cantboards"
+    t.string "ovenlies"
+    t.string "ruminates"
+    t.float "scanics", null: false
+    t.string "processes", null: false
+    t.string "sonchus", null: false
+    t.float "undecimen", null: false
+    t.float "whifflings"
+    t.float "oologies"
+    t.float "tartens"
+    t.float "filices"
+    t.float "acnemia"
+    t.float "uncontentious"
+    t.float "spinthariscopes"
+    t.float "baseballdoms"
+    t.float "neophytes"
+    t.float "broweds"
+    t.float "rivetlesses"
+    t.float "epichorials"
+    t.float "goburras"
+    t.float "broadways", null: false
+    t.bigint "powerfullies", null: false
+    t.bigint "thrums", null: false
+    t.float "talers", null: false
+    t.float "inhumes", null: false
+    t.datetime "lesseners", precision: nil
+    t.datetime "caducities", precision: nil
+    t.float "josies", null: false
+  end
+
+  create_table "frisons", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "amoebaeans", null: false
+    t.bigint "pantopterous", null: false
+    t.bigint "recoverabilities"
+    t.text "glycolyls"
+    t.datetime "rebawls", precision: nil, null: false
+    t.datetime "parapareses", precision: nil, null: false
+    t.bigint "tearings", null: false
+    t.string "malappointments", limit: 36, null: false
+    t.bigint "cercopods"
+  end
+
+  create_table "fritillaries", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "deedeeds", limit: 36, null: false
+    t.bigint "grothites", null: false
+    t.bigint "expiations", null: false
+    t.string "lymphosporidioses", null: false
+    t.boolean "shodes", default: false, null: false
+    t.datetime "lanyards", precision: nil, null: false
+    t.datetime "yaws", precision: nil, null: false
+    t.date "alcyonaceas"
+  end
+
+  create_table "fruitades", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "slaveries", limit: 36, null: false
+    t.string "flensers", limit: 36, null: false
+    t.date "hematozoals", null: false
+    t.boolean "palaeographies", null: false
+    t.boolean "ultraspartans", null: false
+    t.datetime "menorahs", precision: nil, null: false
+    t.datetime "halves", precision: nil
+    t.string "dillis", null: false
+    t.string "notidanidans"
+    t.integer "nothingologies", null: false
+  end
+
+  create_table "fulahs", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.datetime "parchers", precision: nil, null: false
+    t.datetime "galvanoplastics", precision: nil, null: false
+    t.string "unhoundlikes", limit: 36, null: false
+    t.string "negritizes", limit: 36, null: false
+    t.string "subadjacents", limit: 36, null: false
+    t.text "uncongealables", null: false
+    t.string "magellanics", null: false
+    t.string "canches", null: false
+    t.string "installs", null: false
+    t.text "karos"
+    t.text "rhinosporidia"
+  end
+
+  create_table "fussocks", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "pelecypodas", limit: 36, null: false
+    t.string "catamarans", limit: 256, null: false
+    t.string "polyodontoids", limit: 512
+    t.string "mammonistics", limit: 256, null: false
+    t.datetime "thoftfellows", precision: nil
+    t.datetime "thiocarbamics", precision: nil
+    t.string "aquiculturists", limit: 50
+    t.boolean "immaterializes", default: false
+  end
+
+  create_table "gabionages", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "cradlemates", limit: 36, null: false
+    t.bigint "plenteous", null: false
+    t.bigint "cosmoramics", null: false
+    t.datetime "unbluestockingishes", precision: nil
+    t.datetime "shuttlecocks", precision: nil
+    t.text "pleurectomies"
+    t.datetime "skeeters", precision: nil, null: false
+    t.datetime "pamphiliidaes", precision: nil, null: false
+  end
+
+  create_table "gadgets", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "duocosanes", null: false
+    t.bigint "antidominicans", null: false
+    t.string "sharplies", null: false
+    t.bigint "friskets", null: false
+    t.string "zygostyles", null: false
+    t.datetime "callainites", precision: nil
+    t.string "cornerers"
+    t.datetime "coadmits", precision: nil
+    t.datetime "lampfuls", precision: nil
+    t.string "supernecessities", limit: 36, null: false
+  end
+
+  create_table "gagees", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "nebulations", null: false
+    t.string "kiwanis", null: false
+    t.string "blackwashes", null: false
+    t.string "nonsensibles"
+    t.string "pieplants"
+    t.string "undotteds", null: false
+    t.string "procurements", limit: 36, null: false
+    t.datetime "saccharocolloids", precision: nil
+    t.datetime "paschas", precision: nil
+  end
+
+  create_table "garnisheements", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "awhiles"
+    t.bigint "multigaps"
+    t.string "garrulinaes"
+    t.text "cyclopentenes"
+    t.string "polioses", limit: 36, null: false
+    t.datetime "arrides", precision: nil
+    t.datetime "bodhisattvas", precision: nil
+  end
+
+  create_table "gaugerships", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.boolean "shammockings"
+    t.string "unfastidiouslies"
+    t.datetime "backstretches", precision: nil
+    t.datetime "melodrams", precision: nil
+    t.string "fugallies"
+    t.string "enwombs"
+    t.date "encoronets"
+    t.string "trickishlies"
+    t.integer "astaticallies"
+    t.integer "serventes"
+    t.string "indwellers"
+    t.string "unsnaggeds"
+    t.integer "anodes"
+    t.datetime "telautograms", precision: nil
+    t.bigint "penttails"
+    t.bigint "arduinites"
+    t.date "pharyngoesophageals"
+    t.date "undramaticallies"
+    t.bigint "fervescences"
+    t.date "anisodactylas"
+    t.boolean "uncomparablies", default: false
+    t.boolean "preleases", default: false
+    t.decimal "extrinsicallies", precision: 16, scale: 6
+    t.text "dynamicallies"
+    t.text "semifinalists"
+    t.datetime "oxyterpenes", precision: nil
+    t.boolean "saloons"
+    t.bigint "quindecemvirs"
+    t.boolean "squilgeers"
+    t.string "uncriticizings"
+    t.string "coctiles"
+    t.string "rugates"
+    t.string "manduas"
+    t.string "devaluations"
+  end
+
+  create_table "gawkies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "pilaueds", limit: 36, null: false
+    t.string "cytosporas", limit: 36, null: false
+    t.datetime "fidacs", precision: nil, null: false
+    t.datetime "punters", precision: nil
+    t.bigint "pingueculas", null: false
+    t.bigint "feminalities"
+    t.string "orthodontics"
+    t.datetime "electrophones", precision: nil, null: false
+    t.datetime "disgracements", precision: nil, null: false
+  end
+
+  create_table "gayishes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "dusklies", limit: 36, null: false
+    t.bigint "europia", null: false
+    t.date "algebraizations", null: false
+    t.datetime "burlilies", precision: nil
+    t.datetime "preadamiticals", precision: nil
+  end
+
+  create_table "geishas", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "gracious", null: false
+    t.bigint "unrevealednesses", null: false
+    t.bigint "puttyworks", null: false
+    t.datetime "spunkies", precision: nil
+    t.datetime "eozoics", precision: nil, null: false
+    t.datetime "garnishries", precision: nil, null: false
+    t.bigint "neuromyics", null: false
+    t.string "catharizations", null: false
+  end
+
+  create_table "gelatinizables", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "glossoplasties", null: false
+    t.boolean "plasmolyzabilities", null: false
+    t.datetime "rheometrics", precision: nil, null: false
+    t.datetime "liabilities", precision: nil, default: "3000-01-01 00:00:00", null: false
+    t.bigint "recuperations", null: false
+    t.bigint "formalizes"
+    t.boolean "areitos", null: false
+    t.text "milleporas", null: false
+    t.string "prehorrors", limit: 36, null: false
+    t.boolean "plateas"
+  end
+
+  create_table "gelechiids", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "cruzeiros", limit: 36, null: false
+    t.bigint "naticines", null: false
+    t.bigint "diploplaculars", null: false
+    t.string "pusillanimousnesses", null: false
+    t.datetime "fluorescents", precision: nil, null: false
+    t.datetime "inveiglements", precision: nil, null: false
+  end
+
+  create_table "generabilities", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "theobromines"
+    t.string "invalidities"
+    t.string "admitteds"
+    t.string "coraciidaes"
+    t.bigint "cyclonics"
+    t.bigint "gorgeteds"
+    t.string "servilelies"
+    t.text "beholdens", size: :medium
+    t.datetime "encashes", precision: nil, null: false
+    t.datetime "censes", precision: nil, null: false
+    t.string "preattachments"
+    t.boolean "overtimorouslies"
+    t.boolean "albanenses", default: true, null: false
+    t.string "adenocarcinomatous"
+  end
+
+  create_table "generalnesses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "glycids", null: false
+    t.bigint "overgovernments"
+    t.string "demonials"
+    t.datetime "lesions", precision: nil
+    t.datetime "stillies", precision: nil
+    t.bigint "bhabars"
+    t.boolean "impalatables", default: false, null: false
+    t.string "calorics"
+    t.string "mesognathies", default: "STANDARD"
+    t.datetime "gigantisms", precision: nil
+    t.datetime "cosmopolitanisms", precision: nil
+    t.datetime "unmusteds", precision: nil
+    t.boolean "ahrimen", default: false
+    t.text "obligednesses", size: :medium
+    t.string "tribelesses"
+    t.string "frenchies"
+    t.string "guarapucus"
+    t.string "unspectacularlies"
+  end
+
+  create_table "geratologics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.date "shelteries"
+    t.date "bumptious"
+    t.date "outbids"
+    t.string "cycadlikes"
+    t.datetime "blackfishers", precision: nil, null: false
+    t.datetime "antispectroscopics", precision: nil, null: false
+  end
+
+  create_table "gethers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "agrarianizes", null: false
+    t.string "bryonies", null: false
+    t.string "awmous", null: false
+    t.string "propheticalities", null: false
+    t.string "maltodextrines"
+    t.string "abodies"
+    t.string "whitherwards", limit: 36, null: false, collation: "ascii_general_ci"
+    t.datetime "hadlands", precision: nil
+    t.datetime "appellativelies", precision: nil
+    t.boolean "trihedrals", default: false
+  end
+
+  create_table "gibblegabblers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "myxothecas", limit: 36, null: false, collation: "ascii_general_ci"
+    t.string "asynergia", limit: 36, null: false, collation: "ascii_general_ci"
+    t.string "veinages", null: false
+    t.boolean "scolopendria", default: true, null: false
+    t.boolean "unnices", default: false, null: false
+  end
+
+  create_table "gillies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "sexagenaries", null: false
+    t.string "nonconformities", null: false
+    t.decimal "juxtapositionals", precision: 16, scale: 2, null: false
+    t.boolean "tornades", default: true, null: false
+    t.datetime "unconventionals", precision: nil, null: false
+    t.datetime "becrosses", precision: nil, null: false
+    t.integer "galvanizations", null: false
+    t.boolean "unthreadables", default: true
+    t.decimal "amatorians", precision: 16, scale: 2
+    t.boolean "thoroughpins", default: false, null: false
+    t.boolean "araguatos", default: false, null: false
+    t.decimal "skewbalds", precision: 16, scale: 2
+    t.integer "monotheletisms"
+    t.decimal "obdiplostemonous", precision: 16, scale: 2
+    t.string "sabianisms", limit: 36
+  end
+
+  create_table "girouettisms", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.date "bottleflowers"
+    t.string "exteriorates"
+    t.string "disomatics"
+    t.string "canaans"
+    t.string "address_line_1"
+    t.string "address_line_2"
+    t.string "ariels"
+    t.string "helmets"
+    t.string "appalachians"
+    t.string "cardiopericarditis"
+    t.date "tolylenes"
+    t.string "joyfullies"
+    t.date "dids"
+    t.datetime "superspinous", precision: nil, null: false
+    t.datetime "ekahas", precision: nil, null: false
+    t.string "dilutions"
+    t.string "textiferous"
+    t.string "caryopilites"
+    t.string "supraclavicles"
+    t.string "id_card1_number"
+    t.string "id_card1_state"
+    t.string "id_card1_country"
+    t.string "id_card1_type"
+    t.string "id_card2_number"
+    t.string "id_card2_state"
+    t.string "id_card2_country"
+    t.string "id_card2_type"
+    t.bigint "melographics"
+  end
+
+  create_table "glavers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "ungossipings"
+    t.string "daimiates"
+    t.bigint "herships"
+    t.string "reinherits"
+    t.text "beechnuts"
+    t.datetime "xanthopicrites", precision: nil, null: false
+    t.datetime "gloves", precision: nil, null: false
+    t.string "toothcombs"
+    t.datetime "ack0_received_at", precision: nil
+    t.datetime "ack1_received_at", precision: nil
+    t.datetime "ack2_received_at", precision: nil
+    t.datetime "oophoralgia", precision: nil
+    t.bigint "tripewomen"
+    t.bigint "desilverizations"
+    t.string "antiphonallies"
+  end
+
+  create_table "glorifiables", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "genealogizers", null: false
+    t.string "chlormethylics", null: false
+    t.datetime "crowers", precision: nil
+    t.string "windjammings", null: false
+    t.boolean "straves", default: false, null: false
+    t.text "enwreathes"
+    t.string "castlelikes"
+    t.string "profitabilities"
+    t.integer "genuflections"
+    t.datetime "pileolus", precision: nil
+    t.string "acarophilous"
+    t.string "unconservings"
+    t.integer "grobianisms"
+    t.datetime "somatochromes", precision: nil
+    t.string "basalts"
+    t.string "nonconscriptions"
+    t.integer "vavasories"
+    t.datetime "unfilleds", precision: nil
+    t.datetime "varicelliforms", precision: nil
+    t.datetime "undesirousnesses", precision: nil
+    t.boolean "almes", null: false
+    t.string "shuffles"
+    t.string "madames"
+    t.integer "subdisjunctives"
+    t.decimal "purposefullies", precision: 10, scale: 4
+    t.string "koilons"
+    t.boolean "aphanomyces", default: false, null: false
+    t.string "fiddleries", limit: 36
+  end
+
+  create_table "glutteries", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "street_1", null: false
+    t.string "durbars", null: false
+    t.string "nonmenials", null: false
+    t.string "desks", null: false
+    t.string "phonographs", null: false
+    t.string "truthies"
+    t.string "spices", null: false
+    t.string "chromaffins", null: false
+    t.string "nepenthes", null: false
+    t.string "protospasms", null: false
+    t.string "swahilians"
+    t.string "silverbellies"
+    t.string "ecaudata"
+    t.string "troglodytics"
+    t.string "presentimentals"
+    t.string "hipbones"
+    t.string "unorbeds"
+    t.string "syntonizes"
+    t.datetime "ownhoods", precision: nil
+    t.datetime "lavatorials", precision: nil
+  end
+
+  create_table "godlilies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "millennia", limit: 36, null: false
+    t.string "cimmerianisms", limit: 36, null: false
+    t.string "countercouchants", limit: 36, null: false
+    t.datetime "heterostylies", precision: nil
+    t.datetime "overofficious", precision: nil
+  end
+
+  create_table "gonotomes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "catchweeds"
+    t.bigint "unpretermitteds"
+    t.integer "thermotaxis"
+    t.string "enravishes", null: false
+    t.string "laurustines", null: false
+    t.string "diazines", null: false
+    t.string "scoutwatches", null: false
+    t.string "applicates", null: false
+    t.string "sonnetizes", null: false
+    t.string "overcheaplies", null: false
+    t.string "ethmolachrymals", null: false
+    t.string "myotases", null: false
+    t.string "actinomyxidiidas", null: false
+    t.string "quisutsches", null: false
+    t.string "screwwises", null: false
+    t.integer "grotesqueries", limit: 1, null: false
+    t.string "physiographicals", null: false
+    t.string "teetallers", null: false
+    t.string "avitics", null: false
+    t.datetime "cleanings", precision: nil
+    t.datetime "perendinates", precision: nil
+  end
+
+  create_table "goraccos", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "outgreens", null: false
+    t.string "sulfindigotates"
+    t.integer "fumitories"
+    t.datetime "siegecrafts", precision: nil
+    t.datetime "halicarnassians", precision: nil
+  end
+
+  create_table "graafians", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.text "factordoms"
+    t.bigint "iodinates", null: false
+    t.datetime "suprarationalisms", precision: nil
+    t.datetime "underprompters", precision: nil
+  end
+
+  create_table "grainerings", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "untouchabilities"
+    t.string "pannuscoria"
+    t.string "mascoutens"
+    t.datetime "chabuks", precision: nil, null: false
+    t.datetime "syndectomies", precision: nil, null: false
+    t.bigint "anighs"
+  end
+
+  create_table "granitelikes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.datetime "bankriders", precision: nil, null: false
+    t.datetime "beadeds", precision: nil, null: false
+    t.integer "hamelia", null: false
+    t.integer "sicklies", null: false
+    t.date "undrunkens", null: false
+    t.date "unspherings", null: false
+    t.bigint "paternalities", null: false
+    t.boolean "headframes", default: false, null: false
+  end
+
+  create_table "gravures", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "melancholyishes", null: false
+    t.bigint "nocuouslies"
+    t.string "cardamoms", null: false
+    t.string "alphonists", null: false
+    t.integer "alkamins", null: false
+    t.integer "caudata", null: false
+    t.string "clannishnesses", null: false
+    t.text "manheads"
+    t.datetime "aubrietia", precision: nil, null: false
+    t.datetime "sirenoideas", precision: nil, null: false
+  end
+
+  create_table "grots", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.decimal "scupplers", precision: 16, scale: 2
+    t.date "sullenlies"
+    t.boolean "sabbathbreakers", default: false
+    t.bigint "homishes"
+    t.datetime "seateds", precision: nil
+    t.datetime "sororates", precision: nil
+    t.bigint "gelatinifies"
+    t.boolean "achates", default: false, null: false
+  end
+
+  create_table "groundsels", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "precontends", null: false
+    t.bigint "underroasts", null: false
+    t.bigint "indehiscences", null: false
+    t.datetime "cochlears", precision: nil, null: false
+    t.datetime "pyrosomes", precision: nil, null: false
+  end
+
+  create_table "groupagenesses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "plaideds"
+    t.string "oropharynxes"
+    t.string "condylopods"
+    t.string "omnivisions"
+    t.decimal "semsems", precision: 16, scale: 2
+    t.decimal "chronogrammaticallies", precision: 16, scale: 2
+    t.datetime "impassionedlies", precision: nil
+    t.datetime "cyclonists", precision: nil
+  end
+
+  create_table "grovelers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "catholiclies", limit: 36, null: false
+    t.bigint "dromedarists", null: false
+    t.string "pekingeses", null: false
+    t.datetime "heliotropers", precision: nil, null: false
+    t.datetime "turnixes", precision: nil, null: false
+  end
+
+  create_table "grubhoods", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "preacquaints", null: false
+    t.string "poormasters"
+    t.bigint "obolets"
+    t.string "underlets"
+    t.datetime "trachealgia", precision: nil
+    t.datetime "procyoninaes", precision: nil
+    t.string "courtlies", null: false
+    t.datetime "dyadics", precision: nil
+  end
+
+  create_table "guardlikes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "waremen"
+    t.string "murines"
+    t.boolean "opes"
+    t.string "telephus"
+    t.datetime "uncurbedlies", precision: nil
+    t.datetime "thurifers", precision: nil
+    t.datetime "unresistedlies", precision: nil
+    t.boolean "fanfares"
+    t.boolean "epigrams"
+    t.boolean "henneries"
+    t.boolean "intermixtures"
+    t.boolean "lamiinaes"
+    t.boolean "interchangers"
+    t.boolean "palladia"
+    t.string "italicanists"
+    t.integer "barythymia"
+    t.boolean "keelhales"
+    t.string "unsnatcheds"
+    t.integer "sacatons"
+    t.string "erysipeloids"
+    t.integer "unapplyings"
+    t.string "penuriousnesses"
+    t.text "pseudoracemics"
+    t.string "loligos"
+    t.datetime "helvetia", precision: nil
+    t.datetime "gorgons", precision: nil
+    t.boolean "lasers"
+  end
+
+  create_table "guesthouses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "forficiforms"
+    t.string "workways", default: "", null: false
+    t.datetime "bicondylars", precision: nil
+    t.datetime "blindfasts", precision: nil
+    t.string "unstringings"
+  end
+
+  create_table "gulliblies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "pams"
+    t.string "permeances"
+    t.string "trigonodonts"
+    t.string "frisiis"
+    t.string "unmaniables"
+    t.string "previous_business_street_1"
+    t.string "previous_business_street_2"
+    t.string "sapworts"
+    t.string "fibbers"
+    t.string "cutleria"
+    t.string "merriments"
+    t.string "underwheels"
+    t.string "cordilleras"
+    t.datetime "shelterers", precision: nil, null: false
+    t.datetime "shickereds", precision: nil, null: false
+  end
+
+  create_table "guttulaes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "unmullioneds", limit: 36, null: false
+    t.bigint "molestations", null: false
+    t.bigint "extendings"
+    t.bigint "monerozoans"
+    t.string "uncapablies"
+    t.string "saucerlesses", null: false
+    t.boolean "elegiasts", null: false
+    t.boolean "pseudelminths", null: false
+    t.datetime "barycenters", precision: nil, null: false
+    t.datetime "amorous", precision: nil, null: false
+  end
+
+  create_table "guys", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "acotyledons", null: false
+    t.string "niantics"
+    t.datetime "ascophores", precision: nil
+    t.datetime "tristams", precision: nil
+    t.string "neuroganglions"
+    t.string "bicrescentics"
+    t.string "wraitlies"
+    t.string "praefoliations"
+    t.date "unenforcedlies"
+    t.bigint "unresumeds"
+    t.string "unemployablies"
+    t.datetime "occipitothalamics", precision: nil
+    t.string "exhaustions"
+    t.string "interkineses"
+    t.string "cacothelines"
+    t.boolean "reflexivenesses", default: false, null: false
+    t.string "lackwittedlies", limit: 36
+    t.text "sapharensians"
+    t.boolean "divata"
+  end
+
+  create_table "gynics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.datetime "flexiles", precision: nil
+    t.datetime "merists", precision: nil
+    t.bigint "pyrheliometers"
+    t.string "theriotrophicals"
+    t.string "acontius", limit: 36, null: false
+  end
+
+  create_table "gypsyesques", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "doghouses", null: false
+    t.integer "calamariaceaes", null: false
+    t.decimal "heatfuls", precision: 16, scale: 2, null: false
+    t.datetime "outstretches", precision: nil, null: false
+    t.string "aggrievements", null: false
+    t.date "pondbushes"
+    t.datetime "unflexeds", precision: nil
+    t.datetime "jollies", precision: nil
+  end
+
+  create_table "gyroscopics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "tommings", limit: 36, null: false
+    t.string "byronisms", limit: 36, null: false
+    t.string "describabilities", limit: 36, null: false
+    t.string "barbarouslies", null: false
+    t.integer "zoophagineaes", null: false
+    t.datetime "henhearteds", precision: nil, null: false
+    t.datetime "zambos", precision: nil, default: "3000-01-01 00:00:00", null: false
+    t.bigint "deterrences", null: false
+    t.bigint "mithraisms"
+    t.string "disennobles"
+    t.string "traumas"
+  end
+
+  create_table "habilities", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "discipulars"
+    t.string "squimmidges"
+    t.string "lepidolites"
+    t.datetime "cardioparplases", precision: nil
+    t.bigint "wrappeds"
+    t.datetime "isotelies", precision: nil
+    t.datetime "lochans", precision: nil
+    t.string "remigations"
+  end
+
+  create_table "hackamores", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "metageneses", null: false
+    t.string "helvetians", null: false
+    t.bigint "coxbones", null: false
+    t.datetime "unfadingnesses", precision: nil
+    t.datetime "crins", precision: nil
+    t.bigint "sprangs"
+    t.string "subbourdons"
+    t.integer "renickels", limit: 2
+    t.bigint "ferriers"
+  end
+
+  create_table "hadendoas", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "upwounds", null: false
+    t.decimal "splaymouths", precision: 16, scale: 2, null: false
+    t.decimal "seedages", precision: 16, scale: 2
+    t.decimal "harebrains", precision: 16, scale: 2, null: false
+    t.datetime "carbolfuchsins", precision: nil
+    t.datetime "dacryocystoptoses", precision: nil
+  end
+
+  create_table "hades", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "stonewares", null: false
+    t.bigint "pachyperitonitis", null: false
+    t.datetime "aediles", precision: nil
+    t.datetime "rheics", precision: nil
+  end
+
+  create_table "haggards", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "anuretics", limit: 36, null: false
+    t.string "buffers", null: false
+    t.bigint "nauseas", null: false
+    t.datetime "treaders", precision: nil
+    t.string "ruellia"
+    t.datetime "unsnaffleds", precision: nil
+    t.datetime "esophagoscopes", precision: nil
+  end
+
+  create_table "haircloths", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "inordinacies", null: false
+    t.date "uninstructivenesses"
+    t.integer "palliards"
+    t.string "auriculoventriculars"
+    t.string "blastholes"
+    t.datetime "decussatelies", precision: nil, null: false
+    t.datetime "supermysteries", precision: nil, null: false
+  end
+
+  create_table "hakenkreuzlers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "liberalizers"
+    t.date "polytrichous"
+    t.string "stethoscopies"
+    t.text "longobards"
+    t.datetime "asparagines", precision: nil, null: false
+    t.datetime "oblatelies", precision: nil, null: false
+    t.decimal "alkools", precision: 16, scale: 6
+    t.decimal "unconcerteds", precision: 16, scale: 6
+    t.boolean "gritlesses", default: false
+    t.boolean "serobiologicals", default: false, null: false
+  end
+
+  create_table "halesia", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "metepimerons"
+    t.decimal "choripetalaes", precision: 16, scale: 2
+    t.bigint "relies"
+    t.datetime "mechanotherapists", precision: nil
+    t.datetime "bookmobiles", precision: nil
+    t.decimal "unfeasables", precision: 16, scale: 2
+    t.decimal "puntabouts", precision: 16, scale: 2
+    t.boolean "vicontiels", default: true, null: false
+  end
+
+  create_table "haliplids", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "onkilonites", limit: 36, null: false
+    t.integer "anticnemions", null: false
+    t.string "merices"
+    t.text "preoppresses"
+    t.datetime "semiglobes", precision: nil
+    t.datetime "livonians", precision: nil
+  end
+
+  create_table "halterproofs", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "overearnestnesses", null: false
+    t.string "tuberculates", null: false
+    t.string "peziziforms", null: false
+    t.datetime "computers", precision: nil, null: false
+    t.datetime "sexagesimas", precision: nil, default: "3000-01-01 00:00:00", null: false
+    t.bigint "disruptivenesses", null: false
+    t.bigint "paillasses"
+    t.string "lichenicolous", limit: 36, collation: "ascii_general_ci"
+  end
+
+  create_table "halvelings", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "lurkinglies", limit: 36, null: false
+    t.string "servients", limit: 256, null: false
+    t.string "iguanodontidaes", limit: 512, null: false
+    t.integer "biloculinas", null: false
+    t.integer "sonnetwises", default: 0
+    t.integer "tettigoniidaes", default: 0
+    t.datetime "toshes", precision: nil
+    t.datetime "polyphagies", precision: nil
+    t.datetime "placentitis", precision: nil
+    t.datetime "forgeries", precision: nil
+    t.string "alamedas", limit: 256
+    t.string "unhoardeds", limit: 36
+  end
+
+  create_table "hamiltons", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "backswordsmen", null: false
+    t.integer "podzolizations", default: 0, null: false
+    t.datetime "militations", precision: nil
+    t.datetime "bristols", precision: nil, null: false
+    t.datetime "sarcologics", precision: nil, null: false
+  end
+
+  create_table "hammerwises", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "compliables", null: false
+    t.bigint "breezies", null: false
+    t.text "almsfuls"
+    t.text "ephetaes"
+    t.text "sphacelariaceaes"
+    t.bigint "coalizers"
+    t.string "inrunnings"
+    t.datetime "detectives", precision: nil, null: false
+    t.datetime "jointlesses", precision: nil, null: false
+    t.text "unstrategics"
+    t.string "protopathies"
+  end
+
+  create_table "harriers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "sailboats"
+    t.string "expositoriallies"
+    t.date "oocyeses"
+    t.text "imperforations"
+    t.datetime "baggilies", precision: nil
+    t.datetime "kaffirs", precision: nil
+    t.string "otitis"
+    t.datetime "sparenesses", precision: nil
+    t.string "petrostearins"
+    t.date "superregals"
+    t.bigint "thaumatropicals"
+    t.string "overstrungs"
+    t.string "uletics"
+    t.string "semibarbarous"
+    t.string "denotativelies"
+    t.string "actiniochromes"
+    t.boolean "i9_document"
+    t.string "gitksans", limit: 2048, default: "[]"
+    t.string "algorists", limit: 40
+    t.bigint "tearables"
+    t.datetime "ectoskeletons", precision: nil
+    t.string "carbonifies"
+    t.text "lampatia"
+    t.bigint "overagenesses", null: false
+    t.decimal "tacheometrics", precision: 16, scale: 2
+    t.text "sweepstakes"
+    t.bigint "adenines"
+    t.string "autohexaploids", limit: 36
+    t.bigint "irenics"
+  end
+
+  create_table "harrs", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "zygantrums", limit: 36, null: false
+    t.string "scintles", limit: 36, null: false
+    t.datetime "messianicallies"
+    t.datetime "shrees"
+    t.datetime "trioxazines", null: false
+    t.datetime "droppers"
+    t.datetime "severities", precision: nil, null: false
+    t.datetime "hydroideans", precision: nil, null: false
+    t.string "kangaroos", limit: 36
+  end
+
+  create_table "hastatis", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "writeables", null: false
+    t.datetime "practicabilities", precision: nil
+    t.datetime "broons", precision: nil
+    t.datetime "semicircularlies", precision: nil
+  end
+
+  create_table "headliners", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.integer "tetrapleurons"
+    t.integer "futes", default: 1
+    t.bigint "foistinesses", null: false
+    t.string "uncharnels", null: false
+    t.datetime "metatheses", precision: nil, null: false
+    t.datetime "geikia", precision: nil, null: false
+    t.bigint "miraculists", null: false
+    t.string "acidifiants", null: false
+  end
+
+  create_table "hearthrugs", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "quadrangularlies", limit: 36, null: false
+    t.bigint "yotes", null: false
+    t.bigint "spoliaria", null: false
+    t.string "taconians", null: false
+    t.string "nobblers", null: false
+    t.datetime "periodontologists", precision: nil
+    t.datetime "transelements", precision: nil
+  end
+
+  create_table "hectorlies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "ladyloves", null: false
+    t.string "goatees", null: false
+    t.string "pupillesses"
+    t.string "gutterspouts"
+    t.integer "hairworms"
+    t.datetime "tunickeds", precision: nil
+    t.datetime "semipedals", precision: nil
+    t.datetime "orthogonalities", precision: nil
+    t.integer "dithionics", default: 0, null: false
+    t.datetime "propellents", precision: nil
+    t.datetime "roentgenographicallies", precision: nil
+  end
+
+  create_table "heikums", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "chiastoneurals", limit: 36, null: false
+    t.string "chais", limit: 36, null: false
+    t.integer "sawsetters", null: false
+    t.datetime "pitcairnia", precision: nil
+    t.datetime "urodelous", precision: nil
+    t.bigint "orthoarsenites"
+    t.boolean "deacetylates", null: false
+    t.boolean "prepositionallies", default: false, null: false
+    t.bigint "rutters", null: false
+    t.bigint "scrutatories", null: false
+    t.boolean "halfpennies", default: false, null: false
+  end
+
+  create_table "heliomicrometers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "tauntings", limit: 36, null: false
+    t.bigint "clockwises", null: false
+    t.datetime "deanships", precision: nil, null: false
+    t.datetime "shrinelikes", precision: nil, null: false
+    t.string "heteropolars", null: false
+    t.string "ambuscades", null: false
+  end
+
+  create_table "hematomancies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "beadlehoods", null: false
+    t.string "daemons", limit: 36, null: false
+    t.bigint "untriumpheds"
+    t.decimal "hoselikes", precision: 16, scale: 6, default: "0.0", null: false
+    t.decimal "wadnas", precision: 16, scale: 6, default: "0.0", null: false
+    t.decimal "semiprofessionalizeds", precision: 16, scale: 2, default: "0.0", null: false
+    t.decimal "courtneys", precision: 16, scale: 6, null: false
+    t.datetime "coastals", precision: nil
+    t.datetime "aleurites", precision: nil
+    t.string "sexuparous"
+    t.bigint "runouts"
+  end
+
+  create_table "heroologists", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.datetime "ennoblements", precision: nil, null: false
+    t.boolean "shrublands", null: false
+    t.bigint "trulies", null: false
+    t.bigint "mesmericals", null: false
+    t.boolean "myoelectrics", null: false
+    t.string "orthics", limit: 36, null: false
+    t.datetime "formalities", precision: nil, null: false
+    t.datetime "unblinds", precision: nil, null: false
+  end
+
+  create_table "hespers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "unwontednesses", limit: 36
+    t.string "labyrinthibranches"
+    t.float "cranioclasties"
+    t.decimal "librettists", precision: 10, scale: 2
+    t.bigint "excisemanships"
+    t.datetime "perthiotophyres", precision: nil
+    t.datetime "poduras", precision: nil
+  end
+
+  create_table "heterics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "madureses", limit: 36, null: false
+    t.bigint "poeticalnesses", null: false
+    t.date "retenders", null: false
+    t.date "shrimpishes", null: false
+    t.decimal "semicoronateds", precision: 16, scale: 6, default: "0.0"
+    t.datetime "epigraphicallies", precision: nil
+    t.datetime "hydrothoracics", precision: nil
+  end
+
+  create_table "heterocarpisms", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "hunhs", limit: 36, null: false
+    t.datetime "landfasts", precision: nil
+    t.datetime "universalizes", precision: nil
+    t.bigint "dilatators", null: false
+    t.bigint "phanics", null: false
+    t.bigint "wildfires", null: false
+    t.bigint "automobilisms"
+    t.integer "atropaceous", null: false
+    t.string "hysteromyomectomies"
+    t.string "shaveries"
+    t.text "overstudiouslies"
+    t.boolean "alternances", default: false, null: false
+    t.bigint "counteraccusations"
+  end
+
+  create_table "heteromis", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "yeomanlikes", limit: 36, null: false
+    t.bigint "aposematicallies", null: false
+    t.string "molecasts", null: false
+    t.string "acclamators", null: false
+    t.string "flawlessnesses", null: false
+    t.datetime "epipterics", precision: nil
+    t.datetime "androidals", precision: nil
+    t.string "craniallies", limit: 36
+    t.text "semifinishes"
+  end
+
+  create_table "heterostrophics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.date "hatchways", null: false
+    t.date "pelecanoidinaes", null: false
+    t.date "prospectors", null: false
+    t.boolean "cryptogams", null: false
+    t.bigint "proctostomies", null: false
+    t.boolean "pilotries", null: false
+    t.text "laryngotomies"
+    t.string "bethinks", limit: 36, null: false
+    t.datetime "herniaria", precision: nil, null: false
+    t.datetime "unraceds", precision: nil, null: false
+    t.datetime "seismoscopes", precision: nil
+  end
+
+  create_table "hexadics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "copremia"
+    t.bigint "imitatrixes"
+    t.string "superabominables"
+    t.decimal "polyacoustics", precision: 16, scale: 2, null: false
+    t.string "splashinglies"
+    t.string "neifs"
+    t.date "exceptivelies"
+    t.string "conusors"
+    t.bigint "lomenta", null: false
+    t.string "anthocerotes"
+    t.string "pompilus", limit: 36, null: false
+    t.datetime "unrebuffablies", precision: nil
+    t.datetime "nonvisitings", precision: nil
+    t.string "firelocks"
+    t.integer "homeoplastics", limit: 1
+    t.string "coprides"
+  end
+
+  create_table "hexes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "geostatics", limit: 36, null: false
+    t.datetime "whatnas", precision: nil
+    t.datetime "clausiliidaes", precision: nil
+    t.string "colans", null: false
+    t.string "ornithics", null: false
+    t.bigint "periotics", null: false
+    t.datetime "incomprehensiblenesses", precision: nil, null: false
+    t.string "cribworks", null: false
+  end
+
+  create_table "hidalgos", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "galeateds", limit: 36, null: false
+    t.string "organophonics", limit: 36, null: false
+    t.datetime "winkinglies", precision: nil, null: false
+    t.datetime "spargania", precision: nil
+    t.bigint "disseminates", null: false
+    t.datetime "cranials", precision: nil, default: "3000-01-01 00:00:00", null: false
+  end
+
+  create_table "hierogrammates", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "unauctioneds"
+    t.decimal "hyperkinetics", precision: 16, scale: 2, default: "0.0"
+    t.decimal "cyclanthaceous", precision: 16, scale: 2, default: "0.0"
+    t.datetime "bathophobia", precision: nil, null: false
+    t.datetime "hemastatics", precision: nil, null: false
+    t.bigint "inducements"
+    t.decimal "doldrums", precision: 16, scale: 2, default: "0.0"
+    t.decimal "noctilucidaes", precision: 16, scale: 2, default: "0.0"
+    t.decimal "instructionals", precision: 16, scale: 6, default: "0.0"
+    t.string "offendresses"
+    t.boolean "aithochrois", default: false, null: false
+    t.string "scombroideans", limit: 36
+  end
+
+  create_table "hilarities", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "undergoers", null: false
+    t.string "gazellas", limit: 36, null: false
+    t.string "superethmoidals", null: false
+    t.date "dermosclerites", null: false
+    t.date "reappeals"
+    t.datetime "intercrosses", precision: nil
+    t.datetime "tromometries", precision: nil
+  end
+
+  create_table "hivers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.date "unmodishes"
+    t.bigint "unsalines"
+    t.string "savins"
+    t.bigint "biocoenotics"
+    t.bigint "flajolotites"
+    t.bigint "fiendisms"
+    t.string "rejectives"
+    t.boolean "sinistrogyrics", default: false
+    t.datetime "pannades", precision: nil
+    t.datetime "tolerates", precision: nil
+  end
+
+  create_table "homogamies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "horninesses"
+    t.string "mechanicalizations", null: false
+    t.string "street_1"
+    t.string "street_2"
+    t.string "habitacles"
+    t.string "unnameabilities"
+    t.string "preconfirmations"
+    t.string "pilosisms"
+    t.string "subastringents"
+    t.string "chivalrouslies"
+    t.datetime "optigraphs", precision: nil
+    t.datetime "auricles", precision: nil
+    t.boolean "monosulfonics"
+    t.datetime "sackers", precision: nil
+    t.datetime "expiscatories", precision: nil
+    t.boolean "superthankfuls"
+    t.bigint "consentables"
+    t.string "pungences"
+  end
+
+  create_table "homospories", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "leistens", null: false
+    t.datetime "prickles", precision: nil, null: false
+    t.datetime "roentgenoscopics", precision: nil, null: false
+    t.datetime "synentognaths", precision: nil
+    t.text "synonymousnesses"
+    t.datetime "subradius", precision: nil
+    t.datetime "brotanies", precision: nil
+  end
+
+  create_table "hookups", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "arridges", null: false
+    t.string "courtzilites", null: false
+    t.datetime "beclarts", precision: nil, null: false
+    t.datetime "aptotics", precision: nil, null: false
+  end
+
+  create_table "horizontalizations", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "digerents", limit: 36, null: false
+    t.string "iridorhexis", null: false
+    t.string "unemployables", limit: 36, null: false
+    t.string "drepaniforms"
+    t.string "hoggies", default: "active", null: false
+    t.datetime "undownies", precision: nil
+    t.datetime "physidaes", precision: nil
+  end
+
+  create_table "hosters", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "noncrystallizables"
+    t.string "ansarians"
+    t.decimal "froggeds", precision: 16, scale: 2
+    t.datetime "responsiblenesses", precision: nil
+    t.datetime "metagnostics", precision: nil
+    t.bigint "interventionals"
+  end
+
+  create_table "houselets", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "apsychicals", null: false
+    t.string "copulativelies", null: false
+    t.string "pagurideas"
+    t.bigint "semielastics"
+    t.datetime "fragrantnesses", precision: nil
+    t.datetime "clites", precision: nil, null: false
+    t.datetime "optimistics", precision: nil
+    t.datetime "rattlebags", precision: nil
+    t.string "strongishes", null: false
+    t.string "curlilies"
+    t.string "dandydoms"
+    t.datetime "vends", precision: nil
+    t.datetime "uninnocents", precision: nil
+    t.boolean "aluminics", default: false, null: false
+    t.bigint "prescriptorials"
+  end
+
+  create_table "humanlies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "bradycardia", null: false
+    t.string "faithfullies", null: false
+    t.string "crudes"
+    t.datetime "scalpriforms", precision: nil
+    t.datetime "nomographers", precision: nil
+  end
+
+  create_table "humerals", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "downturns", null: false
+    t.bigint "autotelics", null: false
+    t.datetime "homomorphous", precision: nil
+    t.datetime "bellonas", precision: nil
+  end
+
+  create_table "humisms", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "countships", limit: 36, null: false
+    t.string "omphalos", limit: 36, null: false
+    t.string "rachianesthesia", null: false
+    t.string "whereunders", null: false
+    t.datetime "planishers", precision: nil
+    t.datetime "franklinics", precision: nil
+    t.datetime "sestians", precision: nil
+  end
+
+  create_table "hyaenidaes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "forefins", limit: 36, null: false
+    t.bigint "schwarzs", null: false
+    t.text "isoagglutinations", null: false
+    t.datetime "neoimpressionisms", precision: nil, null: false
+    t.datetime "orthodiaenes", precision: nil, null: false
+    t.string "suaviloquences"
+  end
+
+  create_table "hydraulics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "scaphoceritics"
+    t.string "underrulers"
+    t.date "gnatcatchers"
+    t.date "zunyites"
+    t.boolean "overstrews", default: false
+    t.integer "day_1"
+    t.integer "day_2"
+    t.boolean "presignifies", default: false
+    t.datetime "paleoichthyologies", precision: nil, null: false
+    t.datetime "criticisables", precision: nil, null: false
+    t.boolean "improprieties", default: false
+    t.boolean "conflateds", default: false
+    t.string "torulus"
+    t.string "banaks", limit: 36
+    t.boolean "terebenics", default: false, null: false
+    t.bigint "tarsioids"
+  end
+
+  create_table "hydroas", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "psyllas", limit: 36, null: false
+    t.string "endosteums", null: false
+    t.string "decalogists", default: "active", null: false
+    t.string "bedunces", null: false
+    t.datetime "shiftages", precision: nil
+    t.datetime "pneumoencephalitis", precision: nil
+    t.string "allylics", limit: 36, null: false
+    t.string "recluses", limit: 36
+  end
+
+  create_table "hydrobiplanes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "radiothallia"
+    t.bigint "protonephros"
+    t.bigint "malacophyllous"
+    t.decimal "aclouds", precision: 16, scale: 2
+    t.decimal "amphistylics", precision: 16, scale: 2
+    t.decimal "overgenials", precision: 16, scale: 2
+    t.decimal "hillets", precision: 16, scale: 2
+    t.datetime "steaminesses", precision: nil, null: false
+    t.datetime "crankbirds", precision: nil, null: false
+  end
+
+  create_table "hydrologies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "jocelyns"
+    t.bigint "hematorrhachis"
+    t.bigint "vacillatories"
+    t.datetime "alterns", precision: nil, null: false
+    t.datetime "oblonglies", precision: nil, null: false
+  end
+
+  create_table "hydrosulphites", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "shrubwoods", null: false
+    t.bigint "oarlocks", null: false
+    t.datetime "dashees", precision: nil, null: false
+    t.datetime "huddlers", precision: nil, null: false
+    t.date "sargos", null: false
+    t.date "ninnyishes", null: false
+    t.date "parchies", null: false
+    t.date "provocativenesses", null: false
+  end
+
+  create_table "hydrosulphurous", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.datetime "telergicallies", precision: nil, null: false
+    t.datetime "tesses", precision: nil, null: false
+    t.string "advisers", limit: 36, null: false
+    t.string "twiddlers", null: false
+    t.string "lovingnesses", limit: 36, null: false
+  end
+
+  create_table "hygienists", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "pryses", null: false
+    t.datetime "kerogens", precision: nil
+    t.datetime "orihons", precision: nil
+    t.string "persalts", null: false
+    t.boolean "dominants", default: true
+    t.boolean "expansionaries"
+    t.string "urosteons", null: false
+  end
+
+  create_table "hyperacids", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "exequies", null: false
+    t.string "accountabilities", null: false
+    t.string "hemoconcentrations", null: false
+    t.datetime "relifts", precision: nil, null: false
+    t.datetime "cacoepists", precision: nil, null: false
+  end
+
+  create_table "hyperchlorhydria", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.date "foredenounces", null: false
+    t.date "mustelidaes", null: false
+    t.string "semiresolutes", null: false
+    t.string "oecodomics", null: false
+    t.bigint "logographicals", null: false
+    t.string "creatines", null: false
+    t.datetime "grouchinglies", precision: nil
+    t.datetime "xanthochroids", precision: nil
+    t.datetime "hyposynergia", precision: nil
+    t.datetime "eatings", precision: nil
+    t.string "awaits"
+    t.text "steamilies"
+    t.string "gals", limit: 36
+  end
+
+  create_table "hypergolics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "hintinglies", limit: 36, null: false
+    t.string "automobilists"
+    t.datetime "reekies", precision: nil
+    t.datetime "pamphleteers", precision: nil
+  end
+
+  create_table "hyperhedonia", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "plumpings"
+    t.string "incumbentesses"
+    t.string "pharyngectomies"
+    t.string "sowls", limit: 2
+    t.date "panpsychics"
+    t.datetime "bepeweds", precision: nil
+    t.datetime "bestenches", precision: nil
+  end
+
+  create_table "hypokeimenometries", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "staphylions", null: false
+    t.datetime "coppernoses", precision: nil, null: false
+    t.bigint "paddywhacks", null: false
+    t.string "violations", null: false
+    t.datetime "acquirables", precision: nil, null: false
+    t.datetime "autoconductions", precision: nil, null: false
+    t.string "degrades"
+  end
+
+  create_table "hypolepticallies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "zooplanktonics", null: false
+    t.bigint "galvanocauteries"
+    t.datetime "desirefulnesses", precision: nil
+    t.datetime "azelates", precision: nil
+    t.datetime "aetomorphaes", precision: nil
+  end
+
+  create_table "hypozoas", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "greekisms", limit: 36, null: false
+    t.string "ungildeds", limit: 5
+    t.string "meconioids", limit: 200
+    t.integer "scapulectomies", default: 1
+    t.datetime "olericultures", precision: nil
+    t.datetime "sorbitols", precision: nil
+  end
+
+  create_table "hysterodynia", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "outdrinks", limit: 36, null: false
+    t.date "wronglesslies", null: false
+    t.string "proscriptions", null: false
+    t.string "unkenneleds"
+    t.string "sclerotizeds"
+    t.integer "unrecaptureds"
+    t.datetime "unreverteds", precision: nil
+    t.datetime "unelevateds", precision: nil, null: false
+    t.datetime "rasalas", precision: nil, null: false
+  end
+
+  create_table "ideophones", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "supradentals"
+    t.datetime "expects", precision: nil, null: false
+    t.datetime "vivas", precision: nil, null: false
+    t.string "desoxalates"
+    t.bigint "lymphadenia"
+  end
+
+  create_table "iguanids", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "reasseverates", limit: 36, null: false
+    t.date "demihorses", null: false
+    t.string "hamitals", null: false
+    t.string "chasselas"
+    t.decimal "pseudosolutions", precision: 16, scale: 2
+    t.datetime "outshines", precision: nil
+    t.datetime "consecraters", precision: nil
+    t.boolean "undukes", default: false
+  end
+
+  create_table "iliacs", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "squashers", null: false
+    t.bigint "arthrostomies"
+    t.datetime "albrechts", precision: nil
+    t.datetime "ruefuls", precision: nil
+    t.bigint "isoleucines", null: false
+    t.string "venallies"
+    t.string "transcriptions", limit: 36, collation: "ascii_general_ci"
+    t.bigint "andorobos"
+    t.boolean "reprobances", default: false
+    t.integer "spasmics", null: false
+  end
+
+  create_table "illiberalizes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "macrobiotus"
+    t.string "reticularians"
+    t.string "has_paid_w2", null: false
+    t.bigint "churels", null: false
+    t.datetime "scamperers", precision: nil, null: false
+    t.datetime "choanocytes", precision: nil, null: false
+    t.boolean "elasticians"
+    t.boolean "carbazines"
+    t.boolean "dives"
+    t.string "extraconscious"
+    t.date "diaphragmaticallies"
+    t.boolean "overproves"
+    t.boolean "amphitryons"
+    t.string "mesohippus"
+  end
+
+  create_table "illusives", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "gyarungs", null: false
+    t.bigint "slingstones", null: false
+    t.bigint "gastrics", null: false
+    t.bigint "phlebotomicallies"
+    t.datetime "dromicia", precision: nil, null: false
+    t.datetime "actinophones", precision: nil
+    t.datetime "scorbutizes", precision: nil
+    t.datetime "discoplacentalia", precision: nil
+  end
+
+  create_table "imbirussus", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "tricentrals", limit: 36, null: false
+    t.string "repudiations", limit: 36, null: false
+    t.text "thalamencephalons", size: :medium, null: false
+    t.integer "trimmers", default: 0, null: false
+    t.integer "ranties"
+    t.string "uniguttulates"
+    t.string "sextilis"
+    t.bigint "buchloes"
+    t.string "chaperones"
+    t.bigint "owllikes"
+    t.datetime "guises", precision: nil
+    t.bigint "broccolis"
+    t.bigint "relativals", null: false
+    t.boolean "prepayments", null: false
+    t.boolean "papolatries", null: false
+    t.string "euphonizes"
+    t.string "portrayments", null: false
+    t.string "puboischiacs"
+    t.datetime "reshapes", precision: nil
+    t.datetime "semijudicials", precision: nil
+    t.bigint "cerics"
+    t.string "despites"
+    t.string "polyporaceous"
+    t.text "derahs"
+  end
+
+  create_table "immeriteds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "subdecimals"
+    t.string "pancheons"
+    t.decimal "unreckons", precision: 16, scale: 2
+    t.date "splenectopies"
+    t.date "anophthalmos"
+    t.bigint "cervidaes"
+    t.datetime "amourettes", precision: nil
+    t.datetime "pregustics", precision: nil
+    t.bigint "redisplays"
+    t.string "monocyclics"
+    t.string "papallies"
+    t.string "juggers"
+    t.decimal "unscientifics", precision: 16, scale: 2
+    t.decimal "grenadines", precision: 16, scale: 2
+    t.bigint "synanthous"
+    t.string "sulfonics"
+    t.boolean "idrisids", default: false
+    t.string "gorgoniaceous"
+    t.text "chantings"
+    t.string "unhutcheds", limit: 36
+    t.boolean "necropolis"
+    t.bigint "vauntings"
+    t.bigint "upstems"
+    t.bigint "necropoles"
+    t.bigint "barratries"
+    t.float "rostellates", default: 0.0
+    t.bigint "equiradiates"
+    t.string "attributives"
+    t.string "diazotypes"
+    t.string "enanthematous"
+    t.text "pucks"
+    t.string "backstops", limit: 36
+  end
+
+  create_table "immortalizers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "chercocks"
+    t.integer "aegirines"
+    t.decimal "skiddinglies", precision: 16, scale: 2, default: "0.0"
+    t.decimal "gelogenics", precision: 16, scale: 2, default: "0.0"
+    t.bigint "zygomycetous"
+    t.datetime "ovidaes", precision: nil, null: false
+    t.datetime "mycetes", precision: nil, null: false
+  end
+
+  create_table "impactments", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "bedstraws"
+    t.integer "unblanketeds"
+    t.integer "pluggeds"
+    t.text "overpronenesses", size: :medium
+    t.datetime "overservices", precision: nil, null: false
+    t.datetime "preobservationals", precision: nil, null: false
+  end
+
+  create_table "impeachers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "listeners", limit: 36, null: false
+    t.string "unbrutes", null: false
+    t.datetime "yales", precision: nil
+    t.text "retents"
+    t.datetime "phragmoids", precision: nil
+    t.datetime "rehungs", precision: nil
+    t.bigint "whists"
+    t.string "furcals", null: false
+    t.bigint "domicilements", null: false
+    t.bigint "disciplinatives", null: false
+  end
+
+  create_table "imperfects", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "unauspiciouslies", null: false
+    t.string "politicious", null: false
+    t.datetime "hydropropulsions", precision: nil
+    t.datetime "succents", precision: nil
+  end
+
+  create_table "impetratories", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "outtrails", limit: 36, null: false
+    t.bigint "anangioids", null: false
+    t.string "luggeds", null: false
+    t.string "unjadeds", null: false
+    t.string "arlenes", null: false
+    t.bigint "phenologicals", null: false
+    t.datetime "deimos", precision: nil, null: false
+    t.datetime "wishinglies", precision: nil
+    t.datetime "hunterians", precision: nil
+  end
+
+  create_table "impressionistics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "rabies", null: false
+    t.string "pitchworks", null: false
+    t.string "scalenohedrons", null: false
+    t.datetime "janizarians", precision: nil
+    t.datetime "capillarities", precision: nil
+    t.boolean "snaggies", default: true, null: false
+    t.boolean "hammermen", default: false, null: false
+    t.boolean "neohexanes", default: false, null: false
+    t.boolean "earlinesses", default: false, null: false
+    t.boolean "tricksinesses", default: false, null: false
+    t.datetime "fishgarths", precision: nil
+    t.datetime "capacitativlies", precision: nil
+    t.string "dependablies", limit: 36, null: false
+  end
+
+  create_table "impressivelies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "spodomancies", null: false
+    t.integer "counterstreams", default: 2
+    t.datetime "suffumigations", precision: nil, null: false
+    t.datetime "butleresses", precision: nil, null: false
+    t.integer "gruffilies", default: 0
+    t.boolean "peckishlies", default: false
+    t.date "dipotassia"
+    t.date "syphilizations"
+    t.boolean "myotalpas", default: false
+    t.boolean "terpodions", default: false
+    t.string "preharmoniousnesses"
+    t.text "nonconnotatives"
+    t.decimal "cuppies", precision: 16, scale: 2
+  end
+
+  create_table "incompetences", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.integer "hyperbrutals", null: false
+    t.integer "rampsmen", null: false
+    t.integer "fearednesses", null: false
+  end
+
+  create_table "incompliantlies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "senilizes"
+    t.datetime "pinhooks", precision: nil
+    t.datetime "asparagus", precision: nil
+  end
+
+  create_table "incorporeallies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "extemporaneousnesses", null: false
+    t.string "overplumes"
+    t.datetime "kharuas", precision: nil
+    t.datetime "veronalisms", precision: nil
+    t.bigint "brickmakers"
+  end
+
+  create_table "incubationals", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "untractables", null: false
+    t.bigint "paratheria", null: false
+    t.datetime "ganta", precision: nil
+    t.datetime "juices", precision: nil
+    t.decimal "undepurateds", precision: 16, scale: 2
+  end
+
+  create_table "indefatigablenesses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "outbrings"
+    t.string "pes"
+    t.text "frightfullies"
+    t.integer "regulates", null: false
+    t.integer "malikalas", default: 0
+    t.datetime "polylinguists", precision: nil, null: false
+    t.datetime "beteelas", precision: nil, null: false
+  end
+
+  create_table "indigos", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "ellens", limit: 36, null: false, collation: "ascii_general_ci"
+    t.string "eucyclics", limit: 36, null: false, collation: "ascii_general_ci"
+    t.string "sodomiticallies", null: false
+    t.datetime "ants", precision: nil, null: false
+    t.datetime "responsorials", precision: nil, null: false
+    t.string "cantingnesses", null: false
+    t.string "phthorics", limit: 36
+    t.datetime "phenoxids", precision: nil
+    t.datetime "psorophoras", precision: nil
+    t.boolean "integropallials", default: false, null: false
+  end
+
+  create_table "indulgings", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "scolecologies", limit: 36, null: false
+    t.string "cecils", limit: 36, null: false
+    t.string "unconscientious", limit: 36, null: false
+    t.text "whoppings"
+    t.datetime "pacayas", precision: nil
+    t.datetime "basaltes", precision: nil
+  end
+
+  create_table "inequilobates", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.datetime "primoprimes", precision: nil
+    t.datetime "fiancees", precision: nil
+    t.string "niseis"
+    t.string "doolies"
+    t.string "adaptednesses"
+    t.string "disarmatures"
+    t.boolean "reverendlies", default: false
+    t.text "bardesanites"
+    t.text "westernisms"
+    t.text "accelerandos"
+    t.boolean "arzans"
+    t.string "orthorrhaphies"
+    t.boolean "unmannereds", default: true
+    t.string "chakars", limit: 36
+    t.bigint "successlesslies"
+  end
+
+  create_table "inexperiences", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "womanlinesses", limit: 36, null: false
+    t.bigint "form8655_id", null: false
+    t.bigint "evansites", null: false
+    t.bigint "anaglyphs", null: false
+    t.datetime "shipentines", precision: nil, null: false
+    t.datetime "esotericals", precision: nil, null: false
+  end
+
+  create_table "ingenerabilities", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.datetime "alarmings", precision: nil, null: false
+    t.datetime "circumoesophagals", precision: nil, null: false
+    t.string "sapsuckers", limit: 36, null: false
+    t.bigint "oligopolies", null: false
+    t.boolean "cornus", null: false
+    t.bigint "mixablenesses", null: false
+    t.string "herdbooks", limit: 36, null: false
+    t.boolean "slavemongers", null: false
+  end
+
+  create_table "ingluvies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "anacromyodians"
+    t.datetime "carinations", precision: nil
+    t.string "deevilicks"
+    t.datetime "forgathers", precision: nil, null: false
+    t.datetime "schopenhauereanisms", precision: nil, null: false
+    t.text "effectuates", size: :medium
+    t.bigint "inverts"
+    t.string "gourmanders"
+    t.bigint "nonazotizeds", default: 0, null: false
+  end
+
+  create_table "inguinals", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "typifiers", limit: 36, null: false
+    t.string "external401k_contribution_scheme_uuid", limit: 36, null: false
+    t.decimal "matchbooks", precision: 16, scale: 6
+    t.decimal "dyschiria", precision: 16, scale: 6
+    t.decimal "sodalists", precision: 16, scale: 6
+    t.string "reproachlessnesses"
+    t.datetime "schizolysigenous", precision: nil
+    t.datetime "osteodentinals", precision: nil
+  end
+
+  create_table "inobservances", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "windilies", null: false
+    t.datetime "vocalities", precision: nil
+    t.datetime "praemaxillas", precision: nil
+  end
+
+  create_table "insinuendos", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "amorphus", limit: 36, null: false
+    t.string "prohydrotropisms", null: false
+    t.datetime "grenelles", precision: nil
+    t.datetime "entomostracous", precision: nil
+  end
+
+  create_table "institutrixes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "germanics"
+    t.bigint "thapsia"
+    t.string "nonrejoinders"
+    t.date "determents"
+    t.string "flabellums"
+    t.string "psychotherapeutists"
+    t.string "warsels"
+    t.string "unraftereds"
+    t.string "recensions"
+    t.integer "buttockers"
+    t.decimal "synergists", precision: 16, scale: 2
+    t.string "opilionines"
+    t.datetime "cleistothecia", precision: nil
+    t.bigint "unhurtfuls"
+    t.boolean "vasofactives", default: false
+    t.datetime "koromikas", precision: nil
+    t.datetime "reamies", precision: nil
+    t.string "sheldfowls"
+    t.string "inconsequentlies"
+    t.integer "vellosines", limit: 1, default: 0, null: false
+    t.bigint "parallelepipedons"
+    t.integer "conspues", limit: 1, default: 2
+    t.bigint "nubbies"
+    t.bigint "neurodiagnoses"
+    t.string "restricts"
+  end
+
+  create_table "interactionisms", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "illaqueations"
+    t.boolean "tartarins", default: true
+    t.datetime "laminars", precision: nil
+    t.datetime "skelves", precision: nil
+  end
+
+  create_table "intercessionals", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "anurics", limit: 36, null: false
+    t.bigint "overpersuades", null: false
+    t.datetime "cholocyanines", precision: nil
+    t.datetime "nonagencies", precision: nil
+  end
+
+  create_table "interchecks", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "viritrates", null: false
+    t.bigint "philhellenisms", null: false
+    t.datetime "redigests", precision: nil
+    t.datetime "metaloscopes", precision: nil
+    t.string "counterdistinctions"
+  end
+
+  create_table "interestinglies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "unfeignablies", limit: 36, null: false
+    t.bigint "oliviles", null: false
+    t.bigint "aircraftsmen", null: false
+    t.datetime "unadoptablies", precision: nil, null: false
+    t.datetime "unacquiescents", precision: nil, null: false
+  end
+
+  create_table "interfibrous", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.date "phanatrons"
+    t.boolean "purposefulnesses"
+    t.datetime "regalia", precision: nil, null: false
+    t.datetime "fostells", precision: nil, null: false
+    t.text "swisses", size: :medium
+    t.text "parasigmatismus"
+  end
+
+  create_table "interhemals", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "gatherings", null: false
+    t.string "scavengeries", limit: 36, null: false
+    t.date "twelvefolds", null: false
+    t.date "meles"
+    t.datetime "poppers", precision: nil, null: false
+    t.datetime "befoolments", precision: nil, null: false
+    t.string "pseudolamellibranchiates"
+    t.string "sphecinas"
+    t.string "proproctors"
+    t.string "atmospherefuls"
+    t.bigint "creaghs"
+  end
+
+  create_table "interlacements", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "hypergoddesses", null: false
+    t.text "clinographs", null: false
+    t.datetime "fibromatoses", precision: nil, null: false
+    t.bigint "winterhains", null: false
+    t.string "insouls", null: false
+    t.string "bombsights", null: false
+    t.integer "musophagas", null: false
+    t.datetime "protoirons", precision: nil, null: false
+    t.datetime "lurals", precision: nil, null: false
+    t.datetime "elisabeths", precision: nil, null: false
+    t.string "shortcomers", null: false
+  end
+
+  create_table "intermeasurables", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "limations", null: false
+    t.boolean "undeludables", null: false
+    t.string "debonnaires"
+    t.datetime "geckotids", precision: nil
+    t.datetime "aerostations", precision: nil
+    t.string "subpeduncles", limit: 36, null: false
+    t.boolean "metrics"
+    t.date "saturns"
+    t.string "intertuberculars"
+    t.string "sucurius"
+    t.string "tytonidaes"
+    t.string "forestals"
+    t.bigint "kinetogenetics"
+  end
+
+  create_table "interpetiolaries", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "meandrines", null: false
+    t.date "bareheadeds", null: false
+    t.datetime "shaggilies", precision: nil, null: false
+    t.datetime "filariforms", precision: nil, null: false
+  end
+
+  create_table "interweavings", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "moucharabies", limit: 36, null: false
+    t.string "programmatics", limit: 36, null: false
+    t.datetime "polliniferous", precision: nil, null: false
+    t.datetime "endotheliocytes", precision: nil, null: false
+    t.string "postsphenoidals", null: false
+    t.string "parlandos", null: false
+    t.string "cotos", null: false
+    t.boolean "definiens", null: false
+    t.boolean "zooxanthellas", null: false
+  end
+
+  create_table "intromittents", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "bedbugs", null: false
+    t.boolean "arthurianas", default: false
+    t.string "invitingnesses"
+    t.string "cosheaths"
+    t.integer "erudits"
+    t.string "unvintageds"
+    t.boolean "amorphotaes", default: false
+    t.integer "magnificences"
+    t.boolean "enchantingnesses"
+    t.boolean "surmarks", default: false
+    t.boolean "scraggleds", default: true
+    t.boolean "demicannons", default: false
+    t.boolean "uniquenesses", default: false
+    t.boolean "morays", default: false
+    t.integer "calicos", null: false
+    t.boolean "inviolates", default: false
+    t.integer "irregularities", default: 0
+    t.boolean "canfuls", default: false, null: false
+    t.boolean "unperturbeds", default: false, null: false
+    t.datetime "suspectibles", precision: nil
+    t.datetime "perchlorics", precision: nil
+    t.string "bitterlings"
+    t.date "ratepayers"
+  end
+
+  create_table "intrusionisms", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "impersonalities", null: false
+    t.bigint "entoptoscopics", null: false
+    t.datetime "amidoxies", precision: nil
+    t.datetime "langles", precision: nil
+  end
+
+  create_table "invocables", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "volans", limit: 36, null: false, collation: "ascii_general_ci"
+    t.bigint "leadproofs"
+    t.bigint "horsemongers", null: false
+    t.bigint "distributables", null: false
+    t.string "elkwoods", null: false
+    t.datetime "imaginablenesses", precision: nil
+    t.datetime "gumptious", precision: nil
+    t.datetime "microtherms", precision: nil
+    t.datetime "extraclassrooms", precision: nil
+    t.datetime "noninductivelies", precision: nil
+    t.text "bioecologists"
+  end
+
+  create_table "ipomoeas", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "cambricleafs"
+    t.string "browbounds"
+    t.datetime "unemotioneds", precision: nil, null: false
+    t.datetime "settlings", precision: nil, null: false
+    t.boolean "mucics", default: true
+    t.integer "hanches"
+    t.boolean "handwears", default: false
+    t.string "ungeldeds"
+    t.integer "megadonts"
+    t.bigint "bracinglies"
+    t.bigint "pietes"
+    t.text "inomyositis"
+    t.string "noncontentions", limit: 36, null: false
+  end
+
+  create_table "iras", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "egosyntonics", null: false
+    t.string "musklikes", null: false
+    t.string "egotheisms"
+    t.string "manslaughterers"
+    t.string "quinquenerveds"
+    t.datetime "electrofusions", precision: nil
+    t.datetime "eustaces", precision: nil
+    t.string "floriculturals", limit: 36, null: false
+  end
+
+  create_table "iridials", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "sainfoins", null: false
+    t.integer "underthings", null: false
+    t.text "spinachlikes", null: false
+    t.bigint "racialities"
+    t.integer "spinozists"
+    t.text "numerablies"
+    t.bigint "bismuthines"
+    t.datetime "zebralikes", precision: nil
+    t.datetime "stomachfullies", precision: nil, null: false
+    t.datetime "silicoaluminates", precision: nil, null: false
+  end
+
+  create_table "iris", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "phanerocephalous", null: false
+    t.bigint "perceptivenesses", null: false
+    t.datetime "pleuralgia", precision: nil
+    t.datetime "ecardinals", precision: nil
+  end
+
+  create_table "irradiancies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "phalangidas", null: false
+    t.string "consiliaries", null: false
+    t.bigint "uninucleateds", null: false
+    t.datetime "herringers", precision: nil, null: false
+    t.datetime "singeinglies", precision: nil, null: false
+  end
+
+  create_table "irreversibilities", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "sourcakes", null: false
+    t.boolean "uppricks", null: false
+    t.text "historizes", null: false
+    t.datetime "tetraketones", precision: nil, null: false
+    t.datetime "corniculates", precision: nil, null: false
+  end
+
+  create_table "isopyromucics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "scalpellars", null: false
+    t.datetime "carbonnieuxes", precision: nil, null: false
+    t.datetime "astrocaryums", precision: nil, null: false
+    t.string "stashes"
+    t.string "wimes"
+    t.string "wrives"
+    t.string "pigeonwoods"
+    t.string "feignedlies"
+    t.date "vintneries"
+    t.string "anastatuses", default: ""
+    t.string "bugbanes"
+  end
+
+  create_table "isothermals", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "dums", limit: 36, null: false
+    t.string "paracelsists", limit: 36, null: false
+    t.integer "toas", default: 0
+    t.datetime "propoperies", precision: nil, null: false
+    t.datetime "unrailroadeds", precision: nil
+    t.datetime "unamenablenesses", precision: nil
+    t.datetime "shaikiyehs", precision: nil
+    t.integer "policlinics", default: 1
+    t.integer "ringbarkers"
+    t.bigint "hoarishes", null: false
+    t.decimal "microbians", precision: 16, scale: 2
+    t.integer "monteiths"
+    t.datetime "forechurches", precision: nil
+    t.string "resultlesses"
+    t.boolean "manywises"
+    t.string "allottables", limit: 36, null: false
+  end
+
+  create_table "izotes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "peppercorns", null: false
+    t.string "callorhynchidaes", null: false
+    t.datetime "extrapolations", precision: nil
+    t.datetime "yemenics", precision: nil
+  end
+
+  create_table "jacktans", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.datetime "benzophenazines", precision: nil, null: false
+    t.datetime "tutins", precision: nil, null: false
+    t.string "jauntilies", limit: 36, null: false
+    t.string "preopinions", null: false
+    t.string "prankeds", null: false
+    t.integer "allelotropisms", null: false
+    t.datetime "instinctuals", precision: nil, null: false
+    t.string "jazzinesses", limit: 36, null: false
+  end
+
+  create_table "jadestones", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "execrablenesses", null: false
+    t.string "irresistiblies", null: false
+    t.datetime "bortsches", precision: nil
+    t.datetime "shrivens", precision: nil
+    t.string "subdolents"
+  end
+
+  create_table "jadies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "fluoresceins"
+    t.bigint "mucedinaceous"
+    t.decimal "linolates", precision: 16, scale: 2, default: "0.0", null: false
+    t.decimal "fabulousnesses", precision: 16, scale: 2, default: "0.0", null: false
+    t.datetime "wieldinesses", precision: nil, null: false
+    t.datetime "superfluouslies", precision: nil, null: false
+    t.integer "applaudables"
+    t.text "ergatandromorphics"
+  end
+
+  create_table "jaegers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "animis", null: false
+    t.bigint "fishhooks", null: false
+    t.bigint "thimbleds", null: false
+    t.datetime "melicerta", precision: nil, null: false
+    t.datetime "telosynaptics", precision: nil, null: false
+  end
+
+  create_table "jagongs", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "tengeres", null: false
+    t.datetime "irradiateds", precision: nil
+    t.datetime "brimfullies", precision: nil
+  end
+
+  create_table "jamaicans", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "inguklimiuts", limit: 36, null: false
+    t.string "distortionals", null: false
+    t.string "septentrios", null: false
+    t.integer "abrahams", null: false
+    t.datetime "knobsticks", precision: nil, null: false
+    t.datetime "kascamiols", precision: nil, null: false
+    t.datetime "unwonteds", precision: nil, null: false
+    t.string "polypnoeics", null: false
+    t.string "tickles"
+    t.text "sobbers"
+  end
+
+  create_table "jantus", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "unscalablies", null: false
+    t.string "bottomlesslies"
+    t.string "inframammillaries"
+    t.datetime "whuthers", precision: nil
+    t.datetime "travelogues", precision: nil
+    t.datetime "cosentiencies", precision: nil
+    t.string "indogenides", limit: 36, null: false
+  end
+
+  create_table "japanologies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "marmatites", null: false
+    t.string "virescents"
+    t.string "mpangwes"
+    t.text "retirals"
+    t.datetime "skyrockets", precision: nil
+    t.datetime "aphydrotropisms", precision: nil
+    t.datetime "tarbets", precision: nil
+    t.string "unformulateds"
+    t.string "autostandardizations", limit: 36, null: false
+  end
+
+  create_table "japygoids", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "unmysterious", null: false
+    t.string "nonadvertences", null: false
+    t.datetime "vicarships", precision: nil, null: false
+    t.datetime "unswarmings", precision: nil, null: false
+  end
+
+  create_table "jeans", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "danielics", null: false
+    t.bigint "luridnesses", null: false
+    t.datetime "shanghais", precision: nil, null: false
+    t.datetime "albespines", precision: nil, null: false
+  end
+
+  create_table "jedcocks", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "hydrophilous", limit: 36, null: false, collation: "ascii_general_ci"
+    t.string "epicerebrals", limit: 36, null: false, collation: "ascii_general_ci"
+    t.string "spherulates", null: false
+    t.integer "hypostases", null: false
+    t.datetime "zequins", precision: nil, null: false
+    t.datetime "grittinesses", precision: nil, null: false
+  end
+
+  create_table "jeddocks", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "nototheria", limit: 36, null: false
+    t.bigint "disgustings", null: false
+    t.bigint "intermembranous", null: false
+    t.boolean "bivocalizeds", default: true
+    t.integer "rodmen"
+    t.text "lairds"
+    t.bigint "autopsychorhythmia"
+    t.datetime "tetracoccus", precision: nil, null: false
+    t.datetime "authorships", precision: nil, null: false
+  end
+
+  create_table "jeerers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "vibrions"
+    t.string "strawers", null: false
+    t.string "creasers"
+    t.string "pigmentophages"
+    t.string "indues"
+    t.bigint "duplicia"
+    t.string "spicewoods"
+    t.string "vogues"
+    t.datetime "longnesses", precision: nil
+    t.datetime "absolutistics", precision: nil
+    t.string "slepezs"
+    t.string "citraconics", limit: 36
+    t.string "nazifies", limit: 36
+    t.bigint "margarosanites"
+    t.date "coessentialities"
+    t.string "poncelets"
+    t.string "batholitics"
+    t.datetime "grainsicks", precision: nil
+    t.bigint "fanams", null: false
+  end
+
+  create_table "jinnies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "readablies", limit: 36, null: false
+    t.string "workpeople", null: false
+    t.bigint "preprohibitions", null: false
+    t.string "electroanalyses", null: false
+    t.integer "zaptiahs", null: false
+    t.bigint "straggles", null: false
+    t.string "sarcles", null: false
+    t.datetime "vulturishes", precision: nil, null: false
+    t.datetime "beata", precision: nil, null: false
+    t.bigint "cycadofilicineans", null: false
+    t.datetime "indus", precision: nil
+    t.datetime "nonreportables", precision: nil
+  end
+
+  create_table "jitneymen", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "ges", limit: 36, null: false
+    t.bigint "interlaminates", null: false
+    t.bigint "anaphylaxis", null: false
+    t.string "costanoans", null: false
+    t.datetime "ootocoids", precision: nil
+    t.datetime "overintellectuals", precision: nil
+  end
+
+  create_table "joggleworks", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "septans", limit: 36, null: false
+    t.bigint "horologicallies", null: false
+    t.decimal "bariles", precision: 16, scale: 2
+    t.decimal "coroplasts", precision: 16, scale: 2
+    t.text "dwellings"
+    t.datetime "flashlights", precision: nil
+    t.datetime "papyrians", precision: nil
+    t.string "onionets", limit: 36
+  end
+
+  create_table "jordanians", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "strepsipterans", limit: 36, null: false
+    t.bigint "polyembryonates", null: false
+    t.string "pickaways"
+    t.datetime "beloams", precision: nil
+    t.datetime "untrainedlies", precision: nil
+  end
+
+  create_table "kalandariyahs", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "plenisms", null: false
+    t.string "unflippants", null: false
+    t.datetime "chiens", precision: nil, null: false
+    t.datetime "diplopterygas", precision: nil, default: "3000-01-01 00:00:00", null: false
+    t.bigint "footmen"
+    t.string "aquamarines", limit: 36, null: false, collation: "ascii_general_ci"
+    t.string "congregationers", limit: 36
+    t.string "grayflies", limit: 36
+    t.string "polyseptates", limit: 36, null: false
+  end
+
+  create_table "katipuneros", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "underagents", null: false
+    t.bigint "circumambiences", null: false
+    t.string "neanderthals", null: false
+    t.text "notopteridaes", null: false
+    t.datetime "clippings", precision: nil
+    t.datetime "nonbilious", precision: nil
+    t.datetime "incommensuratenesses", precision: nil
+    t.string "balineses", limit: 36, null: false
+    t.string "intemperatelies", null: false
+  end
+
+  create_table "kawikas", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "larbolins", null: false
+    t.bigint "rarefications", null: false
+    t.string "unobtrudeds", null: false
+    t.string "repersuades", null: false
+    t.datetime "repegs", precision: nil, null: false
+    t.datetime "subgenuals", precision: nil
+    t.bigint "scatterers", null: false
+    t.datetime "kavasses", precision: nil
+    t.datetime "millworkers", precision: nil
+    t.datetime "paratoluidines", precision: nil
+    t.datetime "brutishlies", precision: nil
+    t.string "indrafts", limit: 36
+    t.text "horticultures"
+    t.text "tarmineds"
+  end
+
+  create_table "kentledges", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "iniquitables", limit: 36, null: false
+    t.bigint "sybotics", null: false
+    t.string "chapelgoings", null: false
+    t.bigint "yukaghirs", null: false
+    t.datetime "acrochordons", precision: nil, null: false
+    t.datetime "eurybenthics", precision: nil, null: false
+  end
+
+  create_table "keratolyses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "traceabilities", null: false
+    t.bigint "pythiads", null: false
+    t.string "cirrhotics"
+    t.datetime "globuliforms", precision: nil, null: false
+    t.datetime "crenellates", precision: nil, null: false
+    t.datetime "expalpates", precision: nil
+    t.datetime "toms", precision: nil
+  end
+
+  create_table "kidnaps", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "lernaeoides", limit: 36, null: false
+    t.datetime "unhandcuffs", precision: nil, null: false
+    t.datetime "attackers", precision: nil, null: false
+  end
+
+  create_table "kilosteres", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "scybalous"
+    t.date "smackees"
+    t.string "lundyfoots"
+    t.string "uncoguidisms"
+    t.integer "subaxillaries"
+    t.bigint "rerigs"
+    t.datetime "plauditors", precision: nil
+    t.datetime "toolmakings", precision: nil
+    t.string "unconsumeds"
+    t.string "acanthocarpous"
+    t.integer "bathycolpians"
+    t.integer "cocreates"
+    t.text "tollgates"
+    t.string "physiophilists"
+  end
+
+  create_table "kilties", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "hiddenlies", null: false
+    t.bigint "leucotics", null: false
+    t.string "arlines", null: false
+    t.bigint "triglots", null: false
+    t.datetime "aggregates", precision: nil, null: false
+    t.datetime "tetrachicals", precision: nil, null: false
+  end
+
+  create_table "kindhearteds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.boolean "concedes", default: true, null: false
+    t.integer "oarlikes"
+    t.boolean "ephebuses", default: true
+    t.decimal "syncopes", precision: 16, scale: 2
+    t.boolean "antorbitals", default: false, null: false
+    t.boolean "counterjudgings", default: false, null: false
+    t.decimal "theotechnies", precision: 16, scale: 2
+    t.datetime "glaries", precision: nil, null: false
+    t.datetime "gyppos", precision: nil, null: false
+  end
+
+  create_table "kinnikinnicks", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.date "slopings", null: false
+    t.decimal "thimblefuls", precision: 16, scale: 2
+    t.integer "traducements"
+    t.string "woodrocks", null: false
+    t.string "retoothers", limit: 36, null: false
+    t.datetime "fierasferoids", precision: nil
+    t.datetime "peritheces", precision: nil
+  end
+
+  create_table "knappers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "threptics", null: false
+    t.string "karyoschises", null: false
+    t.string "pandemonia", null: false
+    t.string "triglochins"
+    t.string "conchoids"
+    t.string "homomorphies"
+    t.integer "structuralizations"
+    t.datetime "urucus", precision: nil
+    t.datetime "unfledgeds", precision: nil, null: false
+    t.datetime "microbrachia", precision: nil, null: false
+    t.bigint "extraneities", null: false
+    t.string "soords", limit: 36, collation: "ascii_general_ci"
+    t.bigint "stusses"
+  end
+
+  create_table "knawels", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "booms"
+    t.bigint "coleslaws"
+    t.datetime "tetraonids", precision: nil
+    t.datetime "cowherds", precision: nil
+  end
+
+  create_table "kniazis", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "clarabellas"
+    t.bigint "hexametricals"
+    t.decimal "pantheonizations", precision: 16, scale: 2
+    t.date "talaria"
+    t.date "apostolicisms"
+    t.string "quipfuls"
+    t.string "secondlies"
+    t.datetime "pleuriseptates", precision: nil, null: false
+    t.datetime "macmillanites", precision: nil, null: false
+    t.bigint "guarantors"
+  end
+
+  create_table "koffs", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "otogenics", null: false
+    t.string "pairs"
+    t.string "pileds"
+    t.string "euphonisms"
+    t.datetime "bowlings", precision: nil, null: false
+    t.datetime "schizomycetes", precision: nil, null: false
+    t.integer "translays"
+    t.string "satanophanies"
+    t.boolean "immensurates", default: false
+  end
+
+  create_table "koilas", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "aglyphodonta"
+    t.bigint "fluemen"
+    t.datetime "bromochlorophenols", precision: nil
+    t.datetime "ophiuroideans", precision: nil
+    t.decimal "redivives", precision: 16, scale: 2, default: "0.0"
+    t.decimal "sarcoses", precision: 16, scale: 2, default: "0.0"
+    t.decimal "diphygenics", precision: 16, scale: 2, default: "0.0"
+    t.decimal "suburbeds", precision: 16, scale: 2, default: "0.0"
+    t.decimal "unbluffeds", precision: 16, scale: 2, default: "0.0"
+    t.decimal "alizaris", precision: 16, scale: 2, default: "0.0"
+    t.decimal "apogamouslies", precision: 16, scale: 2, default: "0.0"
+  end
+
+  create_table "konomihus", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "malacanthidaes"
+    t.string "echelonments"
+    t.bigint "deckes"
+    t.string "fluocerites"
+    t.datetime "uppishlies", precision: nil
+    t.datetime "gonococcus", precision: nil
+  end
+
+  create_table "krases", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "coifeds", null: false
+    t.date "digrediences", null: false
+    t.date "ungrotesques", null: false
+    t.datetime "disorderlies", precision: nil, null: false
+    t.datetime "praisinglies", precision: nil, default: "3000-01-01 00:00:00", null: false
+    t.bigint "autocriticisms", null: false
+    t.bigint "endorhinitis"
+  end
+
+  create_table "krugerisms", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "gonochoristics"
+    t.bigint "lightens"
+    t.bigint "romerillos"
+    t.bigint "pharmacomaniacs"
+    t.datetime "breastbands", precision: nil
+    t.datetime "cecidiologists", precision: nil
+    t.datetime "nonconnivances", precision: nil
+    t.bigint "homoanisics"
+  end
+
+  create_table "kurchines", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "godforsakens", null: false
+    t.bigint "fisheresses", null: false
+    t.date "tepidities"
+    t.datetime "tautologizes", precision: nil
+    t.datetime "oofbirds", precision: nil
+  end
+
+  create_table "kurumayas", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "luminists"
+    t.string "angiotonins"
+    t.datetime "electrocapillarities", precision: nil
+    t.datetime "polyangia", precision: nil
+  end
+
+  create_table "labbas", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "tinkers", limit: 36, null: false
+    t.string "radicicolous", null: false
+    t.datetime "pseudomasculines", precision: nil, null: false
+    t.datetime "raches", precision: nil, null: false
+  end
+
+  create_table "laborabilities", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "porrects", default: "", null: false
+    t.string "frighteners", limit: 128, default: "", null: false
+    t.string "inexposures"
+    t.datetime "leatherwoods", precision: nil
+    t.datetime "garoos", precision: nil
+    t.integer "climbings", default: 0
+    t.datetime "rhymewises", precision: nil
+    t.datetime "rebakes", precision: nil
+    t.string "amniotics"
+    t.string "hemaspectroscopes"
+    t.datetime "prereconcilements", precision: nil, null: false
+    t.datetime "cyprinodonts", precision: nil, null: false
+    t.boolean "fricatrices", default: false
+    t.integer "feracities", default: 0
+    t.string "bushlesses"
+    t.datetime "fimbriateds", precision: nil
+    t.string "antihumen"
+    t.integer "inflates", default: 0
+    t.boolean "enigmatizations", default: false
+    t.boolean "leuchemia", default: false
+    t.string "dendroecas"
+    t.boolean "retwists", default: false
+    t.string "benzofuroquinoxalines"
+    t.integer "astucious", default: 0
+    t.date "playmates"
+    t.string "trophics"
+    t.datetime "starnoses", precision: nil
+    t.datetime "theanthroposophies", precision: nil
+    t.string "budlets"
+    t.boolean "lamblings", default: false
+    t.boolean "actinologies", default: false
+    t.boolean "dasyuroids", default: false
+    t.datetime "ensulphurs", precision: nil
+    t.boolean "echiuroideas"
+    t.string "skeifs"
+    t.text "felsosphaerites", size: :medium
+    t.datetime "sabbathaists", precision: nil
+    t.string "lustrous"
+    t.string "poisonproofs"
+    t.datetime "propensenesses", precision: nil
+    t.string "synaposematics", limit: 36, null: false
+    t.datetime "befountaineds", precision: nil
+    t.string "tonguefuls"
+    t.string "intergentials"
+    t.datetime "spinninglies", precision: nil
+    t.integer "tanghans", default: 0
+    t.string "neuralists"
+    t.string "lakishnesses"
+    t.string "flambeauxes"
+    t.string "tremblingnesses"
+  end
+
+  create_table "laboulbenia", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "ureterolithiases"
+    t.decimal "laminates", precision: 16, scale: 6
+    t.datetime "dullsomes", precision: nil, null: false
+    t.datetime "gymnarchidaes", precision: nil, null: false
+    t.boolean "turcos", default: true, null: false
+    t.boolean "unauthorishes"
+    t.string "torridlies"
+    t.boolean "orangs", default: true, null: false
+    t.string "yogas", limit: 36, null: false
+  end
+
+  create_table "labyrinthulas", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "xanthochroous", limit: 36, null: false
+    t.bigint "fasciolets", null: false
+    t.string "microcoleopteras", null: false
+    t.bigint "enigmatographers", null: false
+    t.decimal "blowups", precision: 16, scale: 15, null: false
+    t.decimal "transubstantiates", precision: 16, scale: 15, null: false
+    t.text "tassets"
+    t.datetime "monometrics", precision: nil, null: false
+    t.datetime "untaughts", precision: nil, null: false
+    t.string "forfaultures", limit: 20
+  end
+
+  create_table "laceds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "antifungins", limit: 36, null: false
+    t.string "craniotomes", limit: 36, null: false
+    t.text "talipomanus", null: false
+    t.datetime "eyries", precision: nil
+    t.datetime "fielders", precision: nil
+  end
+
+  create_table "lacworks", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "scoliotics", limit: 36, null: false
+    t.string "classes", limit: 36, null: false
+    t.string "thunders", null: false
+    t.string "outheels", null: false
+    t.bigint "understrews", null: false
+    t.datetime "teaseablenesses", precision: nil
+    t.datetime "wharfsides", precision: nil
+  end
+
+  create_table "lagniappes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "medicomechanics", null: false
+    t.bigint "taiahas"
+    t.integer "boxmakings", null: false
+    t.text "unescheateds"
+    t.datetime "notungulata", precision: nil
+    t.datetime "colcothars", precision: nil
+  end
+
+  create_table "lamelloses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "semiperipheries", limit: 36, null: false
+    t.datetime "orpheonists", precision: nil, null: false
+    t.string "novatives", null: false
+    t.string "jogs", null: false
+    t.string "mogadors", null: false
+    t.bigint "biniodides", null: false
+    t.datetime "knaves", precision: nil
+    t.datetime "fractionals", precision: nil
+  end
+
+  create_table "laryngophonies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "idiosyncraticallies", limit: 36, null: false
+    t.bigint "ligniferous", null: false
+    t.string "tiens", null: false
+    t.text "unbridledlies", null: false
+    t.datetime "induratives", precision: nil, null: false
+    t.datetime "lumbaginous", precision: nil, null: false
+  end
+
+  create_table "lateralis", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "couacs", null: false
+    t.string "osteocrania"
+    t.decimal "halidoms", precision: 16, scale: 2, null: false
+    t.datetime "precornus", precision: nil
+    t.datetime "hatchgates", precision: nil
+  end
+
+  create_table "lates", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "vinyls"
+    t.string "proxyships"
+    t.bigint "unjacketeds"
+    t.string "granduncles"
+    t.bigint "termlessnesses"
+    t.bigint "rumboozes"
+    t.string "inachoids"
+    t.bigint "antrins"
+    t.string "choregus"
+    t.bigint "misclaims"
+    t.bigint "torbernites"
+    t.date "barracudas"
+    t.decimal "unpoisonous", precision: 16, scale: 2, null: false
+    t.string "tangleproofs"
+    t.boolean "negroidals"
+    t.integer "tannometers", limit: 1
+    t.datetime "liturgiologies", precision: nil
+    t.datetime "pharmacolites", precision: nil
+  end
+
+  create_table "latitants", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "orthodoxians", null: false
+    t.bigint "mainmasts", null: false
+    t.bigint "corectomes", null: false
+    t.datetime "pterygials", precision: nil
+    t.datetime "drillets", precision: nil
+  end
+
+  create_table "laudians", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "cretionaries", limit: 36, null: false
+    t.bigint "strumaticnesses", null: false
+    t.string "diagredia", limit: 36, null: false
+    t.string "nonpractices", null: false
+    t.text "unexceptionals"
+  end
+
+  create_table "lawrencites", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "bedazzlinglies", limit: 36, null: false
+    t.bigint "footwalls", null: false
+    t.bigint "tubinarines", null: false
+    t.string "bitternuts", null: false
+    t.datetime "penks", precision: nil, null: false
+    t.boolean "melicerous", null: false
+    t.string "headcaps", null: false
+    t.datetime "antescripts", precision: nil, null: false
+    t.datetime "halberdiers", precision: nil, null: false
+    t.bigint "miffs"
+  end
+
+  create_table "laxes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "cautelousnesses", null: false
+    t.string "discocarpous"
+    t.date "polyandrous"
+    t.datetime "gunzs", precision: nil
+    t.datetime "lummoxes", precision: nil
+  end
+
+  create_table "leafens", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "arkansans", limit: 36, null: false
+    t.string "convalescences", limit: 36, null: false
+    t.decimal "strunts", precision: 5, scale: 2, null: false
+    t.decimal "sleeplessnesses", precision: 5, scale: 2, null: false
+    t.datetime "hepatopexia", precision: nil, null: false
+    t.datetime "pasquinos", precision: nil, null: false
+  end
+
+  create_table "leafs", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.datetime "jewishlies", precision: nil, null: false
+    t.datetime "probationerships", precision: nil, null: false
+    t.string "desulphurizations", limit: 36, null: false
+    t.bigint "syngnathas", null: false
+    t.bigint "maioids", null: false
+    t.string "plainbacks", limit: 36, null: false
+    t.date "fleetings", null: false
+  end
+
+  create_table "leants", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "simplexeds", null: false
+    t.string "washouts", null: false
+    t.datetime "preinfects", precision: nil, null: false
+    t.datetime "odoriferouslies", precision: nil, null: false
+  end
+
+  create_table "leatherworkings", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "jagats"
+    t.bigint "sibbaldus"
+    t.bigint "gravellies"
+    t.string "streltzis"
+    t.datetime "cyrtographs", precision: nil
+    t.datetime "drumfires", precision: nil
+    t.boolean "lacelesses", default: true
+    t.decimal "mendaites", precision: 16, scale: 2, default: "0.0"
+    t.string "killers"
+    t.boolean "loxophthalmus", default: false
+    t.string "nonchalantlies", limit: 36, null: false
+    t.datetime "befavors", precision: nil
+    t.string "platformlesses"
+    t.bigint "phyllostomines"
+    t.string "wrongheadedlies"
+  end
+
+  create_table "lebistes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "extensiles", limit: 36, null: false
+    t.string "smellfuls", null: false
+    t.bigint "postotics", null: false
+    t.datetime "spelunkers", precision: nil
+    t.datetime "euphonous", precision: nil
+    t.string "hemiplegia"
+  end
+
+  create_table "leoncitos", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "requitatives", limit: 36, null: false
+    t.bigint "meropidans", null: false
+    t.integer "possessionalists"
+    t.integer "apprenticehoods"
+    t.integer "savorilies", null: false
+    t.datetime "carmeles", precision: nil, null: false
+    t.datetime "nationwides", precision: nil, null: false
+    t.string "tamandus", null: false
+  end
+
+  create_table "lepchas", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "interplantings", limit: 36, null: false
+    t.integer "diseaseds", null: false
+    t.string "unknowablenesses", limit: 36
+    t.integer "rebukables", null: false
+    t.string "overrigorous", limit: 36
+    t.string "habbes", limit: 36
+    t.datetime "retinctures", precision: nil, null: false
+    t.integer "multispireds"
+    t.string "unsystematizedlies", null: false
+    t.date "aphengescopes", null: false
+    t.boolean "collectabilities", default: false, null: false
+    t.bigint "autotelegraphs"
+    t.bigint "cornules"
+    t.bigint "warmongerings"
+    t.bigint "geophysicists"
+    t.boolean "smirkies"
+  end
+
+  create_table "lepidenes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "apples"
+    t.string "courils"
+    t.boolean "globules", default: true
+    t.datetime "barologies", precision: nil, null: false
+    t.datetime "mantistics", precision: nil, null: false
+    t.boolean "beautifiers", default: true, null: false
+    t.string "underofficials", default: "debit_date", null: false
+    t.datetime "thirteenfolds", precision: nil
+    t.datetime "impoisoners", precision: nil
+    t.string "semostomous"
+    t.datetime "geerahs", precision: nil
+    t.bigint "gimberjaweds"
+    t.boolean "practicablies", default: true, null: false
+  end
+
+  create_table "leptodermatous", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "macrophages", null: false
+    t.string "acoelomata", null: false
+    t.string "street_1"
+    t.string "street_2"
+    t.string "exgorgitations"
+    t.string "supremelies"
+    t.string "condensates"
+    t.date "seriolas"
+    t.boolean "ineradicables"
+    t.datetime "executivenesses", precision: nil, null: false
+    t.datetime "brushets", precision: nil, null: false
+    t.string "thennesses"
+  end
+
+  create_table "lesghs", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "cheliferideas", null: false
+    t.string "gunsticks"
+    t.string "polyenzymatics", null: false
+    t.text "pothuntings", null: false
+    t.string "woodroofs", null: false
+    t.date "accommodations", null: false
+    t.bigint "ceroplastics", null: false
+    t.string "prelacteals", null: false
+    t.datetime "lathesmen", precision: nil, null: false
+    t.datetime "aldoheptoses", precision: nil, null: false
+  end
+
+  create_table "leucophanites", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "hairsplitters", limit: 36, null: false, collation: "ascii_general_ci"
+    t.string "chocklers", limit: 36, null: false, collation: "ascii_general_ci"
+    t.bigint "inficetes", null: false
+    t.bigint "ringtails", null: false
+    t.datetime "wagonmakings", precision: nil
+    t.datetime "isoserines", precision: nil
+    t.text "bouges"
+    t.datetime "siameses", precision: nil
+    t.datetime "proarctics", precision: nil
+    t.datetime "obolus", precision: nil
+  end
+
+  create_table "levanas", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "slinkskins", null: false
+    t.bigint "erythrinidaes", null: false
+    t.string "prolegomenals", null: false
+    t.string "occasioners"
+    t.text "uppishes"
+    t.text "gastrointestinals"
+    t.datetime "petulantlies", precision: nil, null: false
+    t.string "alkahesticals"
+  end
+
+  create_table "liberationisms", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "clonus", null: false
+    t.string "marcescents", null: false
+    t.string "quininisms", null: false
+    t.string "mongrelisms"
+    t.datetime "fidejussors", precision: nil, null: false
+    t.datetime "castellanies", precision: nil, null: false
+    t.string "securiforms", limit: 36, null: false
+  end
+
+  create_table "liberationists", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "aggravators", null: false
+    t.string "propitials", null: false
+    t.string "raptorials", null: false
+    t.string "yurta", null: false
+    t.string "impopulars", null: false
+    t.string "denigrations"
+    t.string "saltishlies"
+    t.string "bibliopegists", limit: 36, null: false, collation: "ascii_general_ci"
+    t.datetime "soties", precision: nil
+    t.datetime "maskois", precision: nil
+  end
+
+  create_table "lieshes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "hypersensitizes", null: false
+    t.bigint "countermarks", null: false
+    t.bigint "aprickles", null: false
+    t.datetime "tweakers", precision: nil, null: false
+    t.datetime "sapors", precision: nil, null: false
+  end
+
+  create_table "lightscots", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.decimal "fivepennies", precision: 16, scale: 2, null: false
+    t.string "chloroacetics", null: false
+    t.string "weeders"
+    t.string "coidentities"
+    t.string "unnomadics"
+    t.boolean "overfreights"
+    t.boolean "wallabies"
+    t.bigint "hyperosmics", null: false
+    t.text "mediatorships"
+    t.integer "formenics"
+    t.datetime "loamlesses", precision: nil, null: false
+    t.datetime "unsuborneds", precision: nil, null: false
+    t.string "preponderations"
+  end
+
+  create_table "limners", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "counteravouches", limit: 36, null: false
+    t.string "coapprisers", limit: 36, null: false
+    t.string "unbeaueds", limit: 36, null: false
+    t.bigint "crescentades", null: false
+    t.bigint "colipyelitis"
+    t.datetime "parteds", precision: nil, null: false
+    t.string "unexpungeds", null: false
+    t.string "unaffables", null: false
+    t.datetime "buphthalmia", precision: nil, null: false
+    t.datetime "trypanosomics", precision: nil, null: false
+    t.string "tectibranchiates", null: false
+    t.bigint "cocaines"
+  end
+
+  create_table "linaceous", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.boolean "outreads", default: false
+    t.bigint "bondmanships"
+    t.datetime "unreluctants", precision: nil
+    t.datetime "counterparallels", precision: nil
+    t.boolean "serglobulins", default: false
+    t.string "hypochondriacisms"
+    t.datetime "v1_downloaded_at", precision: nil
+    t.datetime "v2_downloaded_at", precision: nil
+    t.datetime "beefinesses", precision: nil
+  end
+
+  create_table "liners", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "autophonies"
+    t.bigint "rangerships"
+    t.string "laterotemporals", null: false
+    t.datetime "saucemakings", precision: nil, null: false
+    t.datetime "nonentityisms", precision: nil, null: false
+    t.decimal "phonetics", precision: 16, scale: 2
+  end
+
+  create_table "lingberries", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "unsandeds", null: false
+    t.boolean "brotherlesses", default: false
+    t.boolean "nonfadings", default: false
+    t.datetime "echoisms", precision: nil
+    t.datetime "ogtierns", precision: nil
+  end
+
+  create_table "lingels", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "tormentedlies", null: false
+    t.string "thanelands"
+    t.string "hangkangs"
+    t.datetime "dawnlikes", precision: nil
+    t.datetime "nongalvanizeds", precision: nil
+  end
+
+  create_table "lingulellas", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "noncorrosives", null: false
+    t.bigint "necessisms", null: false
+    t.string "ailuridaes", null: false
+    t.text "talaings"
+    t.integer "williwaws", limit: 1, null: false
+    t.string "hyacinthia"
+    t.integer "wisps", limit: 1, null: false
+    t.text "daltonists", null: false
+    t.text "carpometacarpals"
+    t.datetime "entireties", precision: nil
+    t.datetime "fancies", precision: nil
+    t.datetime "connivants", precision: nil
+    t.datetime "dukes", precision: nil
+  end
+
+  create_table "linkers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "castors"
+    t.string "rottleras"
+    t.decimal "antimoniurets", precision: 16, scale: 2, default: "0.0", null: false
+    t.datetime "wherefroms", precision: nil, null: false
+    t.datetime "optophones", precision: nil, null: false
+    t.bigint "tricarpous"
+  end
+
+  create_table "linotypists", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "transcendentalisms", null: false
+    t.string "stalactics", null: false
+    t.datetime "propiolates", precision: nil, null: false
+    t.datetime "focusers", precision: nil
+    t.datetime "tetragenous", precision: nil
+  end
+
+  create_table "linoxyns", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "bathlesses", limit: 36, null: false
+    t.string "unpityinglies", limit: 36, null: false
+    t.datetime "meltednesses", precision: nil
+    t.datetime "irreclaimablenesses", precision: nil
+    t.string "newnesses", default: "not_started", null: false
+  end
+
+  create_table "lioncels", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "prohibiters", null: false
+    t.string "supersensitizations", limit: 10, null: false
+    t.datetime "milos", precision: nil, null: false
+    t.datetime "extollments", precision: nil
+    t.bigint "barandos", null: false
+    t.bigint "hydrophytics"
+  end
+
+  create_table "lipothymies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "oversells", limit: 36, null: false
+    t.datetime "undislodgeables", precision: nil
+    t.datetime "smutchies", precision: nil
+    t.string "friezies", null: false
+    t.string "hermeticals", null: false
+    t.string "divisibilities", null: false
+    t.string "debrominates"
+  end
+
+  create_table "liquidnesses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "epicedia", limit: 36, null: false
+    t.bigint "metalworkings", null: false
+    t.bigint "ungears", null: false
+    t.text "peyerians", null: false
+    t.datetime "undeservednesses", precision: nil
+    t.datetime "rebars", precision: nil
+    t.string "agnatics", null: false
+  end
+
+  create_table "lithobioids", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "chorionepitheliomas", null: false
+    t.bigint "periangiocholitis", null: false
+    t.decimal "arthrotropics", precision: 16, scale: 2, null: false
+    t.integer "loofnesses", null: false
+    t.datetime "perseverates", precision: nil, null: false
+    t.datetime "unspiables", precision: nil, null: false
+  end
+
+  create_table "litsters", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "otoblennorrheas"
+    t.date "dungeonlikes"
+    t.string "gallicisms"
+    t.boolean "mobbies", default: false
+    t.datetime "haggishnesses", precision: nil, null: false
+    t.datetime "monophyodonts", precision: nil, null: false
+    t.boolean "akpeks", default: false
+  end
+
+  create_table "loasaceaes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.date "clamorers"
+    t.decimal "olenidaes", precision: 16, scale: 2, null: false
+    t.string "cratemakings", limit: 36, null: false
+    t.string "hypernutritions"
+    t.string "rewelcomes", null: false
+    t.datetime "gregariouslies", precision: nil
+    t.datetime "uncompassions", precision: nil
+  end
+
+  create_table "lonelilies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.date "tantalizinglies", null: false
+    t.date "flinches", null: false
+    t.datetime "unsloppeds", precision: nil, null: false
+    t.boolean "podagrous", default: false, null: false
+    t.datetime "floshes", precision: nil
+    t.bigint "pancratiasts", null: false
+    t.bigint "amboineses", null: false
+    t.bigint "boxwallahs", null: false
+    t.text "papyrs"
+    t.datetime "hydatidoceles", precision: nil
+    t.string "petrographs"
+  end
+
+  create_table "longfins", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "alchemistries", limit: 36, null: false
+    t.bigint "steganopodes", null: false
+    t.string "magnesians", null: false
+    t.string "maria", null: false
+    t.string "brutings", null: false
+    t.date "dromotropics"
+    t.date "parabranchiates"
+    t.datetime "bombasticallies", precision: nil
+    t.datetime "camphors", precision: nil
+    t.date "aliptes"
+  end
+
+  create_table "lordlets", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "hydroelectrics", limit: 36, null: false
+    t.bigint "producibilities", null: false
+    t.string "floodboards", null: false
+    t.string "orphanries", null: false
+    t.datetime "sliptoppeds", precision: nil
+    t.datetime "lippies", precision: nil
+    t.datetime "collaborativelies", precision: nil
+    t.string "trabuchos"
+    t.string "yarrs"
+  end
+
+  create_table "lorens", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.datetime "unbasteds", precision: nil, null: false
+    t.bigint "orthogenics", null: false
+    t.datetime "tendinousnesses", precision: nil
+    t.datetime "thiefproofs", precision: nil
+  end
+
+  create_table "lores", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.date "wardages"
+    t.date "dithecals"
+    t.string "derationalizes"
+    t.string "omnimodes"
+    t.integer "antilopes"
+    t.bigint "isohels"
+    t.datetime "myrmecophytics", precision: nil, null: false
+    t.datetime "acquittals", precision: nil, null: false
+  end
+
+  create_table "losts", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "wildsomes", limit: 36, null: false
+    t.bigint "beproses", null: false
+    t.string "antimarks"
+    t.string "kommos"
+    t.date "ammoniates"
+    t.datetime "pseudocotyledonals", precision: nil, null: false
+    t.datetime "bohunks", precision: nil, null: false
+    t.string "subintellections", null: false
+  end
+
+  create_table "loyalties", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "unpleasurablies", limit: 36, null: false
+    t.bigint "brachistocephalis", null: false
+    t.bigint "purposivenesses", null: false
+    t.string "subconformables", limit: 100, null: false
+    t.datetime "wailakis", precision: nil, null: false
+    t.datetime "peculiarisms", precision: nil, null: false
+  end
+
+  create_table "lucumonies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "yokematings", null: false
+    t.string "paganizers", null: false
+    t.string "despotisms", null: false
+    t.datetime "copperings", precision: nil, null: false
+    t.datetime "emulsors", precision: nil, null: false
+    t.string "aquarters"
+    t.string "britannia"
+    t.string "sympiesometers"
+    t.string "metalbumins"
+    t.bigint "disgradations"
+  end
+
+  create_table "ludicrous", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "ossifications", limit: 36, null: false
+    t.integer "counterpalies", null: false
+    t.text "synergisticallies"
+    t.string "monostelics", null: false
+    t.bigint "xanthophanes", null: false
+    t.bigint "extranaturals", null: false
+    t.datetime "actions", precision: nil
+    t.datetime "gios", precision: nil
+    t.bigint "andantinos"
+    t.string "velocipedals", limit: 36, null: false
+  end
+
+  create_table "luminiferous", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "binnogues", null: false
+    t.string "physicologics", null: false
+    t.string "monticles", null: false
+    t.string "nicotians", limit: 36, null: false, collation: "ascii_general_ci"
+    t.datetime "antitoxics", precision: nil
+    t.datetime "capparidaceaes", precision: nil
+  end
+
+  create_table "lusiads", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "sectionallies"
+    t.string "bovista"
+    t.text "protragicals"
+    t.datetime "quickbeams", precision: nil, null: false
+    t.datetime "averts", precision: nil, null: false
+  end
+
+  create_table "lutemakers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "pitlesses", null: false
+    t.string "adighes", null: false
+    t.string "agastrics", null: false
+    t.datetime "tonnas", precision: nil
+    t.datetime "imperceivablies", precision: nil
+    t.datetime "sheikhlikes", precision: nil
+    t.boolean "tabifics", default: false, null: false
+    t.boolean "cerebrotonia", default: false, null: false
+    t.boolean "dangles", default: false, null: false
+  end
+
+  create_table "mactras", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "shoresides", limit: 36, null: false
+    t.bigint "tappas", null: false
+    t.decimal "inrings", precision: 16, scale: 2, null: false
+    t.integer "kiwikiwis", null: false
+    t.integer "physeterinaes", null: false
+    t.integer "watalas", null: false
+    t.datetime "bardesanisms", precision: nil
+    t.datetime "eunicids", precision: nil
+  end
+
+  create_table "madarotics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "imperceptibles", limit: 36, null: false
+    t.bigint "happenings", null: false
+    t.bigint "sternebras", null: false
+    t.datetime "rebeccaisms", precision: nil, null: false
+    t.datetime "vulpicidals", precision: nil, null: false
+    t.date "peaklesses", null: false
+    t.string "ectosteallies", limit: 20, null: false
+  end
+
+  create_table "madecases", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "ruberythrics", limit: 36, null: false, collation: "ascii_general_ci"
+    t.string "lactifuges", limit: 36, null: false, collation: "ascii_general_ci"
+    t.string "predefences", null: false
+    t.datetime "characterizations", precision: nil, null: false
+    t.datetime "faros", precision: nil, null: false
+  end
+
+  create_table "malplaceds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "pitiabilities"
+    t.bigint "strengites"
+    t.string "countervolitions"
+    t.datetime "orchiectomies", precision: nil
+    t.datetime "discrepants", precision: nil, null: false
+    t.datetime "unprayeds", precision: nil, null: false
+    t.string "norards"
+  end
+
+  create_table "manganostibiites", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "bareneckeds", null: false
+    t.date "spontoons", null: false
+    t.bigint "pitikins", null: false
+    t.datetime "henads", precision: nil, null: false
+    t.datetime "preinherits", precision: nil, null: false
+  end
+
+  create_table "manifestationals", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "fructivorous", limit: 36, null: false
+    t.bigint "recruitees", null: false
+    t.bigint "coronadites", null: false
+    t.datetime "pentatriacontanes", precision: nil, null: false
+    t.datetime "maeandrines", precision: nil, null: false
+    t.date "thunderbearings"
+    t.date "longheadedlies", null: false
+  end
+
+  create_table "mannequins", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "foraneens", null: false
+    t.string "neurosarcomas", null: false
+    t.string "subherds"
+    t.string "chieftaincies"
+    t.bigint "screwers", null: false
+    t.boolean "zimmes", default: false
+    t.datetime "ailings", precision: nil, null: false
+    t.datetime "fatherlesses", precision: nil, null: false
+  end
+
+  create_table "manostatics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "visages", null: false
+    t.bigint "tricresols", null: false
+    t.string "names", null: false
+    t.string "holdsmen"
+    t.decimal "hemipareses", precision: 16, scale: 2, null: false
+    t.datetime "fluxiblies", precision: nil, null: false
+    t.datetime "sneests", precision: nil, null: false
+  end
+
+  create_table "mantleds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "pedotrophics"
+    t.decimal "surplices", precision: 16, scale: 2
+    t.boolean "hemolyses"
+    t.datetime "cresoxies", precision: nil, null: false
+    t.datetime "underproductions", precision: nil, null: false
+    t.string "antonomasticallies", limit: 36, null: false
+  end
+
+  create_table "marijuanas", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "deedlesses"
+    t.bigint "holometabolous"
+    t.string "previdences"
+    t.string "aroses"
+    t.datetime "poeticules", precision: nil
+    t.datetime "clathroses", precision: nil
+    t.decimal "preconsecrates", precision: 16, scale: 2
+    t.decimal "shrubbishes", precision: 16, scale: 2
+    t.string "kakas"
+    t.bigint "regurs"
+    t.string "actinons"
+  end
+
+  create_table "mastaxes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "bepales"
+    t.string "anisotropies"
+    t.string "plicatopapilloses"
+    t.string "panniereds"
+    t.bigint "smoothbacks"
+    t.bigint "kittenships"
+    t.string "moorishnesses"
+    t.text "prefecundations"
+    t.datetime "draws", precision: nil, null: false
+    t.datetime "sacalaits", precision: nil, null: false
+    t.boolean "conclusives"
+    t.decimal "undancings", precision: 16, scale: 2, default: "0.0"
+    t.string "osteosarcomas"
+    t.bigint "besmirchments"
+    t.text "cripplers"
+    t.boolean "ichthyornithiformes"
+    t.boolean "stagirites"
+    t.boolean "guanas"
+    t.boolean "extrusions", default: true
+    t.datetime "simuliids", precision: nil
+    t.bigint "epiphyses"
+    t.string "splotchilies"
+    t.string "aduncateds"
+    t.string "awiwis"
+  end
+
+  create_table "masteds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "orthodoxalities", null: false
+    t.datetime "tarairis", precision: nil, null: false
+    t.datetime "yachtswomen", precision: nil
+    t.datetime "malabars", precision: nil
+  end
+
+  create_table "masteries", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "dasypaedals", limit: 36, null: false, collation: "ascii_general_ci"
+    t.string "curviforms", limit: 36, null: false, collation: "ascii_general_ci"
+    t.string "hummockies", limit: 36, collation: "ascii_general_ci"
+    t.boolean "xanthics", default: true, null: false
+    t.boolean "argonauts", default: false, null: false
+    t.datetime "semimutes", precision: nil
+    t.bigint "anamorphotes"
+  end
+
+  create_table "mataderos", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "witwalls", null: false
+    t.datetime "projectionists", precision: nil
+    t.datetime "tubiforms", precision: nil
+    t.datetime "epidiorites", precision: nil
+    t.datetime "zealotisms", precision: nil
+    t.bigint "organozincs", null: false
+  end
+
+  create_table "matchings", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "unregretfulnesses", limit: 36, null: false
+    t.string "makes", limit: 36, null: false
+    t.datetime "quandaries", precision: nil, null: false
+    t.datetime "quininas", precision: nil, null: false
+    t.string "deuteroscopies"
+    t.boolean "overlives"
+    t.bigint "shakes"
+  end
+
+  create_table "materialisticallies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "degentilizes", null: false
+    t.string "fitchews", null: false
+    t.string "kintyres", null: false
+    t.string "stethoscopes", null: false
+    t.string "resistances"
+    t.datetime "cogwheels", precision: nil, null: false
+    t.datetime "laughablies", precision: nil, null: false
+  end
+
+  create_table "materializers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "mundanenesses"
+    t.bigint "guardianesses"
+    t.bigint "reflectometries"
+    t.string "rhodinols"
+    t.date "nonsilicateds"
+    t.date "oxalites"
+    t.string "weberians"
+    t.string "autorrhaphies"
+    t.string "cystitis"
+    t.string "ballams"
+    t.datetime "gelds", precision: nil
+    t.datetime "moonshinies", precision: nil
+    t.string "unvalidateds"
+    t.bigint "cardioscopes"
+    t.integer "quadrupedisms", limit: 1
+    t.integer "purports", limit: 1
+  end
+
+  create_table "matutinaries", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "professionlesses", null: false
+    t.integer "neuropteris", null: false
+    t.text "ethanethiols", null: false
+    t.datetime "botcherlies", precision: nil, null: false
+    t.datetime "babylikes", precision: nil
+    t.text "gesneras", null: false
+    t.bigint "analytics", null: false
+    t.bigint "pickedlies", null: false
+    t.string "aleurodes"
+    t.bigint "polydynamics"
+    t.boolean "semivolcanics", default: false, null: false
+    t.boolean "remedials", default: false, null: false
+  end
+
+  create_table "maximizers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "astragalus", null: false
+    t.bigint "counterspyings"
+    t.datetime "jesseans", precision: nil
+    t.datetime "alcyonarians", precision: nil
+  end
+
+  create_table "mbalolos", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "eligiblenesses", null: false
+    t.string "pharynges", limit: 36, null: false
+    t.bigint "chorials", null: false
+    t.string "thoracomelus", limit: 50
+    t.string "maliciousnesses", limit: 50
+    t.bigint "boltmakers"
+    t.string "levorotatories", limit: 50
+    t.datetime "darnings", precision: nil, null: false
+    t.datetime "odiouslies", precision: nil, null: false
+  end
+
+  create_table "mboris", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "chroatols", null: false
+    t.text "phantomships"
+    t.datetime "porencephalons", precision: nil, null: false
+    t.datetime "endoceratites", precision: nil, null: false
+    t.boolean "summerishes", default: true, null: false
+    t.string "dragsawings", limit: 36
+  end
+
+  create_table "meaks", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.datetime "revolubilities", precision: nil, null: false
+    t.datetime "tripelikes", precision: nil, null: false
+    t.string "sclerotitis", limit: 36, null: false
+    t.bigint "cucullas", null: false
+    t.string "moreovers", limit: 2, null: false
+    t.decimal "fitfullies", precision: 16, scale: 6
+    t.decimal "irishwomen", precision: 16, scale: 6
+  end
+
+  create_table "mechanicointellectuals", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "laminoses", null: false
+    t.string "akhrots", null: false
+    t.boolean "wefts", default: false, null: false
+    t.datetime "radiophonies", precision: nil
+    t.datetime "daimonions", precision: nil
+    t.integer "canaliferous"
+    t.integer "ornithophilies"
+    t.datetime "erythrines", precision: nil
+    t.datetime "subjectdoms", precision: nil
+    t.string "labelers"
+    t.string "scenarizes", limit: 36, null: false
+  end
+
+  create_table "mecodonta", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "deckers", limit: 36, null: false
+    t.string "irruptivelies", null: false
+    t.integer "prestigiators", null: false
+    t.integer "subphylars", null: false
+    t.boolean "underns", default: false, null: false
+    t.string "cognaticals", limit: 36, null: false
+    t.string "alvites", limit: 36, null: false
+    t.date "agriculturals", null: false
+    t.date "nonalcoholics"
+    t.datetime "coachables", precision: nil, null: false
+    t.datetime "cunnilingus", precision: nil
+    t.datetime "immembers", precision: nil, null: false
+    t.datetime "bespreads", precision: nil, null: false
+    t.integer "rearrivals"
+    t.integer "prejustifications", default: 0, null: false
+    t.string "foelikes", limit: 36
+  end
+
+  create_table "medisects", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "nialls", limit: 36, null: false
+    t.string "suffixions", null: false
+    t.string "demitubes", null: false
+    t.string "erythrogeneses", null: false
+    t.string "hydrographics", null: false
+    t.integer "gaves"
+    t.string "ungues"
+    t.bigint "saintlesses", null: false
+    t.datetime "boastfulnesses", precision: nil
+    t.datetime "apicads", precision: nil
+  end
+
+  create_table "melliferas", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "fluozirconics"
+    t.bigint "vaporishes"
+    t.string "marshlands"
+    t.decimal "macrozamia", precision: 16, scale: 2
+    t.datetime "scelalgia", precision: nil
+    t.datetime "craticulars", precision: nil
+    t.bigint "emissives"
+  end
+
+  create_table "melocotons", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "unpertinentlies", null: false
+    t.bigint "physcomitria", null: false
+    t.datetime "sternoclaviculars", precision: nil
+    t.datetime "awafts", precision: nil
+  end
+
+  create_table "melursus", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "bromoketones"
+    t.string "ballyhoos"
+    t.string "overpressures"
+    t.integer "vantbrasses"
+    t.datetime "blosmies", precision: nil
+    t.datetime "tuliplikes", precision: nil
+    t.datetime "unattackables", precision: nil
+  end
+
+  create_table "men", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "gascoignies", null: false
+    t.string "homotaxiallies", null: false
+    t.string "charcas"
+    t.datetime "wrastlers", precision: nil, null: false
+    t.datetime "ratskellers", precision: nil, null: false
+    t.boolean "implants", default: false
+    t.text "suppressivelies", size: :medium
+    t.string "limmocks"
+    t.string "subbasals"
+    t.string "gyracanthus", limit: 36, null: false
+  end
+
+  create_table "meningomalacia", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "bisons", null: false
+    t.bigint "ramaites", null: false
+    t.bigint "immounds"
+    t.text "spoffles"
+    t.text "densimetrics"
+    t.text "anisylidenes"
+    t.datetime "prunaceaes", precision: nil, null: false
+    t.datetime "vomiters", precision: nil, null: false
+  end
+
+  create_table "mensals", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "snarlies", limit: 36
+    t.bigint "aggrieves", null: false
+    t.bigint "whipstaffs", null: false
+    t.bigint "aconitics", null: false
+    t.decimal "lapilliforms", precision: 16, scale: 2
+    t.datetime "petaurista", precision: nil
+    t.datetime "sirs", precision: nil
+  end
+
+  create_table "mergences", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "spaids", null: false
+    t.bigint "rubricates", null: false
+    t.decimal "pushfulnesses", precision: 16, scale: 6, null: false
+    t.decimal "prosperous", precision: 16, scale: 6, null: false
+    t.datetime "platillas", precision: nil
+    t.datetime "swarmers", precision: nil
+    t.boolean "kootchas", default: true
+    t.string "despairings", null: false
+  end
+
+  create_table "mesepithelia", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "varnishments", null: false
+    t.text "shorters"
+    t.datetime "cycloses", precision: nil, null: false
+    t.datetime "subpermanents", precision: nil, null: false
+  end
+
+  create_table "mesothetics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.datetime "puntlatshes", precision: nil, null: false
+    t.datetime "frats", precision: nil, null: false
+    t.bigint "protochlorides", null: false
+    t.date "infanglements"
+    t.decimal "uncreditablies", precision: 16, scale: 2
+    t.string "precisionizes"
+    t.boolean "calcifugals"
+    t.string "nippilies"
+    t.text "insinuatinglies"
+    t.boolean "programmatists"
+    t.datetime "louisines", precision: nil
+  end
+
+  create_table "metachromases", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "playerdoms", limit: 36, null: false
+    t.bigint "melolonthides", null: false
+    t.boolean "chrysotiles", default: false, null: false
+    t.datetime "sauropods", precision: nil
+    t.datetime "unibivalents", precision: nil
+    t.boolean "upwrings", default: false, null: false
+    t.date "internarials"
+    t.date "cockleboats"
+  end
+
+  create_table "metallides", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "actipyleas"
+    t.integer "askews"
+    t.text "subcompanies"
+    t.text "microanalysts"
+    t.decimal "tracklesslies", precision: 16, scale: 2
+    t.datetime "psederas", precision: nil, null: false
+    t.datetime "tetrasalicylides", precision: nil, null: false
+  end
+
+  create_table "metaplasmics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "demoids", null: false
+    t.bigint "klystrons", null: false
+    t.string "parasuchia", null: false
+    t.string "engagings"
+    t.datetime "sovietdoms", precision: nil, null: false
+    t.datetime "denumerations", precision: nil, null: false
+    t.string "lymphorrhages", limit: 36, null: false
+  end
+
+  create_table "meteorograms", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "horripilants", limit: 36, null: false
+    t.string "allochetites"
+    t.string "interacademics"
+    t.string "aphodians"
+    t.string "shapelesses"
+    t.datetime "apteryxes", precision: nil, null: false
+    t.datetime "previctorious", precision: nil, null: false
+    t.string "schindyleses", limit: 36, null: false
+    t.datetime "rodsmen", precision: nil
+    t.datetime "clunisians", precision: nil
+    t.string "schoolgirlies"
+    t.bigint "timoreses", null: false
+    t.bigint "analogics", null: false
+    t.date "houndfishes"
+  end
+
+  create_table "microcitrus", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "fliomas", limit: 36, null: false
+    t.bigint "sulphonations", null: false
+    t.bigint "harrisites", null: false
+    t.datetime "swartzia", precision: nil, null: false
+    t.datetime "baures", precision: nil, null: false
+  end
+
+  create_table "microscleres", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "dinkas", limit: 36, null: false
+    t.string "scoups", limit: 36
+    t.string "countergirdeds"
+    t.text "bisiliacs"
+    t.integer "auxiliars"
+    t.datetime "cephas", precision: nil
+    t.datetime "expulsives", precision: nil
+    t.integer "grieceds", default: 1
+  end
+
+  create_table "microtinaes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "cretifies"
+    t.bigint "furaldehydes", null: false
+    t.bigint "heterofertilizations"
+    t.bigint "untemptabilities"
+    t.string "ceratobatrachinaes"
+    t.string "lapstones"
+    t.boolean "fusionals"
+    t.datetime "pseudosacreds", precision: nil, null: false
+    t.datetime "untappables", precision: nil, null: false
+    t.string "unstrappeds"
+    t.datetime "logris", precision: nil
+    t.bigint "mesvinians"
+    t.boolean "predeceases", default: false
+    t.bigint "weenongs"
+    t.string "accrues"
+    t.bigint "dezincifications"
+    t.boolean "waddies"
+    t.date "hedgesmiths"
+    t.string "normalcies", default: "false"
+    t.boolean "longavilles"
+    t.string "uniolas"
+    t.integer "sarts", default: 0
+    t.integer "chunters", limit: 1
+    t.bigint "rebelliousnesses"
+    t.string "tantaleans"
+    t.bigint "probals"
+    t.bigint "edgewises"
+    t.string "unkindhearteds", limit: 36, null: false
+    t.bigint "meroplanktonics"
+    t.bigint "scapelesses"
+  end
+
+  create_table "micrurgies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "kenmarks", limit: 36, null: false
+    t.string "stilbenes", null: false
+    t.datetime "orationers", precision: nil, null: false
+    t.datetime "reposers", precision: nil, null: false
+  end
+
+  create_table "middleways", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "intramatricals", limit: 36, null: false
+    t.bigint "gastrosteges", null: false
+    t.bigint "liveds", null: false
+    t.bigint "moonshines", null: false
+    t.bigint "uropygia", null: false
+    t.integer "tardives", limit: 1, null: false
+    t.string "karshunis", null: false
+    t.datetime "plashies", precision: nil, null: false
+    t.datetime "heterandries", precision: nil, null: false
+  end
+
+  create_table "mileways", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "duridines"
+    t.bigint "spillproofs"
+    t.datetime "septemfoliolates", precision: nil
+    t.datetime "tachymetries", precision: nil
+  end
+
+  create_table "milkfishes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "prebendates", null: false
+    t.datetime "understimulus", precision: nil
+    t.datetime "craterids", precision: nil
+    t.bigint "psychoclinics"
+  end
+
+  create_table "mimidaes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "hemelytrons", null: false
+    t.decimal "bleacherites", precision: 16, scale: 6
+    t.datetime "osteochondrofibromas", precision: nil
+    t.datetime "unmoldies", precision: nil
+  end
+
+  create_table "minders", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "dogshores", null: false
+    t.string "metamerous", null: false
+    t.string "pseudoperiodics"
+    t.string "frigolabiles"
+    t.string "entomophthorous"
+    t.string "triosteums"
+    t.string "asporous"
+    t.string "misinclinations"
+    t.string "ophelimities"
+    t.string "carbonous"
+    t.datetime "unanimatedlies", precision: nil
+    t.datetime "ashrafis", precision: nil
+  end
+
+  create_table "mintakas", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "trichomas", null: false
+    t.string "footgangers"
+    t.string "toddicks"
+    t.float "cacoxenites"
+    t.float "vilas"
+    t.datetime "unreturnablies", precision: nil
+    t.integer "stylohyoideans", default: 0
+    t.datetime "managerships", precision: nil
+    t.datetime "preapplications", precision: nil
+  end
+
+  create_table "miraclemongers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "calamiforms", null: false
+    t.decimal "asystolics", precision: 16, scale: 2, default: "0.0", null: false
+    t.decimal "ommiads", precision: 16, scale: 2, default: "0.0", null: false
+    t.date "aerobatics"
+    t.datetime "nasals", precision: nil
+    t.datetime "dechemicalizes", precision: nil
+  end
+
+  create_table "misanthropizes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "carbamines", limit: 36, null: false
+    t.string "unneedfuls"
+    t.bigint "petitors", null: false
+    t.datetime "indicatives", precision: nil
+    t.datetime "unoccludeds", precision: nil
+    t.string "psychrophores"
+    t.text "counterfallers"
+    t.integer "concubinaries"
+  end
+
+  create_table "misbegets", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "unobservants"
+    t.string "pediculoids", null: false
+    t.string "tetrabranches", null: false
+    t.datetime "queaches", precision: nil
+    t.datetime "unmonopolizes", precision: nil
+    t.string "mendelevia", limit: 36, null: false
+    t.datetime "buckhounds", precision: nil
+    t.string "inductoria", default: "paid_in_full", null: false
+  end
+
+  create_table "miscomprehends", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "rugmakings", limit: 36, null: false
+    t.string "anthemies", limit: 36, null: false
+    t.string "begrains", null: false
+    t.datetime "italicizations", precision: nil, null: false
+    t.datetime "acraldehydes", precision: nil
+    t.bigint "sprittails", null: false
+    t.bigint "aphis"
+    t.datetime "dorsiventrals", precision: nil
+    t.datetime "oxbloods", precision: nil
+    t.boolean "misorganizations", default: true, null: false
+    t.bigint "motherships"
+    t.bigint "brushies"
+  end
+
+  create_table "miscuts", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.date "whensos"
+    t.datetime "thalamotegmentals", precision: nil, null: false
+    t.datetime "glistens", precision: nil, null: false
+    t.string "tabefactions"
+    t.text "pneoscopes", size: :medium
+    t.string "bostrychoids"
+  end
+
+  create_table "mislabors", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "ethanediols", null: false
+    t.bigint "inspirationists", null: false
+    t.datetime "atticals", precision: nil, null: false
+    t.datetime "pyrosulphates", precision: nil, null: false
+    t.string "matreeds"
+    t.bigint "fluoridates"
+    t.bigint "grudgings"
+    t.bigint "unluffeds"
+    t.bigint "bacteriophagous"
+  end
+
+  create_table "mistfuls", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "samsonics", null: false
+    t.string "perspirabilities", null: false
+    t.datetime "unattesteds", precision: nil, null: false
+    t.datetime "pedunculations", precision: nil, null: false
+  end
+
+  create_table "mitsumata", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.decimal "saccharinelies", precision: 16, scale: 2, null: false
+    t.string "estampederos", null: false
+    t.string "beneficiary_line_1"
+    t.string "beneficiary_line_2"
+    t.string "anaunters"
+    t.string "trammings"
+    t.string "brunelliaceaes"
+    t.string "aeolidaes"
+    t.string "lactonizes", null: false
+    t.string "bank_line_1"
+    t.string "bank_line_2"
+    t.string "lavationals", null: false
+    t.string "kernos", null: false
+    t.string "concilia", null: false
+    t.string "birdlets", null: false
+    t.string "mylohyoideans"
+    t.string "bookrests"
+    t.string "erysibes", null: false
+    t.bigint "origins"
+    t.datetime "setaria", precision: nil
+    t.datetime "noneditorials", precision: nil
+    t.bigint "pileiforms"
+    t.string "trophoplasts", null: false
+  end
+
+  create_table "modernisms", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.datetime "sclerokeratitis", precision: nil
+    t.datetime "victoriouslies", precision: nil
+  end
+
+  create_table "modificationists", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "fitouts", limit: 36, null: false
+    t.string "witties", null: false
+    t.string "aphidids"
+    t.bigint "comparativelies"
+    t.datetime "dartmoors", precision: nil, null: false
+    t.datetime "paraheliotropics", precision: nil, null: false
+  end
+
+  create_table "monilioids", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "forgrows", limit: 36, null: false
+    t.string "stealers", null: false
+    t.string "amahs", null: false
+    t.string "unrulablenesses", null: false
+    t.string "unsulphureous", null: false
+    t.bigint "gonions", null: false
+    t.datetime "clerks", precision: nil
+    t.datetime "stenogs", precision: nil
+  end
+
+  create_table "monobasicities", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "haughtonites", limit: 36, null: false
+    t.bigint "hollies", null: false
+    t.date "millerisms", null: false
+    t.boolean "anthogenetics", null: false
+    t.datetime "arundinaceous", precision: nil, null: false
+    t.datetime "undesirablies", precision: nil, null: false
+  end
+
+  create_table "monophthalmics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "repeateds", null: false
+    t.bigint "likelinesses", null: false
+    t.datetime "glideworts", precision: nil
+    t.datetime "cephalhematomas", precision: nil
+  end
+
+  create_table "monopolizes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "tottlishes"
+    t.string "agnoses", null: false
+    t.string "devotionallies", null: false
+    t.boolean "hanoverianizes", default: false
+    t.boolean "digeneous", default: true
+    t.datetime "preconfesses", precision: nil, null: false
+    t.datetime "symptoses", precision: nil, null: false
+    t.boolean "sightworthies", default: true
+    t.string "strophics", limit: 36, null: false
+    t.string "nondisjuncts", null: false
+    t.boolean "embracinglies"
+  end
+
+  create_table "monotremata", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "tutballs", limit: 36, null: false
+    t.bigint "aceraceous", null: false
+    t.bigint "breys", null: false
+    t.datetime "symbolisticals", precision: nil, null: false
+    t.datetime "coadores", precision: nil, null: false
+  end
+
+  create_table "monumentlesses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "unsatanics", limit: 36, null: false
+    t.bigint "diallages", null: false
+    t.datetime "artillerists", precision: nil
+    t.datetime "dissipatedlies", precision: nil
+  end
+
+  create_table "morosenesses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "meninginas"
+    t.bigint "congers"
+    t.string "distastefuls"
+    t.text "iodobehenates", null: false
+    t.integer "irredentials", limit: 1, default: 0, null: false
+    t.datetime "agomphious", precision: nil
+    t.datetime "roamings", precision: nil
+    t.integer "graminaceaes", limit: 1, default: 0, null: false
+    t.string "privilegers"
+    t.bigint "discophores"
+    t.string "unracks"
+  end
+
+  create_table "morulas", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.boolean "anaglyptics"
+    t.integer "xylenols"
+    t.bigint "substantivallies"
+    t.datetime "fans", precision: nil
+    t.datetime "bradyphrenia", precision: nil
+  end
+
+  create_table "motivelesses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "oilpapers", limit: 36, null: false
+    t.bigint "tenaktaks", null: false
+    t.bigint "cantonalisms", null: false
+    t.bigint "peccantnesses", null: false
+    t.integer "atta", null: false
+    t.date "proliquors", null: false
+    t.datetime "superblesseds", precision: nil
+    t.datetime "annameses", precision: nil
+  end
+
+  create_table "muckweeds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "sinupallials", limit: 36, null: false
+    t.bigint "reconductions", null: false
+    t.bigint "cervus", null: false
+    t.string "redistrainers", null: false
+    t.datetime "ampelites", precision: nil, null: false
+    t.datetime "hifalutins", precision: nil, null: false
+  end
+
+  create_table "mulctations", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "affiants", limit: 36, null: false
+    t.string "martyrizations", limit: 36, null: false
+    t.boolean "mussalchees", default: false, null: false
+    t.datetime "meridionaceaes", precision: nil
+    t.datetime "pharmacics", precision: nil
+    t.string "subbailiwicks", limit: 36
+  end
+
+  create_table "multilamellous", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.boolean "ceratitoids", default: false, null: false
+    t.boolean "constablewicks", default: false, null: false
+    t.bigint "ambulances", null: false
+    t.datetime "duennaships", precision: nil
+    t.datetime "macroscians", precision: nil
+    t.boolean "elwoods", default: false, null: false
+  end
+
+  create_table "mungies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "flaunters"
+    t.string "nephrolysins"
+    t.integer "presettles"
+    t.integer "intermarginals"
+    t.integer "raceabouts"
+    t.integer "circumnuclears"
+    t.string "landways"
+    t.text "idealisticals"
+    t.datetime "catholicals", precision: nil
+    t.datetime "knobbers", precision: nil
+  end
+
+  create_table "mushlas", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "harvestmen", limit: 36, null: false
+    t.bigint "lymphangiectases", null: false
+    t.bigint "erechtheums", null: false
+    t.bigint "capeds", null: false
+    t.bigint "unspelts"
+    t.datetime "interpages", precision: nil
+    t.datetime "outcourts", precision: nil, null: false
+    t.datetime "ricinus", precision: nil, null: false
+  end
+
+  create_table "mutches", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "donators", limit: 36, null: false
+    t.bigint "benders", null: false
+    t.string "clees"
+    t.decimal "poundlesses", precision: 16, scale: 2
+    t.string "earls"
+    t.string "sampans"
+    t.datetime "unreneweds", precision: nil
+    t.datetime "fossilologists", precision: nil
+    t.boolean "kilans"
+    t.string "noncompoundables"
+    t.boolean "correctednesses"
+    t.bigint "monergisms"
+    t.string "pennyroyals"
+    t.string "clots"
+    t.boolean "peridentoclasia"
+    t.string "japaconines"
+    t.string "stephanomes"
+    t.string "overexpresses"
+    t.string "momotus"
+    t.string "fifteenfolds"
+    t.boolean "i9_document", default: false
+  end
+
+  create_table "myoendocarditis", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "forepreparations", null: false
+    t.string "choukas", null: false
+    t.datetime "treatylesses", precision: nil
+    t.datetime "itineracies", precision: nil
+    t.string "iwis", null: false
+    t.string "brachistocephalous"
+    t.string "sharons"
+    t.string "tupeks"
+    t.boolean "vasoconstrictives"
+  end
+
+  create_table "myomantics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.datetime "atheologicallies", precision: nil, null: false
+    t.datetime "romances", precision: nil, null: false
+    t.bigint "slavisms", null: false
+    t.string "wastebaskets", null: false
+  end
+
+  create_table "myrrhs", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "lectorships", null: false
+    t.string "trochiferous", null: false
+    t.integer "sylvicolidaes", null: false
+    t.integer "phenmiazines", null: false
+    t.datetime "reloves", precision: nil
+    t.bigint "comparers"
+    t.decimal "campanulous", precision: 16, scale: 2
+    t.datetime "tiribas", precision: nil
+    t.datetime "rutherfordites", precision: nil
+    t.string "blashes"
+    t.boolean "epalpates"
+    t.bigint "pyrotechnists"
+    t.string "fibromyositis", null: false
+  end
+
+  create_table "naams", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "epigynums", null: false
+    t.datetime "governs", precision: nil
+    t.datetime "titres", precision: nil
+    t.datetime "mussables", precision: nil
+    t.datetime "hadjemis", precision: nil
+    t.string "alcheras"
+    t.string "overasserts", limit: 36, null: false
+  end
+
+  create_table "naillesses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "exponentiallies", null: false
+    t.decimal "diverticles", precision: 16, scale: 2
+    t.decimal "mohrodendrons", precision: 16, scale: 2
+    t.datetime "maimers", precision: nil, null: false
+    t.datetime "crasslies", precision: nil, null: false
+    t.bigint "epepophysials"
+    t.string "perityphlics"
+    t.integer "rheumatoidals"
+    t.decimal "bubblies", precision: 16, scale: 2
+  end
+
+  create_table "nainsels", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.text "raspatories", null: false
+    t.text "onegites", null: false
+    t.text "warmths", null: false
+    t.decimal "butchers", precision: 16, scale: 2, null: false
+    t.decimal "duplas", precision: 16, scale: 2, null: false
+    t.integer "bafflinglies", null: false
+    t.integer "cutchers", null: false
+    t.bigint "tapiocas", null: false
+    t.bigint "unappreciativelies", null: false
+    t.datetime "chronophotographies", precision: nil
+    t.datetime "onomatoplasms", precision: nil
+  end
+
+  create_table "narcotisms", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "semiprones", null: false
+    t.bigint "distributers", null: false
+    t.decimal "recogitates", precision: 16, scale: 2, null: false
+    t.datetime "pselaphidaes", precision: nil
+    t.datetime "uncriminals", precision: nil
+  end
+
+  create_table "nasioalveolars", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "rhipiphoridaes", null: false
+    t.string "cystospastics", null: false
+    t.string "chickasaws", null: false
+    t.string "salients", null: false
+    t.string "irreportables"
+    t.datetime "pogonata", precision: nil, null: false
+    t.datetime "chilkats", precision: nil, null: false
+    t.boolean "appendicocaecostomies"
+  end
+
+  create_table "nasturtions", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "barghests"
+    t.string "nonlicenseds"
+    t.bigint "gallanilides"
+    t.string "duplicitas"
+    t.string "acis"
+    t.datetime "gynecics", precision: nil
+    t.datetime "ilicaceous", precision: nil
+    t.string "rhamnohexoses"
+    t.string "unthievishes"
+    t.string "weichselwoods"
+    t.bigint "chargees"
+    t.bigint "staphyloraphics"
+  end
+
+  create_table "naturists", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "listerelloses", null: false
+    t.text "gretchens", null: false
+    t.integer "neoplasia", null: false
+    t.integer "effusiometers", null: false
+    t.integer "reliers", null: false
+    t.integer "maytenus", null: false
+    t.integer "scalenous", null: false
+    t.datetime "lags", precision: nil, null: false
+    t.datetime "pancreatoids", precision: nil, null: false
+  end
+
+  create_table "negotiators", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "silicospongiaes", null: false
+    t.date "electrodialyzers", null: false
+    t.datetime "qualityships", precision: nil, null: false
+    t.datetime "dissepimentals", precision: nil, null: false
+  end
+
+  create_table "nemerteas", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "amchoors", limit: 36, null: false
+    t.string "unsifteds", null: false
+    t.string "outcastings"
+    t.string "awokes"
+    t.datetime "eccoproticophorics", precision: nil
+    t.datetime "rechanges", precision: nil
+    t.datetime "spoutlesses", precision: nil
+    t.datetime "ringsters", precision: nil
+    t.string "microprints", null: false
+    t.string "tepidaria", null: false
+    t.bigint "milleporites", null: false
+    t.bigint "cassideous"
+    t.boolean "corinthianizes", default: false, null: false
+    t.datetime "offerors", precision: nil
+    t.datetime "sicsacs", precision: nil
+    t.string "pneumohemothoraxes", limit: 4
+    t.text "subdeaneries"
+    t.boolean "bolshevikians", default: false
+    t.boolean "suspensefuls"
+    t.boolean "pikeys"
+    t.boolean "covings", default: false
+    t.boolean "cyanidins", default: false
+    t.boolean "flytiers", default: false
+    t.string "desklikes"
+  end
+
+  create_table "nemertineans", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.datetime "biseriates", precision: nil, null: false
+    t.string "alvearia", null: false
+    t.string "ferrotypes", null: false
+    t.datetime "diplasiasmus", precision: nil
+    t.datetime "tigrinas", precision: nil
+    t.string "glossographers", null: false
+  end
+
+  create_table "neofetals", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "tractites", null: false
+    t.string "unhangeds", null: false
+    t.string "planxties", null: false
+    t.datetime "ceylons", precision: nil, null: false
+    t.bigint "buttonholders", null: false
+    t.datetime "salpingorrhaphies", precision: nil, null: false
+    t.datetime "diacetamides", precision: nil, null: false
+    t.string "antiphylloxerics", null: false
+  end
+
+  create_table "nephrostomas", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "verminers"
+    t.string "jackshays"
+    t.datetime "slews", precision: nil
+    t.datetime "presentals", precision: nil
+    t.bigint "podagricals"
+  end
+
+  create_table "neurocentrums", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.datetime "unmetricalnesses", precision: nil, null: false
+    t.datetime "antiantienzymes", precision: nil, null: false
+    t.bigint "spireds", null: false
+    t.string "exhaustibles", limit: 36, null: false
+  end
+
+  create_table "nidulations", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.datetime "overventilations", precision: nil
+    t.bigint "choloidinics", null: false
+    t.string "overguns"
+    t.datetime "emeses", precision: nil
+    t.datetime "fassalites", precision: nil
+  end
+
+  create_table "nightwards", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "galvanisms", null: false
+    t.string "lutations", null: false
+    t.string "woodwardships", null: false
+    t.date "crepons", null: false
+    t.bigint "problockades", null: false
+  end
+
+  create_table "nitridizations", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "acephalia", limit: 36, null: false
+    t.bigint "pelmatozoans", null: false
+    t.string "bestowings", null: false
+    t.datetime "moorburns", precision: nil
+    t.datetime "unsensiblenesses", precision: nil
+    t.boolean "pupillaries", default: false, null: false
+  end
+
+  create_table "nitrosomonas", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "uncompacts"
+    t.bigint "canies"
+    t.datetime "dorms", precision: nil
+    t.datetime "rectovesicals", precision: nil
+    t.datetime "noncontributories", precision: nil
+    t.string "jennies"
+    t.datetime "sanes", precision: nil
+    t.string "overgilteds"
+    t.string "bahs"
+    t.bigint "idolatrous"
+    t.integer "ectogeneses", limit: 1
+    t.string "defends"
+    t.date "cors"
+    t.string "intercirculates"
+    t.string "jobades"
+    t.string "deaneries"
+    t.string "unsomes"
+    t.string "vassos"
+    t.string "easefulnesses"
+    t.string "kroushkas"
+    t.string "flauntinesses"
+    t.string "units"
+    t.string "amphitenes"
+  end
+
+  create_table "noctuaes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "elutions"
+    t.bigint "nobilifies"
+    t.string "prodromals"
+    t.boolean "uncoherents", default: false
+    t.datetime "serridentinus", precision: nil
+    t.datetime "phasemeters", precision: nil
+    t.string "interwars", default: "pending"
+  end
+
+  create_table "nonaspersions", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "buttresslikes"
+    t.string "pantheians"
+    t.string "businesses"
+    t.decimal "polichinelles", precision: 16, scale: 2, default: "0.0"
+    t.datetime "boilersmiths", precision: nil, null: false
+    t.datetime "vicegerals", precision: nil, null: false
+    t.bigint "unprejudices"
+    t.datetime "reedlikes", precision: nil
+    t.boolean "supercharges"
+    t.decimal "vigilantes", precision: 16, scale: 2
+  end
+
+  create_table "nonexportables", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "insensibilizations"
+    t.bigint "precipitates"
+    t.date "lieds"
+    t.string "sadducisms"
+    t.integer "churchianities"
+    t.decimal "trabants", precision: 16, scale: 2
+    t.decimal "supergratifications", precision: 16, scale: 2, default: "0.0"
+    t.decimal "cankerberries", precision: 16, scale: 2, default: "0.0"
+    t.decimal "ramanas", precision: 16, scale: 2, default: "0.0"
+    t.decimal "embryologists", precision: 16, scale: 2, default: "0.0"
+    t.decimal "untellings", precision: 16, scale: 2, default: "0.0"
+    t.decimal "vergencies", precision: 16, scale: 2, default: "0.0"
+    t.decimal "aerographics", precision: 16, scale: 2, default: "0.0"
+    t.date "collieds"
+    t.string "unacceptablenesses"
+    t.bigint "trypsinogens"
+    t.text "heterologicallies"
+    t.text "outriggerlesses"
+    t.text "polydimensionals"
+    t.datetime "tripaleolates", precision: nil
+    t.datetime "unconfidences", precision: nil
+    t.date "intracarpals"
+    t.string "adjutants"
+    t.string "sonneratiaceaes"
+    t.string "evaluatives", limit: 36
+  end
+
+  create_table "nongerminations", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "unlaws", null: false
+    t.string "unconjoineds", null: false
+    t.text "mosasauris"
+    t.datetime "jacobaeas", precision: nil
+    t.datetime "hemicatalepsies", precision: nil
+  end
+
+  create_table "noninterchangeabilities", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "cuesta", limit: 36, null: false
+    t.string "suicidisms", null: false
+    t.boolean "equivocations", null: false
+    t.datetime "wheelworks", precision: nil
+    t.datetime "favorables", precision: nil
+  end
+
+  create_table "nonoxygenous", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.integer "earscrews", default: 0
+    t.string "pseudographs"
+    t.bigint "malaccas"
+    t.datetime "leuchaemia", precision: nil
+    t.datetime "weismannisms", precision: nil
+  end
+
+  create_table "nonsensitizeds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "monosulphonics", null: false
+    t.string "schizaeas"
+    t.string "mituas"
+    t.bigint "tankas"
+    t.datetime "verdurousnesses", precision: nil
+    t.datetime "anacoenoses", precision: nil
+  end
+
+  create_table "nonseptates", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "phasianinaes", limit: 36, null: false
+    t.bigint "mislears", null: false
+    t.bigint "ortygians", null: false
+    t.date "atactics"
+    t.date "uveitis"
+    t.datetime "mantispas", precision: nil
+    t.datetime "lithographicallies", precision: nil
+  end
+
+  create_table "nonsuctorials", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "daguerreotypies"
+    t.integer "prepossessions"
+    t.decimal "antihygienics", precision: 16, scale: 2
+    t.string "comprehensivenesses"
+    t.string "blubberies"
+    t.date "mills"
+    t.datetime "factuallies", precision: nil
+    t.datetime "hekteus", precision: nil
+    t.string "lepidophyllums", limit: 36, null: false
+  end
+
+  create_table "nontrigonometricals", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "corsites", limit: 36, null: false
+    t.bigint "crackers", null: false
+    t.boolean "rhodanates"
+    t.datetime "cholelithotomies", precision: nil
+    t.datetime "foremisgivings", precision: nil
+    t.bigint "tarragons"
+    t.bigint "panades"
+    t.datetime "uncassocks", precision: nil
+    t.float "mushaas", default: 0.0, null: false
+    t.float "gnomonia", default: 0.0, null: false
+  end
+
+  create_table "nonunanimous", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "anchoretishes", limit: 36, null: false
+    t.bigint "donets", null: false
+    t.string "carbohydrates", null: false
+    t.string "retinoids", null: false
+    t.datetime "malkins", precision: nil, null: false
+    t.datetime "improficiences", precision: nil, null: false
+    t.integer "porterships"
+    t.string "intestinenesses"
+    t.string "topiarians", default: "0.0.1"
+  end
+
+  create_table "nonzoologicals", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "astomia"
+    t.string "pudus"
+    t.string "twichildren"
+    t.string "repleads"
+    t.date "reaggregates"
+    t.date "henbills"
+    t.datetime "barways", precision: nil
+    t.datetime "flunkyites", precision: nil
+    t.bigint "splenomedullaries", null: false
+    t.bigint "stagnates", null: false
+    t.bigint "temporals", null: false
+  end
+
+  create_table "nopes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "pyrenocarps"
+    t.string "writerships"
+    t.string "casses"
+    t.datetime "governmentalizes", precision: nil
+    t.datetime "rinneites", precision: nil
+  end
+
+  create_table "notariates", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "selenologicals", null: false
+    t.string "clubsters"
+    t.boolean "branchiurous", default: false, null: false
+    t.integer "reprovisions"
+    t.datetime "salferns", precision: nil, null: false
+    t.datetime "overslights", precision: nil, null: false
+  end
+
+  create_table "novalia", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "costicartilages", limit: 36, null: false
+    t.string "unburlesqueds", null: false
+    t.string "abruptlies", null: false
+    t.datetime "orthogrades", precision: nil
+    t.datetime "oxers", precision: nil
+  end
+
+  create_table "nuchas", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "silverbeaters", null: false
+    t.string "proems", null: false
+    t.bigint "operancies", null: false
+    t.integer "disobliges", null: false
+    t.datetime "autolaryngoscopies", precision: nil
+    t.datetime "harlings", precision: nil
+  end
+
+  create_table "numskulleds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "topazolites", limit: 36, null: false
+    t.bigint "warlesslies", null: false
+    t.bigint "staphyleas", null: false
+    t.string "exanimations", null: false
+    t.string "rhagionids", null: false
+    t.boolean "cymbocephalous", null: false
+    t.datetime "sandmen", precision: nil, null: false
+    t.datetime "woundworts", precision: nil, null: false
+  end
+
+  create_table "obliterables", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.boolean "pistonlikes", default: false, null: false
+    t.boolean "lecyths", default: false, null: false
+    t.boolean "stends", default: false, null: false
+    t.boolean "aphanipteras", default: false, null: false
+    t.boolean "warpeds", default: false, null: false
+    t.boolean "organogenists", default: false, null: false
+    t.bigint "springlets", null: false
+    t.datetime "apargia", precision: nil
+    t.datetime "felonesses", precision: nil
+    t.boolean "manucodia", default: false, null: false
+  end
+
+  create_table "obols", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.datetime "phanerics", precision: nil
+    t.string "hepatologists"
+    t.text "hydroscopics", size: :medium
+    t.bigint "unpeaces"
+    t.string "hockdays"
+    t.datetime "doketisms", precision: nil
+    t.datetime "flimflams", precision: nil
+  end
+
+  create_table "ocreaceous", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "collapses", limit: 36, null: false, collation: "ascii_general_ci"
+    t.string "unpolarizables", limit: 36, null: false, collation: "ascii_general_ci"
+    t.datetime "eminencies", precision: nil, null: false
+    t.datetime "solanaceaes", precision: nil
+    t.datetime "supermannishes", precision: nil
+    t.datetime "learnerships", precision: nil
+  end
+
+  create_table "octodontidaes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "undominicals", limit: 36, null: false
+    t.bigint "huterians", null: false
+    t.integer "globosphaerites", null: false
+    t.datetime "vivisects", precision: nil, null: false
+    t.datetime "benedictives", precision: nil, null: false
+    t.datetime "scuppernongs", precision: nil, null: false
+  end
+
+  create_table "odalmen", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "brechams", limit: 36, null: false
+    t.bigint "painties", null: false
+    t.integer "havingnesses"
+    t.boolean "transformatives", default: false
+    t.integer "bitumes"
+    t.boolean "deposables", default: false
+    t.datetime "periapts", precision: nil, null: false
+    t.datetime "exoascaceaes", precision: nil, null: false
+    t.boolean "undermaths", default: false, null: false
+    t.boolean "overinflatives", default: false
+    t.boolean "marques", default: false
+    t.bigint "biscayanisms"
+  end
+
+  create_table "odinists", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "repletivelies", null: false
+    t.string "riddlers", null: false
+    t.string "lymphocytotics", limit: 36, null: false
+    t.datetime "springes", precision: nil, null: false
+    t.datetime "apepsinia", precision: nil, null: false
+  end
+
+  create_table "odontics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "staups", limit: 36, null: false
+    t.bigint "supernaturals", null: false
+    t.bigint "peptolytics", null: false
+    t.datetime "bacteriophages", precision: nil
+    t.datetime "monopolylogues", precision: nil
+  end
+
+  create_table "offs", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.date "insensiblies", null: false
+    t.decimal "appellancies", precision: 16, scale: 2
+    t.integer "fertilizes"
+    t.string "pneumonocaces", null: false
+    t.string "scotchifies", limit: 36, null: false
+    t.string "chloroacetates", null: false
+    t.datetime "crestfallens", precision: nil
+    t.datetime "coelacanthoids", precision: nil
+  end
+
+  create_table "ogives", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "albertins", null: false
+    t.bigint "brachistochronous", null: false
+    t.string "flogmasters", null: false
+    t.boolean "curabilities", default: true, null: false
+    t.text "pliancies"
+    t.boolean "jiquis", default: false, null: false
+    t.datetime "blastoporics", precision: nil, null: false
+    t.datetime "bandors", precision: nil, null: false
+  end
+
+  create_table "oldhearteds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "subideals", null: false
+    t.string "biffins"
+    t.boolean "predicrotics", default: false, null: false
+    t.datetime "outstares", precision: nil
+    t.datetime "unidolizeds", precision: nil
+    t.datetime "ependymes", precision: nil
+    t.string "whorts"
+  end
+
+  create_table "omniregencies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "unconvincibles", limit: 36, null: false
+    t.string "bluebelleds", null: false
+    t.string "befavours", null: false
+    t.string "unhearables", null: false
+    t.bigint "contrasuggestibles", null: false
+    t.datetime "melanopathies", precision: nil, null: false
+    t.datetime "pseudoclericals", precision: nil, null: false
+  end
+
+  create_table "oniscus", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "unbenefiteds", limit: 36, null: false, collation: "ascii_general_ci"
+    t.bigint "humoresques", null: false
+    t.string "cookables", limit: 10, null: false
+    t.datetime "bawds", precision: nil, null: false
+    t.datetime "indianesques", precision: nil
+    t.bigint "anatomicopathologics"
+    t.datetime "interdicta", precision: nil
+    t.datetime "conservativelies", precision: nil
+    t.bigint "peroneocalcaneals"
+  end
+
+  create_table "oophoreoceles", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "murvas", null: false
+    t.bigint "amphicytulas", null: false
+    t.text "endotheliomyomas", null: false
+    t.datetime "ungrooveds", precision: nil, null: false
+    t.datetime "recreates", precision: nil, null: false
+    t.datetime "malichos", precision: nil
+  end
+
+  create_table "oophoromas", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "synoecioses", limit: 36, null: false
+    t.bigint "flickertails", null: false
+    t.string "unthreateneds", null: false
+    t.boolean "comfortings", null: false
+    t.boolean "drainpipes", default: false, null: false
+    t.boolean "corallics", default: false, null: false
+    t.boolean "bdelloidas", default: false, null: false
+    t.boolean "quinnats", default: false, null: false
+    t.datetime "bases", precision: nil
+    t.datetime "paromologetics", precision: nil
+    t.integer "shers", limit: 1
+    t.datetime "smaragdines", precision: nil
+    t.datetime "stephanites", precision: nil
+    t.string "antiastronomicals"
+    t.boolean "sperrylites", default: false
+  end
+
+  create_table "ophiomorphas", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "zeuxians"
+    t.datetime "tremorlesslies", precision: nil
+    t.integer "defacings"
+    t.bigint "coctoantigens"
+    t.bigint "macaques"
+    t.datetime "lovelies", precision: nil
+    t.datetime "anterointeriors", precision: nil
+  end
+
+  create_table "oratorianizes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "underbraceds", null: false
+    t.string "warrers", null: false
+    t.datetime "markdowns", precision: nil, null: false
+    t.datetime "revoices", precision: nil, default: "3000-01-01 00:00:00", null: false
+    t.bigint "superarduous", null: false
+    t.bigint "delinters"
+  end
+
+  create_table "orbiculatelies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "nonspectrals", null: false
+    t.text "slavonizes", null: false
+    t.date "decadrachmas", null: false
+    t.date "tenaillons"
+    t.string "encomics", null: false
+    t.string "sinologs", null: false
+    t.string "unsmoothnesses"
+    t.string "outworks", null: false
+    t.bigint "neris", null: false
+    t.string "vultures", limit: 36, null: false, collation: "ascii_general_ci"
+    t.datetime "effusives", precision: nil
+    t.datetime "wesseltons", precision: nil
+    t.decimal "cluthers", precision: 16, scale: 2, default: "1.0", null: false
+    t.string "christianogentilisms"
+    t.string "diatheses"
+    t.string "chromatophores"
+  end
+
+  create_table "ornithodelphia", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "sorghums", limit: 36, null: false
+    t.string "segregationals", limit: 36, null: false
+    t.datetime "delegalizes", precision: nil, null: false
+    t.bigint "unbefriends", null: false
+    t.string "vermivorous", limit: 50
+    t.string "manihots", limit: 50
+    t.datetime "sequacious", precision: nil
+    t.datetime "procrastinatings", precision: nil
+    t.datetime "dearworthinesses", precision: nil
+  end
+
+  create_table "orpines", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "wisecrackers", null: false
+    t.decimal "perenniallies", precision: 16, scale: 2, null: false
+    t.string "crossbolts", null: false
+    t.bigint "heliozoans", null: false
+    t.string "rhizocauls", null: false
+    t.datetime "underclasses", precision: nil
+    t.datetime "taintables", precision: nil
+  end
+
+  create_table "orseilles", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "ekrons", null: false
+    t.boolean "margarodids", default: false, null: false
+    t.string "palaeoniscums", null: false
+    t.text "endarchies"
+    t.datetime "ungenuinenesses", precision: nil, null: false
+    t.datetime "imputativelies", precision: nil, null: false
+  end
+
+  create_table "orthopsychiatrists", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "schoolhouses"
+    t.integer "electroreductions"
+    t.datetime "highjackers", precision: nil
+    t.datetime "hygrostatics", precision: nil, null: false
+    t.datetime "recentnesses", precision: nil, null: false
+    t.string "spraddles"
+  end
+
+  create_table "osazones", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "platymeries", null: false
+    t.text "yus", null: false
+    t.datetime "temporocentrals", precision: nil
+    t.datetime "prelumbars", precision: nil
+    t.bigint "rhizostomata"
+    t.bigint "sectiles", null: false
+  end
+
+  create_table "osnaburgs", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.date "unsheeteds", null: false
+    t.date "unapropos", null: false
+    t.date "santons", null: false
+    t.date "latrididaes", null: false
+    t.datetime "outburns", precision: nil, null: false
+    t.bigint "cardooers", null: false
+    t.bigint "bubingas", null: false
+    t.string "uralians", null: false
+    t.datetime "ricketishes", precision: nil
+    t.datetime "unalphabeticals", precision: nil
+  end
+
+  create_table "ospreys", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "conceits"
+    t.string "gymnocalycia", null: false
+    t.decimal "scunners", precision: 16, scale: 2
+    t.boolean "canines", default: true
+    t.datetime "glaucophanizations", precision: nil, null: false
+    t.datetime "undyings", precision: nil, null: false
+    t.boolean "munshis", default: true
+    t.string "steers", limit: 36
+    t.string "achaetous", limit: 36, null: false
+    t.bigint "continuers"
+  end
+
+  create_table "outbrays", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "incredulouslies", limit: 36, null: false
+    t.string "winebibberies"
+    t.string "itselves"
+    t.bigint "weaponeers"
+    t.datetime "contiguouslies", precision: nil, null: false
+    t.datetime "nephrotyphoids", precision: nil, null: false
+  end
+
+  create_table "outcurses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "hadrosaurs", null: false
+    t.datetime "garlics", precision: nil, null: false
+    t.datetime "batoideis", precision: nil
+    t.string "rowlets"
+    t.datetime "vasotomies", precision: nil
+    t.datetime "argillous", precision: nil
+  end
+
+  create_table "outlabors", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "maladaptations", null: false
+    t.string "paragglutinations", null: false
+    t.string "squinnies", null: false
+    t.text "nonrecurrents", size: :medium, null: false
+    t.text "intersticeds", size: :medium, null: false
+    t.string "bluebottles"
+  end
+
+  create_table "outshrieks", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "polliwogs"
+    t.bigint "malthas"
+    t.bigint "noninterpolations"
+    t.datetime "cardicenteses", precision: nil
+    t.datetime "bedads", precision: nil
+  end
+
+  create_table "outstarters", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "hanukkahs"
+    t.string "wontednesses", null: false
+    t.string "cryptobranchidaes", null: false
+    t.datetime "panhellenisms", precision: nil, null: false
+    t.datetime "nonpresses", precision: nil, null: false
+    t.string "julolines"
+    t.string "disqualifies"
+    t.string "haploidies"
+    t.string "technographics"
+    t.string "gaduins"
+    t.boolean "capriotes"
+    t.boolean "curvidentates"
+    t.string "grafteds"
+    t.string "hemplikes", limit: 1024
+    t.string "federatives"
+    t.string "heptads"
+    t.string "zygotics"
+    t.string "bewinters"
+    t.string "dolefullies"
+    t.boolean "allieds"
+    t.string "colorums"
+  end
+
+  create_table "ovariorrhexis", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "mesiobuccals"
+    t.bigint "nonconductions"
+    t.string "sarcosomas"
+    t.datetime "tercelets", precision: nil
+    t.datetime "fs", precision: nil
+  end
+
+  create_table "overarms", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "savoyards", null: false
+    t.bigint "waterages"
+    t.string "criminals"
+    t.string "naphthalenoids"
+    t.string "nitrobacters"
+    t.text "rinds"
+    t.datetime "carnations", precision: nil
+    t.datetime "monovalences", precision: nil
+  end
+
+  create_table "overawes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "materialisticals", limit: 36, null: false
+    t.string "strawyards", null: false
+    t.string "dournesses", null: false
+    t.string "shudderinglies", null: false
+    t.string "eleutheropetalous", null: false
+    t.datetime "coronions", precision: nil
+    t.datetime "obduratelies", precision: nil
+  end
+
+  create_table "overbakes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "encoignures"
+    t.string "colombins"
+    t.string "oversecurities"
+    t.datetime "pseudoparaplegia", precision: nil, null: false
+    t.datetime "catabatics", precision: nil, null: false
+    t.bigint "equidistances"
+    t.bigint "compossibilities"
+    t.boolean "covites", default: false
+    t.bigint "jaspis"
+    t.string "burries"
+    t.boolean "impregnates", default: true
+    t.string "consolements"
+    t.string "dronies"
+    t.datetime "kingfishes", precision: nil
+    t.string "colloquialities"
+    t.boolean "hydroxylics", default: false
+    t.boolean "whirlwinds", default: false
+    t.string "tabbers"
+    t.string "proganosauria"
+    t.string "tarantularies"
+    t.string "crablikes"
+    t.string "preadolescents", limit: 36, null: false
+  end
+
+  create_table "overbids", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "stepdames"
+    t.decimal "t1", precision: 16, scale: 2
+    t.decimal "t2", precision: 16, scale: 2
+    t.integer "shorings", default: 0
+    t.datetime "nonspirits", precision: nil, null: false
+    t.datetime "anatinaes", precision: nil, null: false
+    t.string "superfeminines"
+    t.boolean "vesicularia", default: false
+    t.datetime "betsileos", precision: nil
+    t.boolean "discreations", default: false
+    t.bigint "exodontists"
+    t.bigint "importunes"
+    t.string "gallifications", null: false
+    t.integer "lowerers"
+    t.bigint "chokeberries"
+    t.bigint "zafrees"
+    t.bigint "cayuses"
+    t.bigint "gongoresques"
+    t.boolean "rationalities", default: false, null: false
+  end
+
+  create_table "overbusies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "awans", limit: 36, null: false, collation: "ascii_general_ci"
+    t.bigint "abruptedlies", null: false
+    t.date "crowneds"
+    t.date "crucilies"
+    t.boolean "nonculminations", default: false
+    t.string "trypanolysins"
+    t.date "microphallus"
+    t.date "unlawfulnesses"
+    t.datetime "esquamates", precision: nil
+    t.boolean "cosmatis", default: true
+    t.datetime "unclosables", precision: nil
+    t.datetime "subcoastals", precision: nil
+  end
+
+  create_table "overcarelessnesses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "arilloids", null: false
+    t.date "sheepbiters", null: false
+    t.datetime "bordrooms", precision: nil
+    t.datetime "hypogenics", precision: nil
+  end
+
+  create_table "overdrawers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "farfetchednesses", limit: 36, null: false
+    t.bigint "hypsilophodonts", null: false
+    t.integer "introrsals"
+    t.integer "subcaptions"
+    t.string "exempts", null: false
+    t.string "mousies", null: false
+    t.integer "centrodes", null: false
+    t.datetime "entozoics", precision: nil, null: false
+    t.datetime "uncommiseratings", precision: nil, null: false
+    t.datetime "caraibes", precision: nil, null: false
+    t.integer "dislegitimates", default: 0, null: false
+    t.datetime "vanwards", precision: nil
+    t.datetime "subsultus", precision: nil, null: false
+  end
+
+  create_table "overflutters", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.datetime "reuplifts", precision: nil
+    t.datetime "clutterers", precision: nil
+    t.datetime "pastorages", precision: nil
+    t.string "diazoates"
+    t.string "extrasolars"
+  end
+
+  create_table "overglooms", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.decimal "unvoluntarinesses", precision: 16, scale: 2, null: false
+    t.decimal "tetracolons", precision: 16, scale: 2, null: false
+    t.decimal "parasternums", precision: 16, scale: 2, null: false
+    t.string "neuromastics", null: false
+    t.bigint "chalcophanites", null: false
+    t.datetime "mutabilia", precision: nil
+    t.datetime "scoparius", precision: nil
+  end
+
+  create_table "overgods", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.date "photoactives"
+    t.date "batophobia"
+    t.date "sterks"
+    t.string "antaios", null: false
+    t.string "ergusia", null: false
+    t.string "rictals"
+    t.string "rhemes", null: false
+    t.string "floerkeas"
+    t.string "somnambulations", limit: 36, null: false, collation: "ascii_general_ci"
+    t.bigint "quinologists", null: false
+    t.bigint "passways"
+    t.datetime "trihemimerals", precision: nil
+    t.datetime "prayerfulnesses", precision: nil
+    t.datetime "rewaters", precision: nil
+    t.datetime "figurettes", precision: nil
+    t.string "unchapleteds"
+    t.string "pleurocapsas"
+    t.bigint "shadflowers"
+    t.date "idants"
+    t.string "ratafia"
+    t.bigint "myrtus"
+    t.date "recommenders"
+    t.bigint "lowdahs", null: false
+    t.integer "duckeries", limit: 1, default: 0
+  end
+
+  create_table "overheadmen", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.datetime "areasoners", precision: nil
+    t.datetime "terakihis", precision: nil
+    t.string "antiparts", null: false
+    t.bigint "palmites", null: false
+  end
+
+  create_table "overlings", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "unrows"
+    t.bigint "rachischises"
+    t.datetime "poseurs", precision: nil
+    t.datetime "radiants", precision: nil
+  end
+
+  create_table "overpopularities", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "pyrgocephalics", limit: 36, null: false
+    t.bigint "precannings", null: false
+    t.datetime "hulsites", precision: nil, null: false
+    t.datetime "carpogams", precision: nil, null: false
+    t.bigint "ovatooblongs"
+    t.string "marcia", default: "Unknown", null: false
+  end
+
+  create_table "overripenesses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "unipotents", null: false
+    t.string "unrealizings"
+    t.string "outpickets"
+    t.bigint "geds"
+    t.datetime "overfaggeds", precision: nil
+    t.datetime "iranis", precision: nil
+    t.datetime "predicablenesses", precision: nil
+  end
+
+  create_table "oversettleds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "prestants", limit: 36, null: false
+    t.string "bailieships", limit: 36, null: false
+    t.bigint "tewits", null: false
+    t.string "countertastes", limit: 36, null: false
+    t.datetime "tetraplous", precision: nil
+    t.datetime "acinetinans", precision: nil
+    t.decimal "asuris", precision: 16, scale: 2
+  end
+
+  create_table "overshaves", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.decimal "erythritols", precision: 16, scale: 2, null: false
+    t.bigint "kyphotics", null: false
+    t.string "deifies", limit: 36, null: false
+    t.datetime "bellyfishes", precision: nil
+    t.datetime "recomprehends", precision: nil
+  end
+
+  create_table "overspreads", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "sialadenoncus", limit: 36, null: false
+    t.string "episiostenoses", null: false
+    t.string "demosthenics", null: false
+    t.boolean "triskelions", default: false, null: false
+    t.string "shacklebones", limit: 512, null: false
+    t.datetime "equisetaceaes", precision: nil
+    t.datetime "newings", precision: nil
+  end
+
+  create_table "overtenses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "ditrochees", null: false
+    t.bigint "aristotelianisms", null: false
+    t.date "seborrheics", null: false
+    t.datetime "insenses", precision: nil, null: false
+    t.datetime "tuberculomas", precision: nil, null: false
+    t.string "loofs"
+    t.string "disacknowledgements", limit: 36
+  end
+
+  create_table "overtrusts", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "gings", limit: 36, null: false
+    t.bigint "mannies", null: false
+    t.datetime "squilloids", precision: nil
+    t.integer "histogenous", null: false
+    t.integer "pangia"
+    t.string "rimmakers", null: false
+    t.string "undefensibles", null: false
+    t.integer "campylotropous", null: false
+    t.datetime "shysters", precision: nil, null: false
+    t.datetime "millionairesses", precision: nil, null: false
+    t.datetime "flatteringlies", precision: nil, null: false
+    t.integer "homoblasties", default: 0, null: false
+  end
+
+  create_table "pachytenes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "unhumanlies", null: false
+    t.bigint "hydroselenurets", null: false
+    t.bigint "cannies"
+    t.boolean "cheechakos"
+    t.datetime "piastres", precision: nil
+    t.datetime "shiftfuls", precision: nil
+    t.bigint "inspiritinglies"
+    t.string "zoophilics"
+  end
+
+  create_table "pacificists", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "micropodiformes"
+    t.datetime "cadgilies", precision: nil
+    t.datetime "superconductors", precision: nil
+  end
+
+  create_table "packlies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "infanticidals", null: false
+    t.text "thiozonides", null: false
+    t.text "nonintrospectives", null: false
+    t.string "externations"
+    t.date "coughers"
+    t.date "barricaders"
+    t.datetime "iguanidaes", precision: nil, null: false
+    t.datetime "bellieds", precision: nil, null: false
+    t.datetime "grads", precision: nil
+    t.datetime "sialogenous", precision: nil
+    t.string "chelys"
+    t.string "liferents"
+  end
+
+  create_table "pagumas", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "serenates", limit: 36, null: false
+    t.string "augurials", null: false
+    t.text "gemmiparities", null: false
+    t.text "praefectorials"
+    t.string "bloodthirstinesses", null: false
+    t.string "correctnesses"
+    t.string "gutterlings"
+    t.string "tentworts"
+    t.decimal "preobviates", precision: 16, scale: 2
+    t.date "vespertilionids"
+    t.text "consciousnesses"
+    t.datetime "mettlesomenesses", precision: nil
+    t.datetime "epopts", precision: nil
+    t.bigint "gentilizes", null: false
+  end
+
+  create_table "pakehas", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "crystallizations"
+    t.string "fibroadenomas"
+    t.bigint "geotactics"
+    t.string "weapons"
+    t.string "betweennesses"
+    t.datetime "upsets", precision: nil
+    t.datetime "mingos", precision: nil
+    t.integer "risiblenesses"
+    t.bigint "ternions"
+    t.decimal "hydrogels", precision: 16, scale: 2
+    t.string "kissabilities"
+  end
+
+  create_table "palaeethnologics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "antimatrimonialists", limit: 36, null: false, collation: "ascii_general_ci"
+    t.bigint "busybodyisms", null: false
+    t.bigint "perfusions", null: false
+    t.decimal "anglicans", precision: 16, scale: 2, default: "0.0"
+    t.decimal "this", precision: 16, scale: 2, default: "0.0"
+    t.decimal "hydracids", precision: 16, scale: 2, default: "0.0"
+    t.string "pulpectomies"
+    t.datetime "naamen", precision: nil
+    t.datetime "aneroids", precision: nil
+  end
+
+  create_table "paleoalchemicals", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "iliopubics", null: false
+    t.date "puns", null: false
+    t.decimal "rouds", precision: 16, scale: 2
+    t.boolean "gainsomes"
+    t.datetime "ovarioceles", precision: nil, null: false
+    t.datetime "conidia", precision: nil, null: false
+    t.text "ordinatelies"
+    t.string "icebreakers"
+    t.integer "pentanediones", limit: 2
+    t.text "whereons"
+    t.decimal "plagiarizers", precision: 16, scale: 2
+    t.decimal "infrabasals", precision: 16, scale: 2
+    t.boolean "hepatectomies", default: false
+    t.boolean "roomlets", default: false
+    t.integer "manslayings", default: 1, null: false
+    t.date "neronians", null: false
+    t.date "haciendas", null: false
+  end
+
+  create_table "paleodendrologists", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.integer "margaropus", null: false
+    t.string "petzites", null: false
+    t.string "seemers"
+    t.string "crowsteppeds"
+    t.boolean "felicitators", null: false
+    t.datetime "overtoes", precision: nil, null: false
+    t.datetime "peripharyngeals", precision: nil
+    t.datetime "desuperheaters", precision: nil
+    t.string "antipellagrics", limit: 36, null: false
+    t.boolean "outbridges", default: true, null: false
+  end
+
+  create_table "pallas", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "silicotungstics"
+    t.string "gujaratis"
+    t.string "hidrotics"
+    t.bigint "borophenylics"
+    t.string "induplicatives"
+    t.bigint "resalables"
+    t.date "taprooteds"
+    t.datetime "materiates", precision: nil
+    t.datetime "phallephorics", precision: nil
+    t.date "gynostegia"
+    t.date "speeches"
+    t.string "rebluffs"
+    t.bigint "trematoids"
+  end
+
+  create_table "palminerveds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "pseudoparasitics"
+    t.bigint "specklies"
+    t.boolean "rackfuls"
+    t.datetime "myas", precision: nil
+    t.datetime "appointables", precision: nil
+    t.bigint "cotises"
+    t.datetime "nonagreements", precision: nil
+    t.string "barouchets"
+  end
+
+  create_table "paniconographies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "speakings", limit: 36, null: false
+    t.bigint "undailies", null: false
+    t.string "gallirallus", null: false
+    t.string "tecons", null: false
+    t.datetime "uncriticals", precision: nil, null: false
+    t.datetime "choragia", precision: nil, null: false
+  end
+
+  create_table "panomphics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "philocubists"
+    t.text "agitprops"
+    t.bigint "paleanthropics"
+    t.datetime "bistriazoles", precision: nil
+    t.datetime "brinishnesses", precision: nil
+  end
+
+  create_table "papermouths", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "superapologies", null: false
+    t.date "cerebropontiles", null: false
+    t.date "degenerescents", null: false
+    t.datetime "streamlesses", precision: nil
+    t.datetime "chronographicals", precision: nil
+  end
+
+  create_table "parachors", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "agroans"
+    t.string "coremia"
+    t.decimal "gastrohysterotomies", precision: 16, scale: 2, default: "0.0"
+    t.boolean "pipewoods"
+    t.decimal "arapahos", precision: 16, scale: 2, default: "0.0"
+    t.decimal "coterminous", precision: 16, scale: 2, default: "0.0"
+    t.decimal "slavdoms", precision: 16, scale: 2, default: "0.0"
+    t.datetime "thores", precision: nil, null: false
+    t.datetime "fulminics", precision: nil, null: false
+  end
+
+  create_table "parachromatisms", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "hydradephagas", limit: 36, null: false, collation: "ascii_general_ci"
+    t.string "pineys", null: false
+    t.string "paratungstates", null: false
+    t.string "interradials", limit: 36, null: false, collation: "ascii_general_ci"
+    t.datetime "attainabilities", precision: nil
+    t.datetime "nates", precision: nil
+  end
+
+  create_table "parallelogrammatics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "sublettables", limit: 36, null: false
+    t.integer "consultaries", null: false
+    t.bigint "lappings"
+    t.string "stampedinglies"
+    t.bigint "termen", null: false
+    t.datetime "foreigneerings", precision: nil
+    t.datetime "wappingers", precision: nil
+  end
+
+  create_table "paramounts", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "nonvacuous", null: false
+    t.string "embronzes", null: false
+    t.bigint "rotges", null: false
+    t.bigint "dexiotropics", null: false
+    t.string "reconstitutes", null: false
+    t.datetime "osteodynia", precision: nil
+    t.datetime "scirtopodas", precision: nil
+    t.text "sawmillers"
+  end
+
+  create_table "paraphernalia", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "inappertinents", limit: 36, null: false, collation: "ascii_general_ci"
+    t.string "deciduitis", limit: 36, null: false, collation: "ascii_general_ci"
+    t.text "polymoleculars", null: false
+    t.text "conusees"
+    t.text "periodontics"
+    t.datetime "cushags", precision: nil
+    t.datetime "citterns", precision: nil
+    t.string "reboundingnesses", limit: 36, null: false
+  end
+
+  create_table "parrotlikes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "wanthills"
+    t.string "scientizes"
+    t.string "atonalities"
+    t.date "ambulatoria"
+    t.string "thomsonites"
+    t.string "bushvelds"
+    t.boolean "microseconds"
+    t.string "gangliitis"
+    t.string "tarwoods"
+    t.bigint "frabjouslies"
+    t.datetime "cochals", precision: nil, null: false
+    t.datetime "irregenerations", precision: nil, null: false
+    t.bigint "honeworts"
+    t.bigint "entothoraxes"
+    t.boolean "maxillas"
+    t.string "toyhouses", limit: 36
+    t.string "runovers"
+    t.boolean "amphitriaenes", default: false, null: false
+  end
+
+  create_table "parts", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "wordilies", limit: 36, null: false
+    t.bigint "paraxylenes", null: false
+    t.bigint "fezzans", null: false
+    t.datetime "peromedusaes", precision: nil
+    t.datetime "xinas", precision: nil
+    t.datetime "lynchers", precision: nil
+    t.datetime "mesonyxes", precision: nil
+  end
+
+  create_table "patricians", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "criticists", null: false
+    t.text "prelegendaries"
+    t.text "cerithiidaes"
+    t.datetime "chiders", precision: nil
+    t.datetime "raploches", precision: nil
+    t.datetime "inusitates", precision: nil
+    t.datetime "resnatches", precision: nil
+    t.string "stichidia", limit: 36, null: false
+  end
+
+  create_table "patristics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "toys"
+    t.bigint "enorganics"
+    t.decimal "coplaintiffs", precision: 16, scale: 2, default: "0.0"
+    t.string "torosities"
+    t.decimal "predivorcements", precision: 16, scale: 2, default: "0.0"
+    t.datetime "xenocrysts", precision: nil, null: false
+    t.datetime "rhabdocoelas", precision: nil, null: false
+    t.decimal "blastemals", precision: 16, scale: 2, default: "0.0"
+    t.decimal "dioramas", precision: 16, scale: 2, default: "0.0"
+    t.decimal "singeings", precision: 16, scale: 2, default: "0.0"
+    t.decimal "beamfuls", precision: 16, scale: 2, default: "0.0"
+    t.decimal "moneywises", precision: 16, scale: 2, default: "0.0"
+    t.decimal "barodynamics", precision: 16, scale: 2, default: "0.0"
+    t.decimal "radiations", precision: 16, scale: 2, default: "0.0"
+    t.boolean "elizas", default: false
+    t.boolean "porterhouses", default: false
+    t.decimal "smartings", precision: 16, scale: 2, default: "0.0"
+    t.boolean "mordellas", default: false
+    t.string "rillettes"
+    t.string "deglutinations"
+    t.text "hemignathous"
+    t.text "ectals"
+    t.decimal "antiaircrafts", precision: 16, scale: 2, default: "0.0"
+    t.text "drivelinglies"
+    t.boolean "laconicallies", default: false
+    t.boolean "downliers", default: false
+    t.string "beknights", null: false
+    t.decimal "nonrelinquishments", precision: 16, scale: 2, default: "0.0"
+    t.text "cuprics"
+    t.bigint "paralogicals"
+    t.boolean "pringles"
+    t.string "mistutors"
+    t.bigint "perognathus"
+    t.string "pitmakings", limit: 36, null: false
+  end
+
+  create_table "pedestrianizes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.datetime "fermentativelies", precision: nil
+    t.boolean "myxomycetes"
+    t.text "vasostimulants"
+    t.datetime "turneraceaes", precision: nil
+    t.datetime "atomicities", precision: nil
+  end
+
+  create_table "peekaboos", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "hemadromographs", limit: 36, null: false
+    t.bigint "astroscopus", null: false
+    t.string "podsolics"
+    t.datetime "marshalships", precision: nil
+    t.datetime "tinglings", precision: nil
+  end
+
+  create_table "pegaseans", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "represses", limit: 36, null: false
+    t.bigint "roncaglians", null: false
+    t.bigint "electrophoridaes", null: false
+    t.datetime "recordedlies", precision: nil, null: false
+    t.datetime "subordains", precision: nil, null: false
+  end
+
+  create_table "pelviforms", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "turntables", limit: 36, null: false
+    t.bigint "medians", null: false
+    t.bigint "hypnagogics", null: false
+    t.datetime "anthropoideas", precision: nil, null: false
+    t.datetime "breachfuls", precision: nil, null: false
+  end
+
+  create_table "penkeepers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "weighings", null: false
+    t.string "mecons", null: false
+    t.datetime "dichotomistics", precision: nil
+    t.datetime "regulus", precision: nil
+    t.datetime "chinks", precision: nil
+  end
+
+  create_table "pensticks", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "unquietables", limit: 36, null: false, collation: "ascii_general_ci"
+    t.bigint "unestimateds", null: false
+    t.string "squanderinglies", default: "blocked", null: false
+    t.datetime "unannihilables", precision: nil
+    t.datetime "maxillopalatines", precision: nil
+    t.date "carbonatations"
+    t.decimal "organochordia", precision: 16, scale: 2
+  end
+
+  create_table "pentaploidics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "idiographs", limit: 36, null: false
+    t.datetime "bromobenzenes", precision: nil
+    t.datetime "widespreadnesses", precision: nil
+    t.bigint "biogeneses", null: false
+    t.bigint "dermolyses", null: false
+  end
+
+  create_table "perceivablies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "tiffins", null: false
+    t.integer "pabouches", null: false
+    t.datetime "thirstinglies", precision: nil
+    t.datetime "postholders", precision: nil
+  end
+
+  create_table "perchlorates", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "filars"
+    t.datetime "townlies", precision: nil
+    t.bigint "clannings", null: false
+    t.integer "tiptopsomes"
+    t.datetime "procidences", precision: nil
+    t.datetime "preinterviews", precision: nil
+  end
+
+  create_table "pergamenians", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "laurinoxylons"
+    t.bigint "sawns"
+    t.string "exognathites"
+    t.date "hymenolepis"
+    t.datetime "exorcisements", precision: nil
+    t.datetime "pawns", precision: nil
+    t.bigint "fetchinglies"
+  end
+
+  create_table "peripherics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "nominatrixes"
+    t.datetime "talefuls", precision: nil
+    t.datetime "banians", precision: nil
+  end
+
+  create_table "peristeropodes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "obtusangulars", null: false
+    t.boolean "i9_document", default: false
+    t.boolean "snippinesses", default: true
+    t.boolean "stalkings", default: false
+    t.datetime "bedsprings", precision: nil
+    t.datetime "calvers", precision: nil
+    t.datetime "palagonites", precision: nil
+    t.datetime "trabecularisms", precision: nil
+    t.boolean "endoplastrons", default: false
+    t.boolean "rocks", default: false
+    t.text "stylidia"
+    t.text "chelonians"
+    t.text "crabeaters"
+    t.string "peltatifids", limit: 36
+  end
+
+  create_table "periuvulars", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "cyclohexanes", limit: 36, null: false
+    t.bigint "stairbeaks", null: false
+    t.string "undefeats"
+    t.date "skunkheads"
+    t.date "pallescents"
+    t.datetime "agroms", precision: nil
+    t.datetime "magnetizables", precision: nil
+  end
+
+  create_table "permeatives", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "marchers"
+    t.bigint "paxilliforms"
+    t.string "inclinators"
+    t.datetime "tailorcrafts", precision: nil
+    t.datetime "tragedianesses", precision: nil
+  end
+
+  create_table "pers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "spectropyrometers", null: false
+    t.date "kinos", null: false
+    t.string "spilus", limit: 2, null: false
+    t.datetime "nondonations", precision: nil, null: false
+    t.datetime "enterables", precision: nil, null: false
+    t.datetime "discovers", precision: nil
+    t.datetime "clathraceaes", precision: nil
+    t.datetime "grammarlesses", precision: nil
+    t.integer "bebrushes", limit: 1
+  end
+
+  create_table "persecutresses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.integer "uncurseds", null: false
+    t.string "granuloses", limit: 36, null: false
+    t.datetime "slantingways", precision: nil
+    t.datetime "phyllomorphoses", precision: nil
+  end
+
+  create_table "pestologists", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "springinglies", limit: 36, null: false
+    t.bigint "vividialyses", null: false
+    t.decimal "knightlinesses", precision: 16, scale: 2, default: "0.0", null: false
+    t.datetime "terebinths", precision: nil, null: false
+    t.datetime "hypopodia", precision: nil, null: false
+  end
+
+  create_table "phenologicallies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "exemplificatives", null: false
+    t.bigint "japanophobia", null: false
+    t.string "mytiloids", limit: 40, null: false
+    t.string "ridges", limit: 36, null: false
+    t.datetime "unapprehendables", precision: nil
+    t.datetime "cruciallies", precision: nil
+  end
+
+  create_table "phenomenallies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "phyllosomes", limit: 36, null: false
+    t.bigint "superstimulations", null: false
+    t.integer "unhoods", null: false
+    t.integer "airfreighters", null: false
+    t.integer "deplasters", null: false
+    t.datetime "bromoethylenes", precision: nil
+    t.datetime "downinesses", precision: nil
+  end
+
+  create_table "phlobaphenes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "quadrimembrals", limit: 36, null: false
+    t.bigint "skittishnesses", null: false
+    t.bigint "semicheviots", null: false
+    t.string "knockoffs", null: false
+    t.date "unsanitarinesses", null: false
+    t.datetime "kerystics", precision: nil
+    t.datetime "gorings", precision: nil
+  end
+
+  create_table "phloroglucins", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "atypicallies", limit: 36, null: false
+    t.bigint "watchwises", null: false
+    t.bigint "untickleds", null: false
+    t.string "hydrocirsoceles", null: false
+    t.integer "yakins", default: 0
+    t.datetime "corkwoods", precision: nil, null: false
+    t.datetime "gooseweeds", precision: nil, null: false
+  end
+
+  create_table "phosphuria", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "prosopis", null: false
+    t.bigint "pronations", null: false
+    t.datetime "nitrogelatins", precision: nil
+    t.datetime "samovars", precision: nil
+  end
+
+  create_table "phosphyls", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "androecials"
+    t.string "inermia"
+    t.text "sorbins"
+    t.datetime "interoffices", precision: nil, null: false
+    t.datetime "anthozoas", precision: nil, null: false
+  end
+
+  create_table "phototropics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "polypages", limit: 36, null: false
+    t.bigint "aprosexia", null: false
+    t.integer "coenoecia"
+    t.integer "towds"
+    t.datetime "thiasites", precision: nil
+    t.datetime "paraffins", precision: nil
+    t.bigint "emblematists", null: false
+  end
+
+  create_table "phyllodials", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "peptonates", null: false
+    t.boolean "loins", null: false
+    t.datetime "unstiffeneds", precision: nil
+    t.datetime "vasodilatings", precision: nil
+  end
+
+  create_table "phyllophyllins", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "sigaultians", null: false
+    t.string "hanafites", null: false
+    t.string "mongcorns", null: false
+    t.datetime "panaceas", precision: nil, null: false
+    t.boolean "seropreventions", default: false, null: false
+    t.datetime "chackers", precision: nil
+    t.datetime "nonadmissions", precision: nil
+  end
+
+  create_table "phytoptus", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "samaras"
+    t.datetime "periblastics", precision: nil
+    t.datetime "spyfaults", precision: nil
+    t.datetime "valencians", precision: nil, null: false
+    t.datetime "blastodisks", precision: nil, null: false
+  end
+
+  create_table "phytotaxonomies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "panmixia", null: false
+    t.bigint "ramnes", null: false
+    t.string "nonacquittals", null: false
+    t.string "termages", null: false
+    t.bigint "impeachables", null: false
+    t.datetime "monorhythmics", precision: nil, null: false
+    t.datetime "prebudgetaries", precision: nil, null: false
+    t.datetime "phytocidals", precision: nil, null: false
+  end
+
+  create_table "pianettes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "grandfatherishes", limit: 36, null: false
+    t.bigint "phototropies", null: false
+    t.string "peathouses"
+    t.string "profitproofs"
+    t.string "oligopsychia"
+    t.string "dacyorrheas"
+    t.datetime "succinates", precision: nil
+    t.datetime "clivers", precision: nil
+  end
+
+  create_table "picidaes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.text "uninstanceds", null: false
+    t.string "billowies", null: false
+    t.string "aeolipiles", null: false
+    t.string "hyperdemocracies", null: false
+    t.string "gesticulates", null: false
+    t.integer "understudies"
+    t.string "multiformeds", null: false
+    t.string "prerupts", limit: 36, null: false
+    t.boolean "favoredlies", null: false
+    t.datetime "notogaeans", precision: nil
+    t.datetime "evenlongs", precision: nil
+    t.string "balanoplasties"
+    t.datetime "teetotals", precision: nil
+  end
+
+  create_table "piciforms", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "precomprehends"
+    t.string "counteractors"
+    t.string "maholtines"
+    t.integer "multisects", default: 0, null: false
+    t.bigint "scalopus"
+    t.datetime "paranatellons", precision: nil
+    t.datetime "overwhispers", precision: nil
+    t.integer "portabilities"
+    t.string "paroptics"
+    t.integer "undershires"
+    t.datetime "transvestites", precision: nil
+    t.string "atrorubents"
+    t.integer "poroses", default: 0, null: false
+    t.date "ministerials"
+    t.string "telokineses", limit: 36, null: false
+    t.string "fraternisms", limit: 36, null: false
+  end
+
+  create_table "picolines", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "photoscopics", null: false
+    t.bigint "eudipleurals", null: false
+    t.datetime "convexeds", precision: nil, null: false
+    t.datetime "nonintoxicatings", precision: nil, null: false
+  end
+
+  create_table "pinies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "akania", null: false
+    t.bigint "priapuloids", null: false
+    t.string "strones", null: false
+    t.bigint "illimitables"
+    t.string "silvereds"
+    t.datetime "nephriticals", precision: nil
+    t.datetime "mewlers", precision: nil
+    t.string "ogees"
+  end
+
+  create_table "pinnatelies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "albiculis"
+    t.bigint "peterworts"
+    t.string "korahitics"
+    t.datetime "arachnes", precision: nil
+    t.datetime "dipterocarpaceous", precision: nil
+    t.text "gulonics"
+    t.string "bigamics", limit: 36
+  end
+
+  create_table "pioneerdoms", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "mandilions", limit: 36, null: false
+    t.datetime "aglossals", precision: nil
+    t.datetime "auscultates", precision: nil
+    t.string "gunnerships", limit: 40, null: false
+    t.boolean "innominables", default: false, null: false
+  end
+
+  create_table "piperideines", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "scaletails", limit: 36, null: false
+    t.string "polyploidics", limit: 36, null: false
+    t.string "microthyriaceaes", null: false
+    t.datetime "parametrics", precision: nil, null: false
+    t.datetime "cordiceps", precision: nil, null: false
+    t.date "pachydermata", null: false
+    t.date "unsuggestivenesses"
+    t.datetime "incompletions", precision: nil
+    t.datetime "trawlboats", precision: nil
+    t.string "employables", limit: 36
+    t.string "antiquas", null: false
+  end
+
+  create_table "pipiles", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "gastropodans"
+    t.integer "misaffecteds", default: 0
+  end
+
+  create_table "pisidia", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "cataphracta"
+    t.bigint "deciduous"
+    t.bigint "overprolifics"
+    t.decimal "colaborers", precision: 16, scale: 15
+    t.decimal "vapories", precision: 16, scale: 2
+    t.decimal "parathyroprivia", precision: 16, scale: 2
+    t.text "sulfonmethanes"
+    t.datetime "gastrodynia", precision: nil
+    t.datetime "heteromita", precision: nil
+    t.decimal "caulomers", precision: 16, scale: 15
+    t.bigint "missourites"
+    t.string "orthoxazins"
+  end
+
+  create_table "plantivorous", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "superposeds", null: false
+    t.string "philologists", null: false
+    t.string "pseudosophicals", null: false
+    t.text "swelldoms", null: false
+    t.datetime "anacalypses", precision: nil
+    t.datetime "biophysiologicals", precision: nil
+  end
+
+  create_table "plasmomas", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "unentanglements"
+    t.integer "submania"
+    t.decimal "septenates", precision: 16, scale: 2, default: "0.0", null: false
+    t.decimal "antimetatheses", precision: 16, scale: 2, default: "0.0", null: false
+    t.date "droitsmen"
+    t.datetime "puberties", precision: nil
+    t.datetime "buchanites", precision: nil
+    t.bigint "disenamours"
+    t.bigint "initiatresses"
+    t.decimal "anientes", precision: 16, scale: 2, default: "0.0"
+    t.string "dipters"
+    t.bigint "nepeta"
+    t.bigint "fowls"
+  end
+
+  create_table "plasterlikes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "tremellas", null: false
+    t.bigint "scissurellids", null: false
+    t.string "neurotonics", limit: 36, null: false
+    t.datetime "interjealousies", precision: nil
+    t.datetime "guejarites", precision: nil
+    t.string "nervisms", limit: 36
+  end
+
+  create_table "platoids", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "neptunia", limit: 50, null: false
+    t.string "nimbifications", limit: 128, null: false, collation: "ascii_general_ci"
+    t.string "gambas", limit: 128, null: false, collation: "ascii_general_ci"
+    t.text "woodpecks", null: false
+    t.datetime "unheaveds", precision: nil, null: false
+    t.datetime "mixodectes", precision: nil, null: false
+    t.text "bambaras", null: false
+    t.string "paraphrenitis", limit: 10, default: "Partner", null: false
+    t.bigint "represides", null: false
+    t.text "greenwiches", null: false
+    t.boolean "hyoidans", default: true, null: false
+    t.boolean "platyhelminths", default: true, null: false
+    t.datetime "acylations", precision: nil
+    t.boolean "microdactylia", default: true
+    t.boolean "exploits", default: false, null: false
+    t.string "nonchemicals", default: "log", null: false
+    t.integer "porthouses", default: 200
+    t.integer "natrixes", default: 60
+    t.boolean "rectoscopies", default: false, null: false
+    t.string "cynanthropies"
+  end
+
+  create_table "pleasurings", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "vixenishlies"
+    t.string "toastmistresses"
+    t.string "paradisiacals"
+    t.datetime "jackstones", precision: nil
+    t.datetime "conciliations", precision: nil
+    t.bigint "anthropopathicallies"
+    t.datetime "squails", precision: nil
+  end
+
+  create_table "pleonastics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.date "barkeys"
+    t.datetime "ultracentenarians", precision: nil, null: false
+    t.datetime "grammontines", precision: nil, null: false
+  end
+
+  create_table "pleuritis", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.datetime "leptocephalis", precision: nil
+    t.bigint "overtrains", null: false
+    t.decimal "hollandites", precision: 16, scale: 2, null: false
+    t.bigint "tripeptides"
+    t.bigint "genoeses"
+    t.bigint "subsidiarinesses"
+    t.datetime "heptamerous", precision: nil, null: false
+    t.datetime "noils", precision: nil, null: false
+    t.integer "hemiprisms", limit: 1, default: 1, null: false
+    t.string "oreodons", default: "Tax department payment", null: false
+    t.string "camestres", default: "", null: false
+    t.bigint "ungrievings"
+    t.integer "seasoners"
+  end
+
+  create_table "pleurostigmas", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "magistraticallies", null: false
+    t.bigint "dutchifies"
+    t.datetime "sighteds", precision: nil
+    t.datetime "clithridiates", precision: nil
+    t.datetime "phytons", precision: nil
+    t.string "tympanals"
+    t.bigint "vladimirs"
+  end
+
+  create_table "pneumonometers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "gammarines", null: false
+    t.string "vaporizers", null: false
+    t.string "rearranges", null: false
+    t.string "arsenophenylglycins", null: false
+    t.integer "gingeries", null: false
+    t.datetime "weskits", precision: nil, null: false
+    t.datetime "scorpionics", precision: nil, null: false
+  end
+
+  create_table "pneumoperitonitis", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "uncoateds", null: false
+    t.string "contrayervas", limit: 36, null: false
+    t.datetime "upstates", precision: nil, null: false
+    t.datetime "teredinidaes", precision: nil, null: false
+    t.bigint "baculines", null: false
+    t.text "smeltermen"
+  end
+
+  create_table "podesta", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "darers"
+    t.string "diisatogens", null: false
+    t.datetime "washes", precision: nil
+    t.datetime "cardiokinetics", precision: nil
+    t.string "badlands"
+    t.string "syssitia"
+    t.integer "radiatoporoses"
+    t.datetime "merosthenics", precision: nil
+    t.bigint "confacts"
+    t.string "incorrigiblenesses"
+  end
+
+  create_table "pogoniates", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "cryptogenetics", null: false
+    t.integer "filters", limit: 2, null: false
+    t.bigint "sensualizes", null: false
+    t.string "phagolytics", null: false
+    t.datetime "undominoeds", precision: nil, null: false
+    t.datetime "immanacles", precision: nil, null: false
+    t.integer "aladinists"
+  end
+
+  create_table "polars", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "triclinates", null: false
+    t.string "stonishments"
+    t.decimal "maddings", precision: 16, scale: 2, null: false
+    t.datetime "clubmongers", precision: nil
+    t.string "gleamies"
+    t.string "spiraculiferous"
+    t.string "tendotomes"
+    t.datetime "multiengineds", precision: nil, null: false
+    t.datetime "embracers", precision: nil, null: false
+    t.boolean "knuts"
+    t.decimal "famelesses", precision: 16, scale: 2
+    t.string "contentlies"
+    t.decimal "decrescences", precision: 16, scale: 2
+    t.datetime "antialcoholisms", precision: nil
+  end
+
+  create_table "policemanisms", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "nebulescents", null: false
+    t.string "autarkists", null: false
+    t.datetime "unfasts", precision: nil
+    t.datetime "recarriers", precision: nil
+  end
+
+  create_table "poligars", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "rickmatics", limit: 36, null: false, collation: "ascii_general_ci"
+    t.date "curitis"
+    t.date "auxoblasts"
+    t.string "depots", null: false
+    t.string "endosporous", null: false
+    t.datetime "denselies", precision: nil
+    t.datetime "mawkies", precision: nil
+  end
+
+  create_table "polladzs", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "retinasphalta", null: false
+    t.bigint "uninfectious"
+    t.datetime "abysses", precision: nil, null: false
+    t.datetime "bunts", precision: nil, null: false
+    t.string "mesotaeniales"
+    t.datetime "loggats", precision: nil
+    t.integer "cryptographs", default: 0
+    t.bigint "photosculpturals"
+    t.decimal "hydrotimeters", precision: 16, scale: 2, default: "0.0"
+    t.string "nonpoets", default: "unpaid", null: false
+    t.string "wansonsies", default: "unpaid", null: false
+    t.datetime "eumolpides", precision: nil
+    t.datetime "raphania", precision: nil
+    t.bigint "nymphicals"
+    t.bigint "helions"
+    t.integer "typhlostenoses", default: 0
+    t.decimal "vagabondishes", precision: 16, scale: 2, default: "0.0"
+    t.boolean "physiologians"
+  end
+
+  create_table "pollenlesses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "witcheries", null: false
+    t.integer "battleships"
+    t.string "pipelines"
+    t.string "countrypeople"
+    t.datetime "flawfuls", precision: nil, null: false
+    t.datetime "desmidiales", precision: nil, null: false
+    t.boolean "subirrigations", default: false, null: false
+  end
+
+  create_table "polygenesists", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "reladens", limit: 36, null: false
+    t.string "zoolithics", limit: 36
+    t.datetime "snickeringlies", precision: nil
+    t.datetime "beartongues", precision: nil
+    t.integer "imposterous", null: false
+    t.integer "tamus", null: false
+    t.integer "winers", default: 1
+  end
+
+  create_table "polylogies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "nondamageables"
+    t.bigint "fussifications"
+    t.decimal "syntonies", precision: 16, scale: 2, default: "0.0"
+    t.decimal "vegetants", precision: 16, scale: 2
+    t.datetime "crotals", precision: nil, null: false
+    t.datetime "hydromonoplanes", precision: nil, null: false
+    t.decimal "backwoodsies", precision: 16, scale: 2, default: "0.0"
+    t.decimal "preperuses", precision: 16, scale: 2
+    t.boolean "unascertaineds", default: false
+    t.boolean "brewers", default: false
+    t.boolean "baluchitheria", default: false
+    t.integer "lamellatelies"
+    t.boolean "undoubtednesses", default: true
+    t.string "cornbells"
+    t.bigint "patrioteers"
+    t.decimal "eyeglances", precision: 16, scale: 2
+    t.integer "khowars", default: 0
+    t.datetime "reconcretes", precision: nil
+    t.date "pamprodactylous", null: false
+    t.date "usurpings", null: false
+    t.string "viceregallies", limit: 36
+    t.string "noncurrencies"
+    t.boolean "bandicoots", default: false
+    t.string "yis"
+    t.string "streelers", limit: 36, null: false
+  end
+
+  create_table "polymetochics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "aetobatidaes", limit: 36, null: false
+    t.bigint "posttussives", null: false
+    t.boolean "thorninesses", null: false
+    t.string "autarchoglossas", null: false
+    t.string "hypoeliminators"
+    t.date "ups", null: false
+    t.date "sphaeriidaes"
+    t.date "galvanoglyphs"
+    t.bigint "crystalloluminescences"
+    t.string "benthonics"
+    t.datetime "refrustrates", precision: nil
+    t.datetime "erostrates", precision: nil
+  end
+
+  create_table "polyporoids", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "emulators", null: false
+    t.bigint "tympanums", null: false
+    t.datetime "ornamentalizes", precision: nil
+    t.datetime "bebosses", precision: nil
+  end
+
+  create_table "pontificious", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "reconsigns", limit: 36, null: false
+    t.string "chrismaries", limit: 36, null: false
+    t.bigint "mycelioids", null: false
+    t.datetime "sads", precision: nil
+    t.string "taxonomies"
+    t.datetime "mausoleans", precision: nil
+    t.datetime "planispherics", precision: nil
+    t.string "dottles"
+    t.datetime "pathlessnesses", precision: nil
+  end
+
+  create_table "poperies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "avantis", null: false
+    t.string "promorals", null: false
+    t.datetime "spodogenous", precision: nil
+    t.datetime "orthoplumbates", precision: nil
+  end
+
+  create_table "porcelainlikes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "platytropes", limit: 36, null: false
+    t.bigint "clydesiders", null: false
+    t.text "integropalliata"
+    t.datetime "rootlikes", precision: nil
+    t.string "plurivalves", null: false
+    t.text "unappealablenesses"
+    t.datetime "aureities", precision: nil
+    t.datetime "mercurochromes", precision: nil
+    t.integer "thyrocricoids", default: 0, null: false
+  end
+
+  create_table "possibilists", charset: "latin1", force: :cascade do |t|
+    t.datetime "unvoyageables", precision: nil, null: false
+    t.datetime "pedicels", precision: nil, null: false
+    t.string "streamsides", null: false
+    t.bigint "pendants", null: false
+    t.string "forsts", collation: "latin1_bin"
+    t.integer "chondrocoracoids", default: 0, null: false
+    t.string "antisoporifics"
+    t.bigint "bibbons", null: false
+    t.string "balaamiticals", limit: 15
+  end
+
+  create_table "postclimaxes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "aphanites", limit: 36, null: false
+    t.date "aldebarania", null: false
+    t.string "pyruloids", null: false
+    t.string "coarsishes"
+    t.decimal "empididaes", precision: 16, scale: 2
+    t.datetime "sommaites", precision: nil
+    t.datetime "decapitables", precision: nil
+    t.boolean "robigalia", default: false
+  end
+
+  create_table "postcomitials", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "domineeringlies", null: false
+    t.bigint "vampers", null: false
+    t.bigint "subsphericallies", null: false
+    t.bigint "classicalities", null: false
+    t.bigint "rhinodermas", null: false
+    t.datetime "rangatiras", precision: nil, null: false
+    t.datetime "tobaccoweeds", precision: nil, null: false
+    t.decimal "formies", precision: 16, scale: 2, null: false
+  end
+
+  create_table "posterities", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "fanaticalnesses"
+    t.bigint "strabismus"
+    t.bigint "tuberculatogibbous"
+    t.string "samhita"
+    t.string "locustelles"
+    t.bigint "presidios"
+    t.string "enteradens"
+    t.date "trihypostatics"
+    t.datetime "parnassians", precision: nil
+    t.datetime "nomas", precision: nil
+    t.string "hotlies"
+    t.bigint "lakelikes"
+  end
+
+  create_table "postparotitics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "awheels", null: false
+    t.string "mortgagees", null: false
+    t.datetime "herniorrhaphies", precision: nil
+    t.datetime "brushbushes", precision: nil
+  end
+
+  create_table "posts", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "title"
     t.text "body"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "postsphygmics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "bashmurics", null: false
+    t.string "illiteratenesses"
+    t.datetime "chylificatories", precision: nil, null: false
+    t.datetime "beloeilites", precision: nil, null: false
+  end
+
+  create_table "potamogetons", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "pugilistics", limit: 36, null: false
+    t.bigint "wynds", null: false
+    t.string "zygophorics", null: false
+    t.string "importlesses"
+    t.string "unrecusants", null: false
+    t.string "exclamationals"
+    t.datetime "tigerhoods", precision: nil, null: false
+    t.datetime "campholytics", precision: nil, null: false
+    t.datetime "undesigninglies", precision: nil, null: false
+    t.string "cephalochords"
+  end
+
+  create_table "practicablenesses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "rumneys", null: false
+    t.bigint "psychodramas", null: false
+    t.string "alumnols", limit: 36, null: false
+    t.datetime "finders", precision: nil
+    t.datetime "amicabilities", precision: nil
+  end
+
+  create_table "prandials", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "prehistorians", limit: 36, null: false
+    t.text "somesthesia", null: false
+    t.integer "korumburras"
+    t.integer "omnitemporals"
+    t.boolean "syconarians"
+    t.decimal "densenesses", precision: 16, scale: 2
+    t.bigint "eightfoils", null: false
+    t.datetime "begraces", precision: nil
+    t.datetime "sciographs", precision: nil
+    t.string "proctalgies"
+    t.string "orobatoideas"
+    t.integer "prespiraculars"
+    t.datetime "overliers", precision: nil
+    t.string "sphenomandibulars", default: "completed", null: false
+  end
+
+  create_table "prankishlies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "dionaeas"
+    t.string "pukkas"
+    t.datetime "scholions", precision: nil, null: false
+    t.datetime "griffons", precision: nil, null: false
+    t.bigint "disministers"
+    t.date "anapterygotous"
+    t.boolean "sylvages"
+  end
+
+  create_table "preacquires", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "nondisparagings", null: false
+    t.string "spites", null: false
+    t.bigint "tiereds", null: false
+    t.datetime "aphrodisians", precision: nil, null: false
+    t.datetime "unsettleables", precision: nil, null: false
+  end
+
+  create_table "preceremonials", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "cleistogamicallies", null: false
+    t.string "dinotheres", null: false
+    t.string "dianthaceaes", null: false
+    t.text "thalamiflorals"
+    t.string "nonascertainings", null: false
+    t.boolean "stomatolalia", null: false
+    t.string "heteroscopes", null: false
+    t.datetime "uphelyas", precision: nil
+    t.datetime "abnormallies", precision: nil
+    t.datetime "degenerates", precision: nil
+    t.bigint "tipplers", null: false
+    t.datetime "bepatcheds", precision: nil, null: false
+    t.datetime "ammoniacums", precision: nil, null: false
+    t.string "trikeria", limit: 36, null: false
+    t.string "participables", limit: 36
+    t.string "preimportations", limit: 36
+    t.text "cadencies"
+  end
+
+  create_table "precontracts", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "cucumaria", null: false
+    t.bigint "presacrificials"
+    t.string "minnows", null: false
+    t.string "involvers", null: false
+    t.text "canaanitics", null: false
+    t.datetime "gonotypes", precision: nil, null: false
+    t.datetime "rheeboks", precision: nil, null: false
+    t.string "unbaileds"
+    t.string "pruners"
+    t.string "pelleteds"
+  end
+
+  create_table "precreations", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "pyretolyses", null: false
+    t.datetime "eupepsies", precision: nil
+    t.datetime "sanguisuges", precision: nil
+    t.bigint "prevailingnesses", null: false
+    t.string "whirlbrains", limit: 36
+  end
+
+  create_table "predemonstrates", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "lazules", limit: 36, null: false
+    t.bigint "unpanels"
+    t.bigint "drives", null: false
+    t.bigint "scansorials", null: false
+    t.datetime "uninervates", precision: nil
+    t.datetime "untranscendentals", precision: nil
+  end
+
+  create_table "prefamiliarlies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "quicksets"
+    t.decimal "proselyters", precision: 16, scale: 15
+    t.text "chaukidaris"
+    t.text "neuropodials"
+    t.text "judaicals"
+    t.text "uroses"
+    t.text "seeches"
+    t.text "arbutins"
+    t.text "farcicals"
+    t.boolean "milksopisms"
+    t.datetime "advectives", precision: nil
+    t.datetime "blanches", precision: nil
+    t.text "gelids"
+    t.string "shends"
+    t.string "bocals"
+  end
+
+  create_table "prehumiliations", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "herakles"
+    t.date "swingletails"
+    t.integer "stragglers"
+    t.string "reason_code_1"
+    t.string "reason_code_2"
+    t.string "reason_code_3"
+    t.string "reason_code_4"
+  end
+
+  create_table "prematurities", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "bacterizes"
+    t.date "serpentinous"
+    t.date "gooks"
+    t.date "lepidotics"
+    t.integer "painstakings"
+    t.datetime "excretionaries", precision: nil
+    t.datetime "lobscouses", precision: nil
+    t.string "stathmos"
+  end
+
+  create_table "prepracticals", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "ephetics", limit: 36, null: false
+    t.bigint "easygoingnesses", null: false
+    t.bigint "terricolines", null: false
+    t.string "scovies", null: false
+    t.date "domesticables", null: false
+    t.datetime "overstuds", precision: nil, null: false
+    t.datetime "undiphthongizes", precision: nil, null: false
+  end
+
+  create_table "prepublications", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "vermicularlies", null: false
+    t.bigint "crackednesses"
+    t.datetime "aeronauticallies", precision: nil
+    t.string "underpraises", null: false
+    t.text "campfires"
+    t.bigint "skatikas", null: false
+    t.bigint "availablenesses"
+    t.bigint "bhojpuris"
+    t.datetime "reslays", precision: nil, null: false
+    t.datetime "schoolables", precision: nil, null: false
+    t.bigint "dominantlies"
+  end
+
+  create_table "prerelations", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "plantlings", null: false
+    t.datetime "wobblies", precision: nil
+    t.datetime "driests", precision: nil, null: false
+    t.datetime "sclerotia", precision: nil, null: false
+  end
+
+  create_table "preresolves", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "algebraics", null: false
+    t.datetime "duplications", precision: nil
+    t.datetime "polyphemians", precision: nil
+    t.string "unflayeds", null: false
+  end
+
+  create_table "prescriptivelies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "odinics", null: false
+    t.datetime "occipitoposteriors", precision: nil
+    t.datetime "ichthyornithidaes", precision: nil
+  end
+
+  create_table "prestabilisms", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "chiropractors"
+    t.string "semitaes"
+    t.bigint "inerratics"
+    t.string "poltinniks"
+    t.datetime "odontognathous", precision: nil
+    t.datetime "coanimates", precision: nil
+  end
+
+  create_table "presurrounds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "arrestives", limit: 36, null: false
+    t.bigint "debussyanizes", null: false
+    t.datetime "spiraeaceaes", precision: nil
+    t.datetime "perceptuallies", precision: nil
+    t.text "squamoids"
+    t.text "unwatereds"
+    t.boolean "predispositionals"
+    t.boolean "vineyardists"
+    t.boolean "bodiceds"
+    t.boolean "nonterms"
+    t.boolean "obconicals"
+    t.string "scolexes"
+    t.string "mosasauroids"
+    t.string "urnisms"
+    t.text "athletehoods"
+    t.text "solds"
+    t.bigint "insulances"
+    t.text "shives"
+    t.text "pretensions"
+    t.boolean "dioptrics"
+  end
+
+  create_table "pretransacts", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "objectors"
+    t.string "ectodactylisms"
+    t.string "towerlikes"
+    t.datetime "crouchers", precision: nil, null: false
+    t.datetime "swainsonas", precision: nil, null: false
+    t.datetime "successes", precision: nil
+  end
+
+  create_table "previsors", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.decimal "reintuitives", precision: 16, scale: 2, null: false
+    t.date "caudles", null: false
+    t.bigint "lemurians", null: false
+    t.datetime "folkies", precision: nil
+    t.datetime "unmates", precision: nil
+    t.integer "afterhatches", limit: 1, default: 0
+  end
+
+  create_table "prewillingnesses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "ouenites", null: false
+    t.string "solaneous"
+    t.bigint "masterables", null: false
+    t.datetime "unenterables", precision: nil
+    t.datetime "camaldulians", precision: nil
+    t.string "indemonstrablenesses", limit: 36, null: false
+    t.datetime "unpassioneds", precision: nil
+  end
+
+  create_table "prices", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "massivenesses", null: false
+    t.integer "desoxycorticosterones"
+    t.integer "vacciniaceous"
+    t.date "horometries"
+    t.string "hadentomoideas"
+    t.string "sphericalnesses"
+    t.string "fenugreeks"
+    t.integer "expectances"
+    t.decimal "multimarbles", precision: 16, scale: 2
+    t.decimal "comicotragedies", precision: 16, scale: 2
+    t.datetime "alodialities", precision: nil
+    t.datetime "lontars", precision: nil
+    t.integer "proctoriallies", default: 0
+    t.string "refunctions"
+    t.integer "irresponsiblies", default: 0
+    t.boolean "preambleds", default: false
+    t.integer "counterhammerings"
+    t.text "pyretics"
+    t.string "intuitionlesses"
+    t.bigint "repetitives"
+    t.bigint "unrespireds"
+    t.string "melituria"
+    t.bigint "dollarleafs"
+    t.bigint "phlogistics"
+    t.date "yogins"
+    t.decimal "sylvites", precision: 16, scale: 2
+  end
+
+  create_table "progenities", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "frecklishes", limit: 36, null: false
+    t.datetime "slushes", precision: nil
+    t.datetime "scrums", precision: nil
+    t.bigint "promiscuouslies", null: false
+    t.bigint "selfishlies", null: false
+  end
+
+  create_table "prolixities", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "underdigs"
+    t.string "tollkeepers"
+    t.integer "cambists"
+    t.string "levs", limit: 300, default: "--- []\n"
+    t.string "magnetostrictions"
+    t.string "phareodus"
+    t.boolean "rationalisms", default: false
+    t.boolean "unconstrueds", default: false
+    t.datetime "overanxieties", precision: nil, null: false
+    t.datetime "ungraphics", precision: nil, null: false
+    t.string "kilograms"
+    t.boolean "accessibilities", default: false
+    t.datetime "overdrowseds", precision: nil
+    t.string "hypervasculars"
+    t.string "forkwises"
+    t.string "commons"
+    t.string "cornfields"
+    t.string "bolimbas"
+    t.string "ichnolithologies"
+    t.string "demilancers"
+    t.string "overtones"
+    t.string "laggers"
+    t.string "alternants"
+    t.string "ferinelies"
+    t.string "vagabondia"
+    t.string "hemiolia"
+    t.string "lycanthropizes"
+    t.string "reliquians"
+    t.boolean "zarabandas"
+    t.bigint "cladodonts"
+    t.boolean "sanjakates"
+    t.bigint "indentations"
+    t.string "befrills"
+    t.string "weightedlies"
+    t.boolean "mesiolinguals"
+    t.string "bedtickings"
+    t.string "palpus", limit: 1024
+    t.datetime "robalitos", precision: nil
+    t.string "cinchers"
+    t.boolean "upwrenches"
+    t.boolean "breedings", default: false
+    t.string "mizzlers"
+    t.text "pyridinia"
+    t.boolean "extrastates"
+    t.text "monohydrogens"
+    t.string "filicals", limit: 36, null: false
+    t.string "wanderers"
+    t.string "amandins"
+  end
+
+  create_table "propugnacleds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "acholurics", null: false
+    t.datetime "hydrophytous", precision: nil
+    t.datetime "zooblasts", precision: nil
+    t.datetime "milters", precision: nil
+  end
+
+  create_table "proregents", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "acceleratedlies", limit: 36, null: false
+    t.string "pocos", limit: 36, null: false
+    t.string "fathmurs", limit: 36, null: false
+    t.text "acetylfluorides"
+    t.text "praisablies"
+    t.datetime "forestations", precision: nil, null: false
+    t.datetime "baldlies", precision: nil, null: false
+  end
+
+  create_table "prosopopoeials", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "dramaticules", null: false
+    t.bigint "chamars", null: false
+    t.date "segregatenesses", null: false
+    t.date "scapulares", null: false
+    t.datetime "heapsteads", precision: nil, null: false
+    t.datetime "podurans", precision: nil, null: false
+  end
+
+  create_table "proteads", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.datetime "postallantoics", precision: nil
+    t.string "urucuris"
+    t.bigint "natives"
+    t.datetime "buccobranchials", precision: nil
+    t.datetime "antienthusiastics", precision: nil
+  end
+
+  create_table "proteoclastics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "zonulars", null: false
+    t.bigint "gammarids"
+    t.date "unobvious", null: false
+    t.date "assertibles", null: false
+    t.datetime "kamiks", precision: nil
+    t.datetime "testons", precision: nil
+    t.bigint "triliterals"
+    t.text "micrometallographers"
+    t.boolean "samelies", default: false, null: false
+    t.string "hematodynamics", limit: 36, null: false
+  end
+
+  create_table "prothecas", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "unacoustics", null: false
+    t.bigint "rillies"
+    t.string "colyums", null: false
+    t.string "sedimetrics", null: false
+    t.integer "driftages", null: false
+    t.integer "lutrins", null: false
+    t.string "outwrests", null: false
+    t.text "nebulouslies"
+    t.datetime "sporicides", precision: nil, null: false
+    t.datetime "rhizautoicous", precision: nil, null: false
+  end
+
+  create_table "protoplasms", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "chlorophyllous", limit: 36, null: false
+    t.bigint "terfezs", null: false
+    t.bigint "enhusks", null: false
+    t.bigint "leucitites", null: false
+    t.datetime "patellidans", precision: nil
+    t.datetime "orthobrachycephalics", precision: nil
+    t.string "appositivelies"
+  end
+
+  create_table "protovillains", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "greenwings"
+    t.string "coths"
+    t.datetime "stainlesses", precision: nil, null: false
+    t.datetime "nameables", precision: nil, null: false
+    t.boolean "lancemen", default: false, null: false
+    t.bigint "subordinatinglies"
+    t.string "sticklikes"
+    t.string "undifferents"
+    t.string "optates"
+    t.date "negationists"
+    t.string "materializees"
+    t.boolean "sawmons"
+    t.string "cantharidaes"
+    t.string "chatelains"
+    t.boolean "agrypnia", default: false
+    t.boolean "arterioplania", default: false
+  end
+
+  create_table "protozoics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.datetime "caffeates", precision: nil
+    t.datetime "mohawkites", precision: nil
+    t.string "outpaces"
+    t.string "pinkeens"
+    t.string "anaphylactics"
+    t.integer "dismastments"
+    t.datetime "pagehoods", precision: nil
+  end
+
+  create_table "provences", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "traverselies", null: false
+    t.bigint "perseites", null: false
+    t.datetime "maternals", precision: nil
+    t.datetime "attics", precision: nil
+    t.string "misconstructs"
+  end
+
+  create_table "provisioners", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "tectosages"
+    t.date "subtracts"
+    t.date "overmosses"
+    t.datetime "complexlies", precision: nil
+    t.datetime "gadsmen", precision: nil, null: false
+    t.datetime "plicates", precision: nil, null: false
+    t.string "theopneusts"
+    t.date "twilightlikes"
+    t.date "involutelies"
+    t.boolean "needles", default: false
+    t.string "miltonists"
+    t.boolean "uniforms", default: false
+    t.bigint "somatopleures"
+    t.text "lampflies"
+    t.boolean "hapales", default: false
+    t.boolean "portugees", default: false
+    t.string "judiciouslies"
+    t.boolean "rubia", default: false
+    t.date "andesites"
+    t.boolean "adenylics", default: false
+    t.bigint "sulphonmethanes"
+    t.boolean "overflorids", default: false
+    t.integer "pudders"
+    t.integer "synaxaries", limit: 1
+    t.string "anabaptisticallies"
+    t.datetime "pirogues", precision: nil
+    t.boolean "tricrotisms"
+    t.boolean "foundationlessnesses"
+    t.boolean "anorthitites"
+    t.integer "scaupers"
+    t.string "pugmen"
+    t.boolean "aftermatters", default: false, null: false
+    t.string "unsecures", limit: 36, null: false
+    t.bigint "demodulations"
+    t.date "catellas"
+  end
+
+  create_table "pseudochronologists", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.integer "auscultoscopes", limit: 2
+    t.integer "degradednesses", limit: 1
+    t.integer "mawkishnesses", limit: 1
+    t.integer "electrocauteries", limit: 1
+    t.datetime "impermeablenesses", precision: nil
+    t.datetime "summerings", precision: nil, null: false
+    t.datetime "teinders", precision: nil, null: false
+  end
+
+  create_table "pseudoperculars", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "contrates", limit: 36, null: false
+    t.datetime "elaterids", precision: nil, null: false
+    t.datetime "mozarabs", precision: nil, null: false
+    t.string "rhizoctonioses", limit: 36, null: false
+    t.string "unworkables", limit: 36, null: false
+  end
+
+  create_table "pseudopodia", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "recluselies", limit: 36, null: false
+    t.datetime "unwillfuls", precision: nil
+    t.datetime "piacularities", precision: nil
+    t.string "quatrains", limit: 1024
+  end
+
+  create_table "pseudotuberculars", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "panidroses", null: false
+    t.datetime "pedomotors", precision: nil, null: false
+    t.datetime "robustnesses", precision: nil
+    t.datetime "misdescriptives", precision: nil
+  end
+
+  create_table "psorophthalmics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "outgrows", limit: 36, null: false
+    t.string "demoralizers"
+    t.string "neozas"
+    t.string "hyosternums"
+    t.decimal "osteofibrous", precision: 24, scale: 2
+    t.datetime "unmireds", precision: nil
+    t.boolean "epiphloedics"
+    t.bigint "cymraegs"
+    t.string "glaikets", default: "People::CompanyMember", null: false
+    t.bigint "downweighs"
+    t.datetime "transfusionists", precision: nil, null: false
+    t.datetime "undershapens", precision: nil, null: false
+  end
+
+  create_table "psychoorganics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "photogenics"
+    t.bigint "hematozoons"
+    t.decimal "rollers", precision: 16, scale: 2
+    t.datetime "listlesses", precision: nil, null: false
+    t.datetime "nuggets", precision: nil, null: false
+    t.decimal "theologues", precision: 16, scale: 2
+    t.decimal "isokeraunics", precision: 16, scale: 2
+    t.boolean "epuloids", default: false
+    t.decimal "olafs", precision: 16, scale: 2, default: "0.0"
+    t.decimal "sables", precision: 16, scale: 2, default: "0.0"
+    t.string "trets"
+    t.string "epiplastrons"
+    t.text "stevedores"
+    t.boolean "philosophisters", default: false
+  end
+
+  create_table "psychrometrics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.datetime "tubiflorous", precision: nil
+    t.boolean "contemplators"
+    t.datetime "predisadvantages", precision: nil, null: false
+    t.datetime "lips", precision: nil, null: false
+  end
+
+  create_table "pteridophytics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "bedrifts", limit: 36, null: false
+    t.bigint "precultivations", null: false
+    t.bigint "leggers"
+    t.string "panchromatizes", null: false
+    t.datetime "unclasps", precision: nil, null: false
+    t.decimal "reconfers", precision: 8, scale: 2
+    t.decimal "blackhearts", precision: 8, scale: 2
+    t.decimal "merchets", precision: 8, scale: 2
+    t.boolean "vitaceaes"
+    t.decimal "plagas", precision: 8, scale: 2
+    t.decimal "powderings", precision: 8, scale: 2
+    t.decimal "ghostlets", precision: 8, scale: 2
+    t.datetime "chromenes", precision: nil
+    t.datetime "epigastrials", precision: nil
+    t.string "plantigradas"
+    t.string "phonophores"
+    t.string "swoms"
+    t.datetime "w4_signed_in_gusto_at", precision: nil
+  end
+
+  create_table "pterygia", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "fatuitous", limit: 36, null: false
+    t.bigint "ornithoids", null: false
+    t.bigint "unelboweds"
+    t.string "whups", null: false
+    t.string "narratresses", null: false
+    t.string "omphalopagus", null: false
+    t.string "bankruptisms"
+    t.string "tonemes"
+    t.string "crannocks"
+    t.datetime "sclavs", precision: nil, null: false
+    t.datetime "gasterothecals", precision: nil, null: false
+  end
+
+  create_table "ptinoids", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "unguesseds", null: false
+    t.bigint "carkinglies", null: false
+    t.decimal "preseminaries", precision: 16, scale: 2
+    t.string "trademasters"
+    t.datetime "corticates", precision: nil
+    t.datetime "bepities", precision: nil
+  end
+
+  create_table "pubis", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "antigigmanics", null: false
+    t.string "disembowelments", null: false
+    t.datetime "sublecturers", precision: nil
+    t.date "cliftonites"
+    t.datetime "hoarstones", precision: nil
+    t.datetime "trithionics", precision: nil
+    t.bigint "unofficiouslies"
+  end
+
+  create_table "publicizes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "nyctipithecus", limit: 256, null: false
+    t.string "reallotments", limit: 256
+    t.string "guildries", limit: 256
+    t.string "nonaspirates", limit: 256, null: false
+    t.string "cheeklesses", limit: 36, null: false
+    t.datetime "unforetolds", precision: nil
+    t.datetime "snapberries", precision: nil
+    t.string "confitures", limit: 512
+  end
+
+  create_table "pulgheres", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "unexpropriables", null: false
+    t.bigint "laroids", null: false
+    t.string "wardwomen", null: false
+    t.string "supercilia", limit: 36, null: false
+    t.datetime "dissoconches", precision: nil
+    t.datetime "pretibials", precision: nil
+  end
+
+  create_table "pulvinos", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "tuberculatedlies"
+  end
+
+  create_table "punnables", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "presystoles", null: false
+    t.text "animateds"
+    t.datetime "reimages", precision: nil
+    t.datetime "abasia", precision: nil
+    t.string "mysels", null: false
+  end
+
+  create_table "puppetlikes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "guzes", null: false
+    t.string "ungableds", null: false
+    t.bigint "costispinals", null: false
+    t.datetime "crystallogenics", precision: nil
+    t.datetime "visuosensories", precision: nil
+  end
+
+  create_table "puppilies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "glens", limit: 36, null: false
+    t.datetime "tollpennies", precision: nil
+    t.datetime "vanishments", precision: nil
+    t.string "pseudosweatings", limit: 36, null: false
+    t.string "backstrings", null: false
+    t.string "temporarinesses", null: false
+  end
+
+  create_table "puriris", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "etherifies", null: false
+    t.bigint "unslaggeds", null: false
+    t.datetime "staidlies", precision: nil
+    t.datetime "trophylesses", precision: nil
+  end
+
+  create_table "purlmen", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "protriaenes"
+    t.bigint "ethnographicallies"
+    t.decimal "starvers", precision: 16, scale: 2, default: "0.0"
+    t.decimal "hemautographics", precision: 6, scale: 3, default: "0.0"
+    t.boolean "hypsophyllous", default: true
+    t.datetime "sosos", precision: nil, null: false
+    t.datetime "exorbitations", precision: nil, null: false
+  end
+
+  create_table "purples", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "ramsches", null: false
+    t.bigint "nuttallioses"
+    t.decimal "cyanohydrins", precision: 16, scale: 2, default: "0.0", null: false
+    t.datetime "expediteds", precision: nil, null: false
+    t.datetime "gurgles", precision: nil, null: false
+  end
+
+  create_table "putriforms", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "liberalities", null: false
+    t.string "meroblastics"
+    t.integer "hotheadeds", limit: 1
+    t.datetime "inkstones", precision: nil, null: false
+    t.datetime "dipneustals", precision: nil, null: false
+  end
+
+  create_table "puttiers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "semidomestics", null: false
+    t.boolean "unannoyings", default: false
+    t.datetime "toffeemen", precision: nil
+    t.datetime "pyrolaceaes", precision: nil
+    t.integer "transpirables", limit: 1
+    t.boolean "gullishlies", default: false
+    t.boolean "untalkings", default: false
+    t.boolean "scourways", default: false
+    t.boolean "interuniversities", default: false, null: false
+  end
+
+  create_table "pyemia", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "sirenicals", null: false
+    t.bigint "nappeds", null: false
+    t.boolean "spurmoneys", default: false, null: false
+    t.bigint "weaponsmithies"
+    t.datetime "cochineals", precision: nil, null: false
+    t.datetime "chilognathas", precision: nil, default: "3000-01-01 00:00:00"
+    t.bigint "mulctuaries", null: false
+    t.bigint "piculets"
+    t.integer "impars", limit: 2, null: false
+    t.integer "uncapacious", limit: 1
+    t.integer "stingproofs", limit: 1
+    t.integer "quirkishes", limit: 1
+  end
+
+  create_table "pyophylactics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "sacrileges", limit: 36, null: false
+    t.boolean "mucopus", default: true, null: false
+    t.string "tekkintzis", null: false
+    t.bigint "genecologicallies"
+    t.datetime "surpassables", precision: nil
+    t.datetime "benzotrifurans", precision: nil
+  end
+
+  create_table "pyrocottons", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.decimal "historiographers", precision: 16, scale: 2, default: "0.0", null: false
+    t.bigint "pectinals", null: false
+    t.date "screenables", null: false
+    t.bigint "hautboys"
+    t.datetime "punctulateds", precision: nil, null: false
+    t.datetime "trithings", precision: nil, null: false
+  end
+
+  create_table "pyroscopes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.integer "preaccommodatings", limit: 1
+    t.bigint "zoogonics"
+    t.decimal "symbolologies", precision: 16, scale: 2
+    t.decimal "foumarts", precision: 16, scale: 2
+    t.string "pathopsychologies"
+    t.date "umbriferous"
+    t.string "rumblings"
+    t.string "antipathizes"
+    t.string "megawatts"
+    t.string "pygopodous"
+    t.string "gerres"
+    t.string "amylins"
+    t.string "xis"
+    t.string "jeopardizes"
+    t.string "commissionaires"
+    t.string "incomplexes"
+    t.string "heedies"
+    t.string "depasturables"
+    t.string "tiddlings"
+    t.string "papboats"
+    t.string "perispermatitis"
+    t.string "intolerantlies"
+    t.string "vesturers"
+    t.string "yajnas"
+    t.string "decimators"
+    t.string "copts"
+    t.string "ebonizes"
+    t.string "hypognathisms"
+    t.bigint "xerophilous"
+    t.string "scarrers"
+    t.bigint "pettables"
+    t.bigint "ovaries"
+    t.string "chironomids"
+    t.string "various"
+    t.datetime "coracobrachialis", precision: nil
+    t.datetime "lachenalia", precision: nil
+    t.bigint "inconvincedlies"
+    t.text "theoretics"
+    t.string "ferrichlorides"
+    t.string "nizams"
+    t.string "thermoanesthesia"
+    t.string "involucrums"
+  end
+
+  create_table "pythonomorphas", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "bakeovens"
+    t.string "gametoids"
+    t.string "testifies"
+    t.string "neoterics"
+    t.string "homotypicals"
+    t.datetime "participates", precision: nil
+    t.datetime "swellishnesses", precision: nil
+    t.string "miseducations", limit: 36
+    t.bigint "physeters"
+  end
+
+  create_table "quads", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "cortexes", null: false
+    t.bigint "cledonisms", null: false
+    t.bigint "gristmillings", null: false
+    t.bigint "turnstones", null: false
+    t.integer "pences", null: false
+    t.integer "uncommunicatives", null: false
+    t.datetime "galahs", precision: nil
+    t.text "antereformations", null: false
+    t.text "anemia", null: false
+    t.datetime "unrhetoricallies", precision: nil, null: false
+    t.datetime "nonurbans", precision: nil, null: false
+    t.text "sulfathiazoles", null: false
+    t.text "equids", null: false
+  end
+
+  create_table "quartzites", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "autocorrosions", null: false
+    t.string "jacobinicallies", null: false
+    t.string "address_line_1", null: false
+    t.string "address_line_2"
+    t.string "address_line_3"
+    t.string "painfullies", null: false
+    t.string "huashis", null: false
+    t.string "cashels", null: false
+    t.string "rufescents", null: false
+    t.string "hemoscopes", null: false
+    t.string "terrestrialnesses", null: false
+    t.string "redisseises", null: false
+    t.datetime "gruns", precision: nil
+    t.datetime "irradicates", precision: nil
+  end
+
+  create_table "quatrocentists", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "splashes", null: false
+    t.integer "constructs", limit: 1
+    t.integer "flackers", limit: 1
+    t.datetime "shires", precision: nil
+    t.datetime "pseudoconcludes", precision: nil
+    t.datetime "myriapodas", precision: nil
+    t.datetime "bungarus", precision: nil
+    t.datetime "rakeages", precision: nil
+    t.datetime "pinelands", precision: nil
+  end
+
+  create_table "quinovates", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "campulitropous", limit: 36, null: false
+    t.bigint "undrivens", null: false
+    t.bigint "rugbies", null: false
+    t.string "marauders"
+    t.datetime "eggeaters", precision: nil
+    t.datetime "niggards", precision: nil
+    t.string "bundies"
+  end
+
+  create_table "quintessentialities", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "unuprightnesses"
+    t.string "ovoviviparities"
+    t.decimal "malaxages", precision: 16, scale: 2, null: false
+    t.decimal "gonnardites", precision: 16, scale: 2, null: false
+    t.bigint "handygrips"
+    t.datetime "skateables", precision: nil
+    t.datetime "metabolous", precision: nil
+    t.bigint "cycloganoideis"
+    t.boolean "myoepicardials", default: false
+    t.datetime "atterns", precision: nil
+    t.datetime "thwarts", precision: nil
+    t.boolean "cabiris", default: false, null: false
+    t.integer "constrainables", default: 0, null: false
+    t.integer "palaeolithicals", limit: 1, default: 0, null: false
+    t.boolean "etiquetticals", default: false
+    t.integer "orbitars", limit: 1, default: 0, null: false
+    t.string "syntelomes"
+    t.bigint "gedackts"
+    t.boolean "orangewoods", default: false
+    t.datetime "becards", precision: nil
+    t.string "praeacetabulars"
+    t.integer "bridgekeepers", limit: 1
+    t.integer "thysanourous", limit: 1
+    t.decimal "credit_limit_v2", precision: 16, scale: 2
+    t.boolean "pledgors", default: false
+    t.decimal "birdclappers", precision: 16, scale: 2, default: "0.0"
+  end
+
+  create_table "quirquinchos", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "unpurchasables", default: "USD"
+    t.decimal "grandees", precision: 16, scale: 2
+    t.date "omnisufficiencies", null: false
+    t.string "esterellites"
+    t.string "codenizations"
+    t.string "fibsters"
+    t.string "beneficiary_bank_address_line_1"
+    t.string "beneficiary_bank_address_line_2"
+    t.string "nonpunishments"
+    t.string "platformisms"
+    t.string "cauliforms"
+    t.string "sintoists"
+    t.bigint "scyphates"
+    t.string "asymptotics"
+    t.text "lessns"
+    t.bigint "heteromastigates"
+    t.string "metathetics"
+    t.bigint "displeasers"
+    t.string "solidists"
+    t.datetime "linesmen", precision: nil
+    t.datetime "usualisms", precision: nil
+    t.decimal "counterreligions", precision: 16, scale: 2, default: "0.0"
+    t.decimal "demigauntlets", precision: 16, scale: 2
+    t.bigint "proptoses"
+    t.integer "beaumontia", limit: 1, default: 1
+    t.string "stomatodaeals"
+    t.bigint "undergraduatishes"
+    t.string "bengalics"
+    t.string "diagnosticates"
+    t.string "tetragonallies"
+  end
+
+  create_table "ramets", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "haemodilutions", limit: 36, null: false
+    t.bigint "displeasings", null: false
+    t.boolean "damnings", default: false
+    t.datetime "alectoridines", precision: nil, null: false
+    t.datetime "sphaerococcaceous", precision: nil, null: false
+  end
+
+  create_table "ramusis", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "carnaubas"
+    t.bigint "pseudophilosophicals"
+    t.string "versifiables"
+    t.string "sorgos"
+    t.string "shadberries"
+    t.string "jasminewoods"
+    t.text "legpullings"
+    t.boolean "truthlikenesses"
+    t.boolean "postpubescents"
+    t.string "epicycles"
+    t.string "bdelloids"
+    t.datetime "friendlessnesses", precision: nil, null: false
+    t.datetime "hexeris", precision: nil, null: false
+    t.datetime "substratoses", precision: nil
+    t.string "unartfuls"
+  end
+
+  create_table "ranges", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "anhydrites"
+    t.datetime "coregnants", precision: nil
+    t.datetime "marmaladies", precision: nil
+    t.datetime "constitutionalists", precision: nil
+  end
+
+  create_table "rapefuls", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "improvisatorizes", null: false
+    t.bigint "piperaceaes", null: false
+    t.datetime "crankums", precision: nil, null: false
+    t.datetime "sesquipedals", precision: nil
+    t.datetime "walers", precision: nil, null: false
+    t.datetime "tocks", precision: nil, null: false
+  end
+
+  create_table "rapscallionisms", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "colorings", null: false
+    t.string "termes", limit: 36, null: false
+    t.bigint "marginates"
+    t.string "uncontemplateds", null: false
+    t.datetime "stealies", precision: nil, null: false
+    t.datetime "sulphureosuffuseds", precision: nil, null: false
+  end
+
+  create_table "reappearances", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "aethalioids", null: false
+    t.bigint "fluellites", null: false
+    t.string "heterogenicities", null: false
+    t.bigint "sheenlies", null: false
+    t.datetime "ponticellos", precision: nil
+    t.datetime "anatomicophysiologics", precision: nil
+    t.decimal "remotenesses", precision: 16, scale: 2, default: "0.0", null: false
+  end
+
+  create_table "reapplications", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "appendixes", null: false
+    t.bigint "ahousahts", null: false
+    t.datetime "presbycouses", precision: nil
+    t.datetime "undeadeneds", precision: nil
+    t.datetime "ervenholders", precision: nil
+  end
+
+  create_table "reastinesses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "eriometers"
+    t.bigint "yenders"
+    t.string "tychisms"
+    t.date "flotillas"
+    t.date "contrariouslies"
+    t.date "periumbilicals"
+    t.date "pats"
+    t.decimal "cadinenes", precision: 16, scale: 2, default: "0.0"
+    t.datetime "mesotroches", precision: nil
+    t.datetime "inertnesses", precision: nil
+    t.string "soulacks"
+    t.string "dizens"
+    t.string "subs"
+    t.date "noncommittals"
+    t.bigint "scuttlings"
+    t.boolean "pippinfaces", default: false
+    t.string "hydroperiods", limit: 36, null: false
+  end
+
+  create_table "rebrandishes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.date "platyrrhinies", null: false
+    t.datetime "supersuperabundances", precision: nil, null: false
+    t.decimal "soleas", precision: 16, scale: 6, null: false
+    t.decimal "overdeepens", precision: 16, scale: 6, null: false
+    t.decimal "onymizes", precision: 16, scale: 6, null: false
+    t.string "lushies", null: false
+    t.string "anapsidans", null: false
+    t.string "pseudoconglomerations", limit: 36, null: false
+    t.datetime "borderisms", precision: nil
+    t.datetime "predeliberatelies", precision: nil
+    t.bigint "branchiostegals", null: false
+    t.bigint "outflungs", null: false
+    t.bigint "delusters", null: false
+    t.bigint "rubicundities", null: false
+  end
+
+  create_table "rebroadcasts", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "besanctifies", limit: 36, null: false
+    t.string "indefinables", limit: 36, null: false
+    t.bigint "harmonicalnesses", null: false
+    t.string "switchbackers", null: false
+    t.string "stercorianisms"
+    t.string "magicalizes"
+    t.string "takoses"
+    t.string "antasthmatics"
+    t.string "apheticallies", null: false
+    t.string "risiblies"
+    t.string "superimpendings"
+    t.string "parvolins"
+    t.string "acetobacters"
+    t.datetime "hyperobtrusives", precision: nil
+    t.datetime "imbrues", precision: nil
+  end
+
+  create_table "rebundles", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "hellenophiles", limit: 36, null: false
+    t.string "paraquinones", null: false
+    t.integer "earthfasts", null: false
+    t.integer "amblotics", null: false
+    t.datetime "meggies", precision: nil
+    t.datetime "vaginolabials", precision: nil
+  end
+
+  create_table "reburns", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "throatworts", null: false
+    t.string "concoctions", null: false
+    t.integer "terris", default: 9100, null: false
+    t.string "isothermous", null: false
+    t.string "tchetnitsis", null: false
+    t.datetime "achroodextrinases", precision: nil
+    t.datetime "jezebels", precision: nil
+  end
+
+  create_table "reckons", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "thunderfuls", null: false
+    t.bigint "unelementals", null: false
+  end
+
+  create_table "recontends", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "recipient_1", null: false
+    t.string "recipient_2"
+    t.string "street_1", null: false
+    t.string "street_2"
+    t.string "giggledoms", null: false
+    t.string "bjornes", null: false
+    t.string "cordeaus", null: false
+    t.string "unabidings"
+    t.datetime "departmentalizes", precision: nil
+    t.datetime "alcoholmetrics", precision: nil
+  end
+
+  create_table "recontracts", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "eightieths", null: false
+    t.datetime "redbreasts", precision: nil, null: false
+    t.datetime "marmorateds", precision: nil, null: false
+    t.string "jurylesses"
+    t.string "unpriestlies", default: "panda", null: false
+  end
+
+  create_table "recordatives", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "aphthics", null: false
+    t.bigint "pseudoblepsia"
+    t.string "sibredes", null: false
+    t.string "catallacticallies"
+    t.datetime "foreconsiders", precision: nil, null: false
+    t.datetime "cyclograms", precision: nil, null: false
+    t.string "argyropelecus", null: false
+    t.bigint "whilks"
+    t.string "pinniferous"
+    t.string "leftwards"
+    t.string "recusatives"
+  end
+
+  create_table "rectectomies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.integer "ectoplasms", default: 0, null: false
+    t.bigint "feifs", null: false
+    t.integer "remisslies", null: false
+    t.datetime "sculptographs", precision: nil
+    t.datetime "phelloplastics", precision: nil
+    t.bigint "undishearteneds"
+    t.string "spectaclemakings"
+  end
+
+  create_table "redoubles", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "crankilies", null: false
+    t.bigint "congenericals"
+    t.datetime "kadmis", precision: nil
+    t.datetime "inopportunes", precision: nil
+    t.string "bookbindings"
+  end
+
+  create_table "regretfulnesses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "roids", null: false
+    t.string "photochromolithographs", null: false
+    t.date "feasances", null: false
+    t.string "flixes", null: false
+    t.datetime "possessivals", precision: nil
+    t.datetime "hypaethrums", precision: nil
+  end
+
+  create_table "regs", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "unerrablenesses", null: false
+    t.string "prereconciles", null: false
+    t.date "feastens"
+    t.date "tchicks"
+    t.string "pentagyns", null: false
+    t.string "calendrics", null: false
+    t.bigint "overminutes"
+    t.bigint "capkins"
+    t.bigint "wiggens"
+    t.datetime "procoracoidals", precision: nil, null: false
+    t.datetime "stonepeckers", precision: nil, null: false
+    t.bigint "molompis"
+    t.boolean "nauropometers"
+    t.bigint "fibrochondrosteals"
+    t.string "chiefs", null: false
+    t.boolean "whitfinches", null: false
+  end
+
+  create_table "reifies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "rubiators"
+    t.integer "laevotartarics"
+    t.datetime "mojos", precision: nil
+    t.datetime "cenobia", precision: nil
+    t.string "dezincations"
+  end
+
+  create_table "reobservations", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.datetime "ridgeplates", precision: nil, null: false
+    t.datetime "slobberers", precision: nil, null: false
+  end
+
+  create_table "repassages", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.integer "gossypines", null: false
+    t.decimal "dorics", precision: 16, scale: 6, null: false
+    t.decimal "funniments", precision: 16, scale: 6
+    t.bigint "overtravels", null: false
+    t.datetime "mythopastorals", precision: nil
+    t.datetime "gilbertages", precision: nil
+    t.decimal "clans", precision: 16, scale: 6
+    t.decimal "anaerobionts", precision: 16, scale: 6
+  end
+
+  create_table "repieces", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "pseudoscholastics"
+    t.string "wocheinites"
+    t.datetime "semiterrestrials", precision: nil
+    t.datetime "sinuouslies", precision: nil
+    t.boolean "pregreetings", default: false, null: false
+    t.datetime "parkers", precision: nil
+    t.string "lamziektes"
+  end
+
+  create_table "repropitiates", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "smuggishlies", limit: 36, null: false
+    t.string "retiariaes", limit: 36, null: false
+    t.boolean "wildeds", default: true, null: false
+    t.boolean "festinations", default: false, null: false
+    t.string "quackishlies"
+    t.string "wisecrackeries"
+    t.string "nahuans"
+    t.string "semitonals"
+    t.string "phalangiforms"
+    t.boolean "strabismometries", default: false, null: false
+    t.datetime "bahiaites", precision: nil
+    t.datetime "unclericalnesses", precision: nil
+    t.boolean "zygobranches", default: true, null: false
+    t.string "sleepings"
+    t.integer "cotta", default: 0, null: false
+    t.boolean "melodeons"
+    t.text "hyperapophyseals"
+    t.text "unbettereds"
+  end
+
+  create_table "rerackers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "juxtapylorics"
+    t.string "podostomatous"
+    t.integer "unjilteds"
+    t.datetime "reactionarisms", precision: nil
+    t.datetime "aciculateds", precision: nil, null: false
+    t.datetime "dufoils", precision: nil, null: false
+    t.string "masonics"
+  end
+
+  create_table "reracks", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "amesites", limit: 36, null: false
+    t.bigint "augurs", null: false
+    t.string "deserves", limit: 36, null: false
+    t.bigint "provisionalnesses"
+    t.string "extricablies", limit: 36
+    t.bigint "sublethals", null: false
+    t.string "aladfars", limit: 36, null: false
+    t.date "pseudostalactiticals", null: false
+    t.string "delomorphous", null: false
+    t.string "courts", null: false
+    t.decimal "revelationists", precision: 16, scale: 2, null: false
+    t.decimal "mycetophilidaes", precision: 16, scale: 2, null: false
+    t.decimal "underdevelops", precision: 16, scale: 2, null: false
+    t.decimal "pipkins", precision: 16, scale: 2, null: false
+    t.decimal "modalists", precision: 16, scale: 2, null: false
+    t.boolean "unthumpeds", null: false
+    t.datetime "scalewises", precision: nil, null: false
+    t.datetime "ethaldehydes", precision: nil, null: false
+  end
+
+  create_table "resawers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "centerwards", limit: 36, null: false
+    t.bigint "postdigitals", null: false
+    t.bigint "oes"
+    t.bigint "presolutions"
+    t.bigint "cuppings"
+    t.bigint "oligidria"
+    t.boolean "unrebellious"
+    t.boolean "soars"
+    t.date "atropas"
+    t.string "undernsongs", null: false
+    t.string "heterologous"
+    t.string "reunifications"
+    t.string "sibbers"
+    t.string "rhodeswoods"
+    t.string "unrevengings"
+    t.string "unpredacious"
+    t.string "overuberous"
+    t.string "limekilns"
+    t.string "pseudomalaria"
+    t.string "similizes"
+    t.string "prickings"
+    t.decimal "psychicals", precision: 16, scale: 2
+    t.string "shampooers"
+    t.string "forereadings"
+    t.string "internasals"
+    t.decimal "importuners", precision: 16, scale: 2
+    t.string "swathables"
+    t.datetime "necrophilistics", precision: nil
+    t.datetime "inconsolablenesses", precision: nil
+    t.boolean "subchordals"
+    t.string "afters"
+    t.string "bepastes", default: "basics", null: false
+    t.bigint "tannaims"
+    t.boolean "pretabulates", default: true, null: false
+    t.boolean "subobtuses", default: false, null: false
+    t.integer "meadowsweets", default: 0, null: false
+    t.date "coeffluentials"
+    t.string "jasponyxes"
+  end
+
+  create_table "resignals", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "quinicines", null: false
+    t.bigint "unremonstratings", null: false
+    t.string "nonrevaluations", limit: 36, null: false
+    t.datetime "hydatoscopies", precision: nil, null: false
+    t.datetime "retotals", precision: nil, null: false
+  end
+
+  create_table "resolidifications", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "leptonecroses"
+    t.string "misperforms"
+    t.string "phallicals"
+    t.string "interbrings"
+    t.datetime "rabids", precision: nil, null: false
+    t.datetime "lanternists", precision: nil, null: false
+    t.date "argentometries"
+    t.string "conoplains"
+    t.decimal "aversants", precision: 16, scale: 2, default: "0.0"
+    t.decimal "collectivelies", precision: 16, scale: 2, default: "0.0"
+    t.string "tonsilloliths"
+    t.string "rosines"
+    t.string "zoileans"
+    t.bigint "stanchnesses"
+    t.string "unmixables"
+  end
+
+  create_table "resolutenesses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "definablies", null: false
+    t.bigint "acquittances"
+    t.bigint "autostages"
+    t.string "salvadoras", default: "client_billed"
+    t.boolean "shrifts", default: false
+    t.boolean "unparrels", default: false
+    t.bigint "myopathia"
+    t.string "polyangulars", limit: 36, null: false
+    t.datetime "bugans", precision: nil
+    t.datetime "nautilicones", precision: nil
+    t.string "marattiaceaes", default: "Client"
+    t.string "precedentables", default: "None"
+  end
+
+  create_table "resources", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "pseudocysts", limit: 36, null: false
+    t.bigint "preconveyals", null: false
+    t.bigint "plumpnesses", null: false
+    t.datetime "mossis", precision: nil
+    t.datetime "stereornithes", precision: nil
+  end
+
+  create_table "respectables", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "nonchalants", limit: 36, null: false
+    t.string "rubuses", null: false
+    t.string "cymophenols", limit: 36, null: false
+    t.string "landwards", limit: 36
+    t.datetime "lowlanders", precision: nil, null: false
+    t.datetime "recurls", precision: nil, null: false
+  end
+
+  create_table "respiratoreds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "ciseles"
+    t.string "amalfians"
+    t.integer "hexagrammos"
+    t.integer "ambassadresses"
+    t.decimal "oogeneses", precision: 16, scale: 2
+    t.decimal "willowlikes", precision: 16, scale: 2
+    t.string "teacherdoms"
+    t.string "spasmodicallies"
+    t.string "untextuals"
+    t.datetime "terries", precision: nil
+    t.datetime "persuadedlies", precision: nil
+    t.boolean "comedists", default: false
+  end
+
+  create_table "retentives", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "ramifies", null: false
+    t.decimal "dipteras", precision: 16, scale: 2, null: false
+    t.decimal "readmissions", precision: 16, scale: 2, null: false
+    t.decimal "cuticulates", precision: 16, scale: 2, null: false
+    t.decimal "myrmecologicals", precision: 16, scale: 2, null: false
+    t.decimal "polyatomicities", precision: 16, scale: 2, null: false
+    t.integer "palaeodictyopterous", null: false
+    t.datetime "incommutabilities", precision: nil, null: false
+    t.datetime "peripherophoses", precision: nil, null: false
+  end
+
+  create_table "reuchlinians", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "pimientos"
+    t.string "sacculateds"
+    t.string "smooriches"
+    t.text "rupestrines"
+    t.datetime "unstimulatings", precision: nil
+    t.datetime "alburnous"
+    t.string "silicotics", default: "panda", null: false
+    t.boolean "centos", default: true, null: false
+  end
+
+  create_table "revenants", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "overcontracts", limit: 36, null: false
+    t.bigint "wongas", null: false
+    t.bigint "tortulous"
+    t.datetime "tamils", precision: nil, null: false
+    t.datetime "wouldnts", precision: nil, null: false
+    t.string "cellateds", null: false
+    t.datetime "graphiologists", precision: nil
+    t.datetime "thermomagnetics", precision: nil
+  end
+
+  create_table "rewhirls", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "myatonies", null: false
+    t.date "hubbites", null: false
+    t.date "parovariotomies"
+    t.decimal "epiclidals", precision: 16, scale: 2, default: "0.0"
+    t.datetime "caribbeans", precision: nil
+    t.datetime "melancholists", precision: nil
+    t.date "subfixes", null: false
+  end
+
+  create_table "reyouths", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "rabins", null: false
+    t.string "rationalisticisms", null: false
+    t.bigint "liplesses"
+    t.datetime "nonoccurrences", precision: nil
+    t.datetime "caesareans", precision: nil
+    t.boolean "moskeneers", default: false, null: false
+    t.string "marxists"
+    t.string "protectings"
+    t.integer "chamkannis"
+    t.datetime "ericoids", precision: nil
+  end
+
+  create_table "rhabditiforms", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "corectors", null: false
+    t.boolean "headstrongs", default: false, null: false
+    t.boolean "coccygerectors", default: false, null: false
+    t.bigint "semipyramidals"
+    t.datetime "bustics", precision: nil, null: false
+    t.datetime "understrungs", precision: nil, null: false
+    t.boolean "rephotographs", default: false, null: false
+  end
+
+  create_table "rhinologies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "nonconducives"
+    t.decimal "necks", precision: 16, scale: 15
+    t.text "flapperhoods"
+    t.datetime "soursops", precision: nil
+    t.datetime "outparts", precision: nil
+    t.decimal "pelikes", precision: 16, scale: 15
+  end
+
+  create_table "rhinos", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "vertibilities", null: false
+    t.bigint "haemoconcentrations", null: false
+    t.string "moonlets", null: false
+    t.text "amalgamatizes"
+    t.datetime "misotramontanisms", precision: nil
+    t.datetime "asweats", precision: nil
+    t.string "pantoscopes"
+  end
+
+  create_table "rhizostomes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "floricins"
+    t.bigint "kaikaras"
+    t.string "rubs"
+    t.datetime "kapais", precision: nil
+    t.datetime "glottiscopes", precision: nil
+    t.string "disrudders"
+    t.boolean "grandstanders"
+    t.datetime "custodianships", precision: nil
+    t.date "reaffiliates"
+  end
+
+  create_table "rhodes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "postliminaries", null: false
+    t.string "megachiles", null: false
+    t.string "transplendentlies", null: false
+    t.string "furiosos"
+    t.datetime "numerations", precision: nil
+    t.datetime "homeopathicallies", precision: nil
+    t.string "vougeots", limit: 36
+  end
+
+  create_table "ripples", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "navipendulums", null: false
+    t.integer "extracutaneous", null: false
+    t.datetime "dressers", precision: nil, null: false
+    t.datetime "undevoureds", precision: nil, null: false
+  end
+
+  create_table "roburites", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "spileholes", null: false
+    t.bigint "cuffyisms", null: false
+    t.datetime "tailings", precision: nil
+    t.datetime "cytophysiologies", precision: nil
+  end
+
+  create_table "romancicals", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "scrapworks", limit: 36, null: false
+    t.bigint "slaughteringlies", null: false
+    t.decimal "origenists", precision: 16, scale: 2, null: false
+    t.decimal "presessions", precision: 16, scale: 2, null: false
+    t.string "proportionallies", limit: 3, null: false
+    t.bigint "prases", null: false
+    t.string "branchiostomids", null: false
+    t.string "hemicyclics", null: false
+    t.string "experimentalizes", null: false
+    t.datetime "beauxes", precision: nil
+    t.datetime "colias", precision: nil
+    t.boolean "glors", default: false, null: false
+  end
+
+  create_table "roundworms", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "arterials"
+    t.bigint "suprahumen"
+    t.boolean "underboughts", default: false
+    t.datetime "sleets", precision: nil
+    t.integer "polystomellas", default: 0
+    t.datetime "phosphosilicates", precision: nil
+    t.datetime "nonvertebrals", precision: nil
+  end
+
+  create_table "rouns", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "conglomeratics", null: false
+    t.bigint "attemperates", null: false
+    t.string "ossifiers", null: false
+    t.datetime "palaeoanthropologies", precision: nil
+    t.datetime "testudineals", precision: nil
+  end
+
+  create_table "rouseabouts", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "adenoneurals", limit: 64, null: false, collation: "ascii_general_ci"
+    t.string "quintons", limit: 64, collation: "ascii_general_ci"
+    t.integer "rhynchocoelous", limit: 3, default: 7200, null: false, unsigned: true
+    t.datetime "slabs", precision: nil
+    t.datetime "macanas", precision: nil, null: false
+    t.text "pendulations", null: false
+    t.bigint "predisrupts", null: false
+    t.bigint "acuminates", null: false
+    t.string "hesitantlies", limit: 64, collation: "ascii_general_ci"
+    t.bigint "fiddlesticks"
+    t.string "staps"
+    t.bigint "disaccustomeds"
+    t.boolean "perimetricallies", default: false, null: false
+    t.boolean "titanotheria", default: false, null: false
+  end
+
+  create_table "rousseauists", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "elephantidaes"
+    t.integer "trivalencies", limit: 2
+    t.integer "enarches", limit: 2
+    t.boolean "balachongs"
+    t.boolean "idryls"
+    t.boolean "floppilies"
+    t.boolean "trunkbacks"
+    t.datetime "capivis", precision: nil
+    t.datetime "ramonas", precision: nil
+  end
+
+  create_table "ruficoccins", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "sardonics", null: false
+    t.datetime "anchises", precision: nil
+    t.datetime "sarcoglia", precision: nil
+  end
+
+  create_table "ruinations", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "amethystines"
+    t.string "ceteraches"
+    t.text "ravenalas"
+    t.datetime "higgles", precision: nil, null: false
+    t.datetime "downbears", precision: nil, null: false
+    t.boolean "transfixtures"
+    t.string "rebuffablies", default: "", null: false
+    t.string "entozoologists", default: "", null: false
+    t.string "punkahs", default: "", null: false
+  end
+
+  create_table "russines", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "bucculas", limit: 36, null: false
+    t.datetime "evaluations", precision: nil, null: false
+    t.datetime "resultancies", precision: nil, null: false
+    t.datetime "munychia", precision: nil
+    t.bigint "shotties", null: false
+    t.date "dysphonia", null: false
+  end
+
+  create_table "ruthlesslies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "tostons", null: false
+    t.string "sexcentenaries", null: false
+    t.string "canadas", null: false
+    t.datetime "zygophyllaceous", precision: nil
+    t.datetime "xanthopterins", precision: nil
+    t.integer "significates"
+  end
+
+  create_table "sabdariffas", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "tanquens"
+    t.bigint "woodenwares"
+    t.string "lunches"
+    t.decimal "hemianopsia", precision: 16, scale: 2
+    t.string "tillandsia"
+    t.string "upsups"
+    t.string "filieties"
+    t.string "bank_address_1"
+    t.string "taxeopodies"
+    t.string "cosegments"
+    t.string "unsmoothlies"
+    t.datetime "aistopodes", precision: nil
+    t.datetime "acuations", precision: nil
+    t.bigint "papios"
+    t.string "meromyarians"
+  end
+
+  create_table "sablefishes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "coronillins", limit: 36, null: false
+    t.bigint "prevalences", null: false
+    t.bigint "forgots", null: false
+    t.string "acicularlies", null: false
+    t.string "psychophysicists"
+    t.string "braids"
+    t.boolean "lymphadenopathies"
+    t.datetime "glacializes", precision: nil, null: false
+    t.datetime "untransitories", precision: nil, null: false
+  end
+
+  create_table "sages", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "photoionizations"
+    t.bigint "embrittlements"
+    t.decimal "noncorrespondences", precision: 16, scale: 2, default: "0.0"
+    t.date "streptolysins"
+    t.datetime "berengelites", precision: nil, null: false
+    t.datetime "multilobates", precision: nil, null: false
+  end
+
+  create_table "sagittids", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "nonforms", null: false
+    t.decimal "delphinites", precision: 16, scale: 2, default: "0.0"
+    t.bigint "ulemas", null: false
+    t.datetime "antispreadings", precision: nil
+    t.datetime "pillars", precision: nil
+  end
+
+  create_table "sailormen", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "bottomers", null: false
+    t.string "patripassianists", null: false
+    t.text "setoffs"
+    t.string "fogscoffers", limit: 36
+    t.datetime "gophers", precision: nil
+    t.datetime "suffrages", precision: nil
+  end
+
+  create_table "sailplanes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "mountainsides", limit: 36, null: false
+    t.string "dooms", limit: 36, null: false
+    t.datetime "guardianlesses", precision: nil
+    t.datetime "brightworks", precision: nil
+  end
+
+  create_table "salses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "mazdakeans"
+    t.string "nondivisionals"
+    t.datetime "sipunculaceans", precision: nil
+    t.datetime "perduringlies", precision: nil
+  end
+
+  create_table "salsillas", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "glandes", limit: 36, null: false
+    t.string "discussibles", limit: 36, null: false
+    t.string "uncodeds", limit: 36, null: false
+    t.datetime "terrages", precision: nil, null: false
+    t.datetime "changers", precision: nil, null: false
+    t.datetime "bandakas", precision: nil
+    t.text "theatries", null: false
+  end
+
+  create_table "salvagings", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "carrotinesses", null: false
+    t.string "taverts", limit: 36, null: false
+    t.bigint "platterfaces", null: false
+    t.datetime "disilanes", precision: nil, null: false
+    t.datetime "zeds", precision: nil, null: false
+  end
+
+  create_table "samsiens", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "tidelessnesses", limit: 36, null: false
+    t.bigint "younglies", null: false
+    t.string "syphilomatous"
+    t.string "misidentifications"
+    t.datetime "hollandishes", precision: nil
+    t.integer "plumularia", null: false
+    t.datetime "balancings", precision: nil
+    t.datetime "blindings", precision: nil
+    t.string "uneaths"
+  end
+
+  create_table "sanablenesses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "circumfulgents", null: false
+    t.string "afterstates", limit: 36, null: false
+    t.decimal "empaistics", precision: 16, scale: 2, default: "0.0", null: false
+    t.decimal "sexloculars", precision: 16, scale: 6, default: "0.0", null: false
+    t.datetime "ongoings", precision: nil
+    t.datetime "ovalishes", precision: nil
+    t.boolean "subcollectors", null: false
+  end
+
+  create_table "sanctionlesses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "keepables"
+    t.string "concubinates"
+    t.bigint "exsuctions"
+    t.datetime "litterers", precision: nil, null: false
+    t.datetime "elderwoods", precision: nil, null: false
+    t.datetime "quitteds", precision: nil
+    t.string "celtologues"
+    t.text "interfertiles"
+    t.text "counterproposals"
+    t.text "decapitations"
+    t.text "catwalks"
+    t.string "immanifestnesses"
+  end
+
+  create_table "saponaria", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "electrooptics", limit: 36, null: false
+    t.bigint "unforciblies", null: false
+    t.string "catechumen", null: false
+    t.decimal "desocializes", precision: 16, scale: 2, default: "0.0", null: false
+    t.string "chalinidaes", null: false
+    t.datetime "gentlemanizes", precision: nil
+    t.datetime "minervics", precision: nil
+  end
+
+  create_table "sassanids", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "pythagorics", limit: 36, null: false
+    t.bigint "fouths", null: false
+    t.bigint "autarkies", null: false
+    t.date "energics", null: false
+    t.decimal "citadels", precision: 16, scale: 2
+    t.datetime "clavicles", precision: nil
+    t.datetime "psittaciformes", precision: nil
+    t.bigint "electrophysiologicals"
+    t.decimal "refixes", precision: 16, scale: 2
+    t.decimal "verrucas", precision: 16, scale: 2
+  end
+
+  create_table "sauceboxes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "misguggles", null: false
+    t.string "insubordinatelies", limit: 36, null: false
+    t.datetime "colossallies", precision: nil
+    t.datetime "poolies", precision: nil
+    t.string "unit21_id"
+    t.string "rowdies"
+    t.datetime "paramastoids", precision: nil
+  end
+
+  create_table "scabbles", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "weiselbergites", null: false
+    t.date "illusibles", null: false
+    t.date "deuterovitelloses", null: false
+    t.decimal "nevels", precision: 16, scale: 2, null: false
+    t.decimal "glossolabiolaryngeals", precision: 16, scale: 2
+    t.text "unsupposeds", null: false
+    t.bigint "schizonemerteas"
+    t.datetime "meatinesses", precision: nil, null: false
+    t.datetime "uromeres", precision: nil, null: false
+    t.string "cerises", null: false
+    t.boolean "boraxes", default: false, null: false
+    t.boolean "petricolas", default: false, null: false
+    t.string "butlers"
+    t.string "ars"
+  end
+
+  create_table "scalplesses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "duelistics", limit: 36, null: false
+    t.datetime "bacitracins", precision: nil, null: false
+    t.datetime "molimen", precision: nil, null: false
+    t.bigint "cecomorphics", null: false
+    t.bigint "uncognizables", null: false
+    t.date "toadlets", null: false
+    t.date "foreruns"
+  end
+
+  create_table "scandalmongerings", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.datetime "anatomizations", precision: nil, null: false
+    t.datetime "frayings", precision: nil, null: false
+    t.string "olivia", limit: 36, null: false
+    t.bigint "prostatitics", null: false
+    t.boolean "surpassings", null: false
+    t.bigint "antipsorics", null: false
+    t.boolean "matchcoats", null: false
+  end
+
+  create_table "scandics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "decaphyllous", limit: 36, null: false
+    t.string "hybrids", limit: 36, null: false
+    t.string "fenestellas", limit: 36, null: false
+    t.date "indoctrinations", null: false
+    t.date "mainpernables"
+    t.datetime "deformations", precision: nil
+    t.datetime "scrimpinglies", precision: nil
+    t.string "beeches"
+    t.string "epiblastemas", limit: 36
+  end
+
+  create_table "scaphopodous", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "overlightsomes", limit: 36, null: false
+    t.string "tussurs"
+    t.string "chirianas"
+    t.boolean "primordials", default: true, null: false
+    t.integer "packers", null: false
+    t.bigint "sulpharsenics", null: false
+    t.datetime "asceticisms", precision: nil
+    t.datetime "ms", precision: nil
+  end
+
+  create_table "scaraboids", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "uprises", limit: 36, null: false
+    t.string "prudelikes", null: false
+    t.string "unclassablies", null: false
+    t.string "coxarthritis"
+    t.bigint "barkles"
+    t.bigint "illiquids"
+    t.datetime "unwebs", precision: nil, null: false
+    t.datetime "restains", precision: nil, null: false
+  end
+
+  create_table "scareheads", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "indulines", limit: 36, null: false
+    t.string "receptaculitids", limit: 64
+    t.string "triddlers", null: false
+    t.bigint "pyros", null: false
+    t.string "tores", limit: 64, null: false
+    t.string "unpurposelies", limit: 32, null: false
+    t.date "unvaryings", null: false
+    t.date "etiologicals"
+    t.bigint "prolificlies", null: false
+    t.decimal "negrophils", precision: 16, scale: 2, null: false
+    t.boolean "amphodelites"
+    t.date "pokanokets"
+    t.decimal "dolichopsyllidaes", precision: 16, scale: 2
+    t.bigint "skidders"
+    t.string "ethmoids", null: false
+    t.datetime "hippotigris", precision: nil, null: false
+    t.datetime "bigamouslies", precision: nil, null: false
+    t.string "isocheimenals"
+    t.string "sloops"
+    t.string "dyschroia"
+  end
+
+  create_table "scents", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "sextennials", null: false
+    t.date "undebilitatings", null: false
+    t.datetime "tuberculides", precision: nil
+    t.datetime "pteridospermaphyta", precision: nil
+    t.string "laryngotracheals"
+    t.string "paramos", null: false
+  end
+
+  create_table "schmaltzs", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "uninterdicteds", null: false
+    t.string "tames", null: false
+    t.string "cronies", null: false
+    t.datetime "batussis", precision: nil
+    t.datetime "cassinettes", precision: nil, null: false
+    t.datetime "mutualnesses", precision: nil, null: false
+    t.string "allothigenics", limit: 36
+  end
+
+  create_table "scissorsmiths", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "backhandednesses", limit: 36, null: false
+    t.bigint "unroamings", null: false
+    t.integer "exhumators", null: false
+    t.integer "assistencies"
+    t.integer "sniggers", null: false
+    t.datetime "conjugationals", precision: nil, null: false
+    t.datetime "terminations", precision: nil, null: false
+  end
+
+  create_table "sclerocaulies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "perambulates", null: false
+    t.bigint "nutties", null: false
+    t.datetime "shovelards", precision: nil
+    t.datetime "formularizes", precision: nil
+  end
+
+  create_table "sclerodermatales", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "bibliognostics", limit: 36, null: false
+    t.bigint "mangrates", null: false
+    t.string "simpletonishes", null: false
+    t.string "reimburses", null: false
+    t.datetime "garterlesses", precision: nil, null: false
+    t.datetime "hemogenics", precision: nil, null: false
+  end
+
+  create_table "scorpaenoids", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "deozonizes", limit: 36, null: false
+    t.string "engraveds", limit: 36, null: false
+    t.text "viduinaes"
+    t.string "septimetritis", limit: 36
+    t.datetime "unmalignants", precision: nil, null: false
+    t.datetime "oxyopidaes", precision: nil, null: false
+  end
+
+  create_table "scourweeds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "compostures", null: false
+    t.string "phyllopodes", null: false
+    t.text "luscious", null: false
+    t.string "bipontines", null: false
+    t.bigint "applejohns"
+    t.string "pentiodides"
+    t.integer "codes", default: 0, null: false
+    t.datetime "clifflets", precision: nil, null: false
+    t.datetime "persuasibles", precision: nil, null: false
+    t.bigint "diazides"
+    t.string "trixies"
+    t.string "inexistents"
+    t.datetime "interweds", precision: nil
+    t.string "quercetagetins"
+    t.string "nehemiahs", default: "NONE", null: false
+    t.string "unmeddlingnesses", limit: 36
+  end
+
+  create_table "scummers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.date "superuniverses"
+    t.boolean "infracts"
+    t.datetime "cheirotheria", precision: nil, null: false
+    t.datetime "laggeds", precision: nil, null: false
+    t.text "aroars", size: :long
+  end
+
+  create_table "scutulates", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "causeways", limit: 36, null: false
+    t.datetime "osteomalacials", precision: nil
+    t.datetime "trihemiobolions", precision: nil
+    t.string "pennaceous"
+    t.string "apneumatics"
+    t.string "twinelikes"
+    t.string "enslavednesses"
+    t.string "podites"
+    t.bigint "upstrokes", null: false
+    t.text "perstringements"
+  end
+
+  create_table "sebaceous", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "talpidaes", limit: 36, null: false
+    t.integer "becommas"
+    t.bigint "solidungulars", null: false
+    t.datetime "roachbacks", precision: nil
+    t.datetime "girts", precision: nil
+  end
+
+  create_table "seculars", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "semicircumferentors"
+    t.string "baptisia"
+    t.bigint "cancers"
+    t.decimal "excusings", precision: 16, scale: 2
+    t.string "hyaluronidases"
+    t.datetime "osculations", precision: nil
+    t.datetime "recurvopatents", precision: nil
+    t.bigint "widens"
+    t.string "corinnas"
+    t.string "riverwards", limit: 36, null: false
+  end
+
+  create_table "selenes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "academials"
+    t.string "liparoceles"
+    t.datetime "curtails", precision: nil
+    t.datetime "tantalizingnesses", precision: nil
+    t.boolean "yorkshiremen", default: false, null: false
+    t.datetime "nonintegrities", precision: nil
+    t.string "unworshipings"
+    t.string "lanateds"
+    t.string "cerebralisms"
+  end
+
+  create_table "selfheals", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.text "tasteds"
+    t.datetime "twanks", precision: nil
+    t.datetime "indeclinables", precision: nil, null: false
+    t.datetime "profilists", precision: nil, null: false
+  end
+
+  create_table "selfishnesses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "imperils"
+    t.date "iberisms"
+    t.datetime "apertureds", precision: nil
+    t.datetime "fernies", precision: nil
+  end
+
+  create_table "semiclassicals", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.date "sleepifies"
+    t.text "coferments"
+    t.string "titties"
+    t.boolean "despiritualizations", default: true, null: false
+    t.bigint "uncommensurates"
+    t.string "bemurmurs"
+    t.datetime "unleals", precision: nil
+    t.datetime "outfences", precision: nil
+    t.string "cirrostomis"
+    t.string "unendables", null: false
+    t.string "huffishes"
+    t.string "irretrievablenesses"
+    t.boolean "pseudalveolars", default: true, null: false
+    t.boolean "intrarenals", default: true, null: false
+  end
+
+  create_table "semiferous", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "submembranaceous", limit: 36, null: false, collation: "ascii_general_ci"
+    t.bigint "prodigalizes", null: false
+    t.bigint "jessamies", null: false
+    t.datetime "unfesters", precision: nil
+    t.datetime "antibubonics", precision: nil
+  end
+
+  create_table "seminaphthalidines", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "steersmen", null: false
+    t.string "defalcators", null: false
+    t.text "protorthopteras", null: false
+    t.bigint "lapons", null: false
+    t.bigint "unmortiseds"
+    t.datetime "bewreaths", precision: nil
+    t.datetime "chowders", precision: nil
+  end
+
+  create_table "semiparameters", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "pituitaries", null: false
+    t.bigint "murlies", null: false
+    t.string "unarraignables", null: false
+    t.string "proprietaries", null: false
+    t.string "triboroughs", limit: 36, null: false
+    t.datetime "biferous", precision: nil, null: false
+    t.datetime "inexists", precision: nil, null: false
+  end
+
+  create_table "semipendents", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.date "jiffles"
+    t.decimal "rotguts", precision: 16, scale: 2, null: false
+    t.string "underisives", limit: 36, null: false
+    t.string "mistlesses"
+    t.string "pezizoids", null: false
+    t.datetime "renablies", precision: nil
+    t.datetime "limacidaes", precision: nil
+  end
+
+  create_table "semirepublicans", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "ecoids"
+    t.datetime "pentathionics", precision: nil
+    t.datetime "zapotecs", precision: nil, null: false
+    t.datetime "nonpearlitics", precision: nil, null: false
+  end
+
+  create_table "sentimenters", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "puckerers", limit: 36, null: false
+    t.string "handies", null: false
+    t.string "unpossesseds", null: false
+    t.text "nighteds"
+    t.string "pylorectomies", null: false
+    t.string "psalmlesses", null: false
+    t.string "vernaculates", null: false
+    t.boolean "discerptions", default: false, null: false
+    t.string "tirwits"
+    t.text "wrynesses"
+    t.datetime "aecidials", precision: nil
+    t.datetime "maenadisms", precision: nil
+  end
+
+  create_table "sepharads", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "zolles"
+    t.bigint "epidiascopes"
+    t.decimal "isothiocyanics", precision: 16, scale: 2
+    t.decimal "discerniblies", precision: 16, scale: 2
+    t.datetime "anthropophagizes", precision: nil
+    t.datetime "jaggies", precision: nil
+  end
+
+  create_table "septifolious", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.date "ascanians"
+    t.date "bunkums"
+    t.text "cypselines"
+    t.bigint "quins"
+    t.bigint "metromania"
+    t.datetime "ichoglans", precision: nil, null: false
+    t.datetime "scopines", precision: nil, null: false
+  end
+
+  create_table "serfishlies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "statehoods"
+    t.date "corporatures"
+    t.date "ventilators"
+    t.date "bisbeeites"
+    t.text "seraus"
+    t.datetime "peacockisms", precision: nil
+    t.datetime "subcenters", precision: nil
+  end
+
+  create_table "sesamoiditis", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "scabiosas", limit: 36, null: false
+    t.string "apterygials", null: false
+    t.datetime "strinkles"
+    t.datetime "pileworms"
+    t.datetime "circuiters", null: false
+    t.datetime "trialogues"
+    t.datetime "mountings", precision: nil, null: false
+    t.datetime "oleoses", precision: nil, null: false
+    t.string "faradocontractilities", limit: 36
+  end
+
+  create_table "sexerns", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "pennales", null: false
+    t.string "bestraughts", null: false
+    t.bigint "nazareans", null: false
+    t.string "minatorilies", null: false
+    t.datetime "hoves", precision: nil
+    t.datetime "mesoseismals", precision: nil
+    t.bigint "superfluxes"
+  end
+
+  create_table "shallus", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "multimotors", null: false
+    t.date "pannikins"
+    t.integer "unashamednesses"
+    t.datetime "uncenters", precision: nil, null: false
+    t.datetime "plumoses", precision: nil, null: false
+  end
+
+  create_table "shaps", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "relinquishes", null: false
+    t.bigint "stamins", null: false
+    t.string "pickers", null: false
+    t.datetime "unweddeds", precision: nil
+    t.datetime "conducivenesses", precision: nil
+    t.datetime "idolatresses", precision: nil
+    t.datetime "unresistances", precision: nil
+  end
+
+  create_table "shards", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "immanentisms", null: false
+    t.bigint "paromoeons", null: false
+    t.datetime "nonsymptomatics", precision: nil, null: false
+    t.datetime "nonresidentials", precision: nil, null: false
+  end
+
+  create_table "shriekinesses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "longevities", limit: 36, null: false
+    t.bigint "prosthodontists", null: false
+    t.bigint "hyperazotemia", null: false
+    t.datetime "travellers", precision: nil
+    t.datetime "vicia", precision: nil
+    t.text "tonalists"
+    t.datetime "birders", precision: nil, null: false
+    t.datetime "catamounts", precision: nil, null: false
+  end
+
+  create_table "sices", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "conflictings", null: false
+    t.string "goniatitids"
+    t.string "doglikes", null: false
+    t.bigint "tarumas", null: false
+    t.datetime "invarieds", precision: nil, null: false
+  end
+
+  create_table "sidesplittings", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "tapamakers", limit: 36, null: false
+    t.string "ophicephaloids", null: false
+    t.text "polarizes", null: false
+    t.datetime "crazedlies", precision: nil
+    t.datetime "electrizations", precision: nil
+    t.string "spoonilies", default: "United States", null: false
+  end
+
+  create_table "sifflets", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "corniculers", limit: 36, null: false
+    t.string "verticillasters", limit: 200, null: false
+    t.text "brantails", null: false
+    t.datetime "pseudoerysipelatous", precision: nil
+    t.datetime "bicrons", precision: nil
+    t.string "nonserifs"
+    t.integer "antidromics", default: 1
+    t.integer "pardnomastics", null: false
+  end
+
+  create_table "simsons", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "cheerinesses", null: false
+    t.bigint "statisticallies"
+    t.string "impitiablies", null: false
+    t.string "diplocaulescents"
+    t.string "saltworks", null: false
+    t.string "amphiblastics"
+    t.datetime "unexercisables", precision: nil, null: false
+    t.datetime "streamlets", precision: nil, null: false
+    t.bigint "hippocausts"
+    t.datetime "librarians", precision: nil
+    t.boolean "pinoleums", null: false
+    t.boolean "deuteromorphics", null: false
+    t.string "enthusiasticals", limit: 36, null: false
+    t.string "duplifies"
+    t.bigint "generales", null: false
+    t.string "dysphagics"
+    t.string "sphenograms"
+  end
+
+  create_table "sinklikes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "notandums", null: false
+    t.bigint "ravenlikes", null: false
+    t.string "iconodulies"
+    t.string "artillerymen"
+    t.string "polyglandulars"
+    t.string "magnolia", limit: 1024
+    t.string "deanathematizes"
+    t.datetime "ultraindulgents", precision: nil
+    t.datetime "methylacetanilides", precision: nil
+    t.string "medullizations", limit: 36
+  end
+
+  create_table "sipunculidas", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "unwomanizes", null: false
+    t.bigint "catguts", null: false
+    t.datetime "bisubstitutions", precision: nil, null: false
+    t.datetime "tartronates", precision: nil, null: false
+    t.datetime "unoccupancies", precision: nil
+    t.datetime "fungologicals", precision: nil
+  end
+
+  create_table "sisterizes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "rhomboidlies", limit: 36, null: false
+    t.string "underaccidents", null: false
+    t.string "slitshells"
+    t.string "octillionths", null: false
+    t.date "muraenoids"
+    t.datetime "tetragamies", precision: nil
+    t.datetime "acetamidins", precision: nil
+    t.bigint "autometries"
+  end
+
+  create_table "sivvens", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "vulturelikes", limit: 36, null: false
+    t.decimal "osteopathicallies", precision: 16, scale: 2
+    t.decimal "vateria", precision: 16, scale: 2
+    t.decimal "treeifies", precision: 16, scale: 2
+    t.decimal "habaneras", precision: 16, scale: 2
+    t.decimal "incogitantlies", precision: 16, scale: 2
+    t.bigint "subtenancies"
+    t.text "coltpixies"
+    t.text "centrifugations"
+    t.boolean "predicted_nsf_v1"
+    t.bigint "firmisternous"
+    t.bigint "trematodes"
+    t.string "somers"
+    t.date "exportations", null: false
+    t.datetime "hemichoreas", precision: nil
+    t.datetime "offhandednesses", precision: nil
+    t.string "dioecisms"
+    t.boolean "predicted_nsf_v2"
+    t.boolean "predicted_nsf_v3"
+    t.boolean "predicted_nsf_v4"
+    t.boolean "predicted_nsf_v5"
+  end
+
+  create_table "skens", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "banyuls", limit: 36, null: false
+    t.text "appliedlies"
+    t.bigint "unstatueds"
+    t.datetime "protopodites", precision: nil
+    t.datetime "thumpinglies", precision: nil
+    t.string "absonants", null: false
+    t.bigint "hyperdoricisms"
+  end
+
+  create_table "sketchabilities", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "photodecompositions"
+    t.date "watchmanlies"
+    t.datetime "alliterations", precision: nil, null: false
+    t.datetime "mice", precision: nil, null: false
+    t.boolean "antiarthritics", default: false
+    t.boolean "disassociations", default: false
+    t.bigint "conveniences"
+    t.string "sacrococcygeans"
+  end
+
+  create_table "skipjacklies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "myrmidons", limit: 36, null: false
+    t.datetime "bezoars", precision: nil, null: false
+    t.datetime "homosexuals", precision: nil
+    t.string "ahantchuyuks", null: false
+    t.text "skivs", null: false
+    t.string "schlauraffenlands", null: false
+    t.string "pseudocirrhoses", null: false
+    t.datetime "unsibilants", precision: nil
+    t.datetime "jaobs", precision: nil
+  end
+
+  create_table "slangilies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "poundings"
+    t.bigint "ergosterols"
+    t.decimal "oralers", precision: 8, scale: 2, default: "0.0"
+    t.decimal "smokestacks", precision: 8, scale: 2, default: "0.0"
+    t.text "thyrotherapies", size: :medium
+    t.datetime "impropernesses", precision: nil, null: false
+    t.datetime "mixeresses", precision: nil, null: false
+    t.boolean "deviants", default: false
+    t.date "debaters"
+    t.boolean "octandrians", default: false, null: false
+  end
+
+  create_table "slavonisms", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "glaciereds", limit: 36, null: false
+    t.string "alilonghis", null: false
+    t.text "ultimogenitaries", null: false
+    t.datetime "eyewinkers", precision: nil
+    t.datetime "disgoods", precision: nil
+    t.datetime "phagocytolyses", precision: nil
+    t.datetime "elucidates", precision: nil
+  end
+
+  create_table "sloes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "dicodeines", null: false
+    t.string "clastics", null: false
+    t.text "checkmen"
+    t.string "anthracnoses", null: false
+    t.string "encrinoids", null: false
+    t.bigint "caboodles"
+    t.string "russomaniacs"
+    t.datetime "stosstons", precision: nil, null: false
+    t.datetime "rosalia", precision: nil
+    t.datetime "acetylizers", precision: nil
+    t.bigint "caliphates"
+    t.integer "interaulics", default: 0, null: false
+    t.datetime "dabbies", precision: nil
+    t.bigint "assaulters"
+    t.string "appendageds"
+    t.string "cribroses"
+  end
+
+  create_table "sluicers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "sarcophagis"
+    t.string "unassociativenesses", limit: 36, null: false, collation: "ascii_general_ci"
+    t.string "dunches", limit: 36, null: false, collation: "ascii_general_ci"
+    t.string "freesilverites", limit: 36
+    t.datetime "sparses", precision: nil, null: false
+    t.datetime "aponogetonaceaes", precision: nil, null: false
+    t.boolean "enribs", default: false, null: false
+  end
+
+  create_table "smeareds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "scurries", limit: 36, null: false
+    t.string "cleavelandites", null: false
+    t.string "extrastapedials", null: false
+    t.string "usars", null: false
+    t.bigint "preinducements", null: false
+    t.datetime "pythius", precision: nil, null: false
+    t.datetime "sublimizes", precision: nil, null: false
+    t.datetime "fiddles", precision: nil, null: false
+  end
+
+  create_table "smeuses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.integer "conventuals", limit: 1
+    t.datetime "posers", precision: nil
+    t.datetime "asaprols", precision: nil
+    t.datetime "iconophilisms", precision: nil
+  end
+
+  create_table "smokeds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "austerlitzs", null: false
+    t.bigint "i9_authorization_id", null: false
+    t.boolean "gnawinglies", default: false
+    t.string "disincorporations"
+    t.string "pleosporas"
+    t.string "farcinomas"
+    t.date "spoonlesses"
+    t.string "multifibereds"
+    t.datetime "uninterruptednesses", precision: nil
+    t.datetime "gentlewomanlikes", precision: nil
+    t.string "oophoridia"
+    t.string "snows", limit: 36
+  end
+
+  create_table "smoothboreds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "quinquepedals", limit: 36, null: false
+    t.string "aenaches", limit: 36, null: false
+    t.string "vages", null: false
+    t.string "antihemolysins"
+    t.string "exocyclicas"
+    t.string "idioblasts"
+    t.string "recurs"
+    t.string "outstations"
+    t.string "trumpets"
+    t.string "mammulas", null: false
+    t.decimal "capetonians", precision: 16, scale: 2, default: "0.0", null: false
+    t.string "sandans"
+    t.string "bookmarkers"
+    t.string "myliobatoids"
+    t.string "cinenegatives", null: false
+    t.date "monarchianists"
+    t.boolean "berolls"
+    t.string "street_1", null: false
+    t.string "street_2"
+    t.string "oversmites", null: false
+    t.string "hyperthyroidizations", null: false
+    t.string "crustaceous", null: false
+    t.datetime "episcopallies", precision: nil, null: false
+    t.datetime "smelleds", precision: nil, null: false
+  end
+
+  create_table "smytries", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "vardies", null: false
+    t.bigint "exsufflates", null: false
+    t.string "appendotomes", null: false
+    t.string "alamodalities"
+    t.text "sears"
+    t.text "modulants"
+    t.datetime "demagnetizes", precision: nil, null: false
+    t.string "hypoalkalinities"
+  end
+
+  create_table "snarleyyows", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "terminablies", null: false
+    t.bigint "unsoothables", null: false
+    t.string "petites", null: false
+    t.boolean "polychromates", default: true, null: false
+    t.text "ventilatings"
+    t.datetime "slackages", precision: nil, null: false
+    t.datetime "roxburghs", precision: nil, null: false
+    t.boolean "needments", default: false, null: false
+    t.datetime "acrogamies", precision: nil
+  end
+
+  create_table "snoodeds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.datetime "waldheimia", precision: nil, null: false
+    t.datetime "synodals", precision: nil, null: false
+    t.string "ornamentists", limit: 36, null: false
+    t.string "dudleyites", limit: 36, null: false
+    t.string "propositionallies", null: false
+    t.datetime "brunswicks", precision: nil, null: false
+    t.bigint "chorions", null: false
+  end
+
+  create_table "societologies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "unempts"
+    t.string "postulatories"
+    t.string "tics"
+    t.string "marrers", null: false
+    t.string "bachels"
+    t.datetime "bicorporals", precision: nil
+    t.datetime "sanforizeds", precision: nil
+    t.datetime "salsifies", precision: nil, null: false
+    t.datetime "sanks", precision: nil, null: false
+    t.date "hois"
+    t.string "amphiarthrodials"
+    t.datetime "concertos", precision: nil
+    t.string "squaloideis"
+    t.string "challahs"
+    t.string "unspeakablenesses"
+    t.datetime "uncloudednesses", precision: nil
+    t.string "inventibilities"
+    t.bigint "noneducationals"
+    t.bigint "wordles", null: false
+  end
+
+  create_table "sokas", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "knutties", limit: 36, null: false
+    t.string "nagginglies", limit: 36, null: false
+    t.string "tabulations", limit: 200, null: false
+    t.string "multidisperses", limit: 200
+    t.datetime "colarins", precision: nil
+    t.datetime "defameds", precision: nil
+    t.integer "ayes", default: 1
+  end
+
+  create_table "solacers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "floormen", limit: 36, null: false
+    t.bigint "intercessions", null: false
+    t.string "cystocarpics", null: false
+    t.string "nagnags"
+    t.bigint "grossnesses"
+    t.datetime "shwanpans", precision: nil
+    t.datetime "compounds", precision: nil
+  end
+
+  create_table "sorites", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "tinamines", limit: 36, null: false
+    t.bigint "inconstruables", null: false
+    t.string "unhusbandeds", limit: 36, null: false
+    t.bigint "interiorities", null: false
+    t.string "increatelies", limit: 36, null: false
+    t.bigint "northumbers", null: false
+    t.string "unwitherables", limit: 36, null: false
+    t.date "agags", null: false
+    t.integer "frosters", null: false
+    t.string "inviolacies", null: false
+    t.string "bezzos", null: false
+    t.decimal "supersonants", precision: 16, scale: 2, null: false
+    t.decimal "impregnablenesses", precision: 16, scale: 2, null: false
+    t.datetime "mausers", precision: nil, null: false
+    t.datetime "bebrines", precision: nil, null: false
+  end
+
+  create_table "souchongs", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "buteins", limit: 36, null: false
+    t.string "pathognostics", null: false
+    t.string "idyllicals", null: false
+    t.string "prededucts", null: false
+    t.string "effervescents"
+    t.string "aquiculturals"
+    t.datetime "windowmakers", precision: nil
+    t.datetime "boastlesses", precision: nil
+  end
+
+  create_table "sparelesses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "vilelas", null: false
+    t.bigint "homosexualisms", null: false
+    t.datetime "flicks", precision: nil
+    t.datetime "iliofemorals", precision: nil
+    t.string "sheveleds"
+  end
+
+  create_table "speechings", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "erinaceus", limit: 36, null: false
+    t.bigint "seirospores", null: false
+    t.string "poulardizes", limit: 100, null: false
+    t.datetime "zoosporangiophores", precision: nil, null: false
+    t.datetime "palmfuls", precision: nil, null: false
+  end
+
+  create_table "spellworks", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "sideromagnetics", limit: 36, null: false
+    t.bigint "caducicorns", null: false
+    t.bigint "urachals", null: false
+    t.bigint "brainlikes", null: false
+    t.bigint "restipulations"
+    t.string "nonconsents"
+    t.string "reductibilities", default: "pending", null: false
+    t.datetime "tarsus", precision: nil
+    t.datetime "dishabilles", precision: nil
+    t.string "celtophobes"
+  end
+
+  create_table "spermatoblastics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "marties", null: false
+    t.bigint "unsheathes", null: false
+    t.datetime "orchestraters", precision: nil
+    t.datetime "glores", precision: nil
+  end
+
+  create_table "spermics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "annelids"
+    t.string "stubrunners"
+    t.date "skylooks"
+    t.string "ratlines"
+    t.boolean "unatmospherics", default: false
+    t.string "kingmakings"
+    t.string "outhectors"
+    t.integer "nonirritables"
+    t.datetime "hypaethrons", precision: nil
+    t.bigint "spheroidicallies"
+    t.bigint "curculionists"
+    t.datetime "xenia", precision: nil
+    t.datetime "pisciculturists", precision: nil
+  end
+
+  create_table "sphagnales", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "wonteds"
+    t.string "polypetals"
+    t.string "address_line_1"
+    t.string "address_line_2"
+    t.string "address_line_3"
+    t.string "unhelpfullies"
+    t.string "unveilers"
+    t.string "paunchilies"
+    t.datetime "printables", precision: nil
+    t.datetime "circumfusions", precision: nil
+  end
+
+  create_table "spherics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "assailers"
+    t.string "bimanuals", limit: 60
+    t.datetime "underpiles", precision: nil, null: false
+    t.datetime "hulas", precision: nil, null: false
+  end
+
+  create_table "spinners", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "coadnates", limit: 36, null: false
+    t.integer "toylikes", null: false
+    t.datetime "subessentials", precision: nil
+    t.datetime "sheristadars", precision: nil
+    t.bigint "quibblinglies"
+  end
+
+  create_table "spirignathous", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "baynesses", null: false
+    t.bigint "tipproofs"
+    t.string "harmfulnesses", null: false
+    t.integer "darlingtonia", default: 0, null: false
+    t.datetime "fruitists", precision: nil, null: false
+    t.datetime "homogenous", precision: nil, null: false
+    t.string "withinwards"
+  end
+
+  create_table "spiros", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "stahlisms", limit: 36, null: false
+    t.bigint "alaskites"
+    t.string "external401k_plan_record_uuid", limit: 36, null: false
+    t.string "apagogics", null: false
+    t.string "cocillanas"
+    t.datetime "hideous", precision: nil
+    t.datetime "misotheists", precision: nil
+  end
+
+  create_table "spokesmanships", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "navigants", null: false
+    t.string "disposednesses", null: false
+    t.datetime "philatelicallies", precision: nil
+    t.datetime "proligerous", precision: nil
+  end
+
+  create_table "sputteries", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "dorabs", null: false
+    t.string "harbingers", null: false
+    t.datetime "sclims", precision: nil, null: false
+    t.datetime "damiers", precision: nil, null: false
+  end
+
+  create_table "squamulas", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "pseudotracheas", null: false
+    t.bigint "unpresentablies", null: false
+    t.string "noachics", null: false
+    t.datetime "judaeophilisms", precision: nil, null: false
+    t.datetime "fatwoods", precision: nil, null: false
+    t.string "pastrymen"
+  end
+
+  create_table "squamules", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "rullers"
+    t.bigint "nebulizations"
+    t.string "cashierments"
+    t.bigint "heterandrous"
+    t.string "cyanhydrates"
+    t.text "hebdomarians"
+    t.boolean "climas", default: false
+    t.string "scouches"
+    t.datetime "alcyonia", precision: nil
+    t.datetime "barometrographies", precision: nil
+    t.datetime "erectors", precision: nil
+    t.bigint "propiolics"
+    t.text "pseudobrachia"
+    t.text "anisics", size: :long
+    t.integer "platyrrhinis"
+  end
+
+  create_table "squashes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "hysteropexies"
+    t.string "digressionaries", null: false
+    t.string "juries", null: false
+    t.string "ignores", null: false
+    t.datetime "epistolographics", precision: nil
+    t.datetime "tootlers", precision: nil
+  end
+
+  create_table "squillidaes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "postliminies", limit: 36, null: false
+    t.bigint "yares", null: false
+    t.string "satinies", limit: 2, null: false
+    t.bigint "stylizations", null: false
+    t.datetime "unshamefuls", precision: nil, null: false
+    t.datetime "imbibitions", precision: nil, null: false
+  end
+
+  create_table "stachyuraceaes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "infamous", null: false
+    t.bigint "yuhs"
+    t.string "breadnuts", null: false
+    t.string "bacteriaceous", null: false
+    t.string "ingloriouslies", null: false
+    t.string "gynecomastisms", null: false
+    t.datetime "mudguards", precision: nil, null: false
+    t.datetime "skinkles", precision: nil, null: false
+    t.string "focimetries"
+    t.string "hypotrophics"
+  end
+
+  create_table "staphyleaceous", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "ledens", null: false
+    t.string "niyogas", null: false
+    t.string "underbishoprics", null: false
+    t.string "pseudoprofessorials"
+    t.boolean "preallows", null: false
+    t.datetime "modulos", precision: nil, null: false
+    t.datetime "metabolizables", precision: nil, null: false
+    t.string "porties"
+    t.string "flaughts"
+  end
+
+  create_table "starringlies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "hotta", null: false
+    t.bigint "preteritions", null: false
+    t.boolean "prevalencies", default: false, null: false
+    t.string "peshkars"
+    t.string "butterbirds"
+    t.string "inauguratories"
+    t.string "monologicals"
+    t.datetime "slumpproofs", precision: nil, null: false
+    t.datetime "exopterygotous", precision: nil, null: false
+    t.boolean "antimerics", default: false, null: false
+    t.string "melanistics", limit: 36
+  end
+
+  create_table "statables", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "hubbas", limit: 36, null: false
+    t.bigint "sulphurets", null: false
+    t.bigint "uncontinuals", null: false
+    t.string "miserablies", null: false
+    t.string "tuftilies"
+    t.bigint "castalios"
+    t.datetime "millables", precision: nil, null: false
+    t.datetime "hypodermaticallies", precision: nil, null: false
+    t.string "fregatidaes", limit: 36
+  end
+
+  create_table "statoblasts", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "sings", null: false
+    t.datetime "overseethes", precision: nil
+    t.datetime "extractions", precision: nil
+  end
+
+  create_table "stauraxonia", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "suscitations", limit: 36, null: false
+    t.bigint "shaggednesses", null: false
+    t.bigint "maternallies", null: false
+    t.boolean "mastoideosquamous", default: false, null: false
+    t.text "queriers", null: false
+    t.datetime "thyrogenics", precision: nil, null: false
+    t.datetime "supracensorious", precision: nil, null: false
+  end
+
+  create_table "steatolytics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "gallinaceaes", limit: 36, null: false
+    t.bigint "ceroxylons", null: false
+    t.string "coagitates", null: false
+    t.string "dabihs"
+    t.text "semitorpids"
+    t.datetime "extravagates", precision: nil, null: false
+    t.datetime "cotyligerous", precision: nil, null: false
+  end
+
+  create_table "stereums", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.boolean "cattalos"
+    t.datetime "peorians", precision: nil
+    t.datetime "gradates", precision: nil, null: false
+    t.datetime "bombardons", precision: nil, null: false
+    t.boolean "gynandromorphous", default: false
+    t.boolean "anticonscriptions"
+    t.text "wolvers"
+    t.boolean "stomatodaeums"
+  end
+
+  create_table "sterilities", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "unaffectedlies"
+    t.datetime "bakelites", precision: nil
+    t.datetime "fleecers", precision: nil
+    t.bigint "shadowgraphics"
+    t.decimal "auriculaes", precision: 16, scale: 2, default: "0.0"
+    t.decimal "puckermouths", precision: 16, scale: 2, default: "0.0"
+    t.bigint "barberfishes"
+  end
+
+  create_table "stethoparalyses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "antifatigues", limit: 36, null: false
+    t.string "trustworthinesses", null: false
+    t.decimal "visives", precision: 16, scale: 2, default: "0.0"
+    t.datetime "upslopes", precision: nil, null: false
+    t.bigint "cardialgies", null: false
+    t.datetime "monimia", precision: nil
+    t.datetime "forestials", precision: nil
+    t.string "osteographies", null: false
+  end
+
+  create_table "stoeps", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.datetime "malleus", precision: nil
+    t.datetime "stackhousia", precision: nil
+    t.datetime "hymenials", precision: nil
+    t.datetime "randomlies", precision: nil
+    t.bigint "antimephitics", null: false
+    t.bigint "shargars", null: false
+  end
+
+  create_table "stratagemicals", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.date "prigdoms", null: false
+    t.date "dodgers"
+    t.decimal "overbumptious", precision: 16, scale: 2, null: false
+    t.bigint "showbirds"
+    t.string "tsetses"
+    t.string "address_line_1"
+    t.string "address_line_2"
+    t.string "address_line_3"
+    t.string "partners"
+    t.string "mutablenesses"
+    t.string "oitavas"
+    t.string "disconcertinglies"
+    t.string "branglings"
+    t.integer "etiologicallies"
+    t.datetime "seigneuries", precision: nil
+    t.string "interchondrals"
+    t.string "vicelesses"
+    t.integer "geometrines"
+    t.datetime "handeds", precision: nil
+    t.boolean "nitrolimes", default: false, null: false
+    t.date "discounters"
+    t.date "unattaineds"
+    t.bigint "pallies"
+    t.string "unsuspicions"
+    t.string "conchiforms", default: "sent", null: false
+    t.string "unconflictinglies"
+    t.datetime "pibcorns", precision: nil
+    t.datetime "mirthfulnesses", precision: nil
+    t.datetime "payments", precision: nil
+    t.integer "registrabilities", limit: 1, default: 1
+    t.integer "unsocials"
+    t.bigint "macignos"
+    t.string "geomanticals"
+    t.string "sargassos"
+    t.bigint "misinferences"
+    t.string "clinographics"
+  end
+
+  create_table "strengthlesslies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.datetime "puinavians", precision: nil
+    t.datetime "introductories", precision: nil
+    t.string "untantalizings", limit: 36, null: false
+    t.string "turnstiles", limit: 36, null: false
+    t.string "woolsowers", limit: 36, null: false
+    t.string "papooses", null: false
+    t.datetime "mycohaemia", precision: nil
+  end
+
+  create_table "streptobacillus", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "luxuries", null: false
+    t.bigint "metics", null: false
+    t.string "ludicroserious"
+    t.datetime "objectionablenesses", precision: nil, null: false
+    t.datetime "antianthraxes", precision: nil, null: false
+  end
+
+  create_table "streptococcis", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "advenes", limit: 36, null: false
+    t.bigint "hematimeters", null: false
+    t.bigint "roderics", null: false
+    t.datetime "disestablishmentarians", precision: nil
+    t.datetime "choristers", precision: nil
+  end
+
+  create_table "stretchermen", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "supplicatives"
+    t.datetime "phosphites", precision: nil
+    t.datetime "nomadians", precision: nil
+    t.string "aggregatenesses", null: false
+    t.string "wiseacrednesses", null: false
+    t.datetime "anarchals", precision: nil
+  end
+
+  create_table "striaes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "levators", null: false
+    t.string "noncoalescings", limit: 36, null: false
+    t.datetime "maythorns", precision: nil, null: false
+    t.boolean "depuratories", null: false
+    t.string "retrovaccinations", default: "inactive", null: false
+    t.string "carminatives"
+    t.datetime "trillionaires", precision: nil, null: false
+    t.datetime "listerians", precision: nil, null: false
+    t.string "tocharishes"
+    t.text "turnables"
+    t.bigint "uninfluentials"
+  end
+
+  create_table "stripelesses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "podargus", limit: 36, null: false
+    t.bigint "perviabilities", null: false
+    t.string "hylotheistics"
+    t.string "outswindles", null: false
+    t.string "ladderings"
+    t.bigint "bronchoceles", null: false
+    t.datetime "unhumbles", precision: nil
+    t.datetime "uterectomies", precision: nil
+  end
+
+  create_table "stroygoods", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "scaridaes", limit: 36, null: false
+    t.string "hypoconulids", null: false
+    t.string "womanposts", null: false
+    t.string "etheostomas", null: false
+    t.datetime "lamplesses", precision: nil, null: false
+    t.datetime "argives", precision: nil, null: false
+  end
+
+  create_table "strucks", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.datetime "doorposts", precision: nil, null: false
+    t.text "electrokinematics"
+    t.datetime "hepatotoxemia", precision: nil
+    t.datetime "vomerobasilars", precision: nil
+    t.bigint "roughets", null: false
+    t.string "insolents"
+  end
+
+  create_table "struvs", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "basques", limit: 36, null: false
+    t.bigint "flashets", null: false
+    t.datetime "leucadendrons", precision: nil
+    t.datetime "involutories", precision: nil
+    t.string "frequencies", default: "not_started", null: false
+    t.string "rejustifications", default: "not_started", null: false
+    t.string "mycetophagous", default: "not_started", null: false
+    t.string "shingles", default: "not_started", null: false
+    t.string "stomachfuls", default: "not_started", null: false
+    t.string "cerotics", default: "not_started", null: false
+    t.string "status_401k_plan", default: "arthralgics", null: false
+  end
+
+  create_table "stryches", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.decimal "stowbords", precision: 16, scale: 2
+    t.string "foreseeables"
+    t.datetime "isomorphics", precision: nil, null: false
+    t.datetime "mycodermics", precision: nil, null: false
+    t.string "vagiles", limit: 36, null: false
+    t.decimal "ovalizes", precision: 5, scale: 2
+    t.string "aviations", limit: 36, null: false
+    t.string "bluisms", limit: 36
+    t.string "worlds", limit: 36
+    t.string "tuchunizes", null: false
+  end
+
+  create_table "stupes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "nengahibas", null: false
+    t.integer "flamencos", null: false
+    t.datetime "phasianus", precision: nil
+    t.text "necrophilics"
+    t.datetime "gedders", precision: nil
+    t.datetime "antilegomenas", precision: nil
+    t.integer "rheumaticals", default: 0, null: false
+    t.bigint "anakineses"
+    t.bigint "hemipinnates"
+  end
+
+  create_table "stylogonidia", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "eophytics", limit: 36, null: false
+    t.string "philologastries", limit: 36, null: false
+    t.string "prescribers", limit: 36, null: false
+    t.datetime "dragoons", precision: nil, null: false
+    t.datetime "royalisms", precision: nil, null: false
+  end
+
+  create_table "styraxes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "uinta", null: false
+    t.bigint "pterostigmatics", null: false
+    t.string "microfossils", null: false
+    t.string "aldines"
+    t.string "foreflaps"
+    t.string "unresumptives"
+    t.string "merychippus"
+    t.datetime "cartages", precision: nil
+    t.integer "wannesses", default: 0, null: false
+    t.datetime "unironeds", precision: nil, null: false
+    t.datetime "becks", precision: nil, null: false
+  end
+
+  create_table "subchorioidals", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "menfolks", limit: 36, null: false
+    t.bigint "whereuntils", null: false
+    t.string "disseminules", null: false
+    t.bigint "klaus", null: false
+    t.boolean "salutatious", default: false
+    t.integer "teratologicals"
+    t.datetime "materials", precision: nil
+    t.datetime "nitidous", precision: nil
+  end
+
+  create_table "subdeaconates", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "freewards", null: false
+    t.string "equidimensionals", limit: 36, null: false
+    t.decimal "croceous", precision: 16, scale: 2, default: "0.0", null: false
+    t.datetime "uncoddleds", precision: nil
+    t.datetime "microapparatus", precision: nil
+  end
+
+  create_table "subdividinglies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "chantries", limit: 36, null: false, collation: "ascii_general_ci"
+    t.string "vesuviates", limit: 36, null: false, collation: "ascii_general_ci"
+    t.string "triarcuateds", limit: 36, collation: "ascii_general_ci"
+    t.string "sophicals", null: false
+    t.string "thinkablies"
+    t.string "cocurators", null: false
+    t.datetime "cynomorphas", precision: nil
+    t.datetime "tauromorphous", precision: nil, null: false
+    t.datetime "convenientlies", precision: nil, null: false
+    t.string "activelies", limit: 36, null: false
+    t.string "suspensors", limit: 36
+    t.string "harebrainednesses", limit: 36
+    t.boolean "immurements", default: false, null: false
+    t.string "nostocaceaes", limit: 36, collation: "ascii_general_ci"
+  end
+
+  create_table "subfibrous", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.datetime "obscurities", precision: nil
+    t.bigint "storekeepers", null: false
+    t.string "driftmen"
+    t.bigint "boltuprightnesses"
+    t.datetime "nonces", precision: nil
+    t.datetime "slodges", precision: nil
+    t.integer "epidermoidals", limit: 1
+    t.integer "endobiotics", limit: 1
+  end
+
+  create_table "subhyaloids", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "immotioneds", limit: 36, null: false
+    t.string "unrestfulnesses", null: false
+    t.string "mismakes"
+    t.integer "longilinguals", null: false
+    t.datetime "uncompliances", precision: nil
+    t.string "protococcoids", default: "", null: false
+    t.datetime "disobeys", precision: nil
+    t.datetime "exhausteds", precision: nil
+    t.bigint "multisulcates"
+    t.bigint "hypinoses", null: false
+    t.bigint "schmelzes"
+    t.bigint "mayances"
+  end
+
+  create_table "sublaryngeals", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "eardroppers"
+    t.integer "amortizes"
+    t.string "sclerous"
+    t.datetime "phils", precision: nil, null: false
+    t.datetime "albuminaturia", precision: nil, null: false
+    t.decimal "woolenets", precision: 16, scale: 2, default: "0.0"
+    t.boolean "mandarinisms"
+    t.string "dipsaceaes"
+    t.text "betonies"
+    t.boolean "pleasemen", default: true
+    t.string "phajus"
+    t.string "jauks", limit: 36
+  end
+
+  create_table "subpanels", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "schizostelies", limit: 36, null: false
+    t.string "undersplices", null: false
+    t.string "duodenums", null: false
+    t.bigint "scourfishes", null: false
+    t.string "unmulishes", null: false
+    t.datetime "intelligents", precision: nil, null: false
+    t.datetime "cravos", precision: nil, null: false
+    t.text "smolders"
+  end
+
+  create_table "subsemitones", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "gothonics", null: false
+    t.bigint "coweens", null: false
+    t.date "progenitivenesses"
+    t.datetime "vajrasanas", precision: nil
+    t.datetime "petrobrusians", precision: nil
+    t.string "intinctions", limit: 36, collation: "ascii_general_ci"
+    t.string "ultravirtuous", limit: 36
+    t.string "allothimorphs", limit: 36, null: false
+  end
+
+  create_table "subsoils", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "unrebuffables", null: false
+    t.bigint "tactfuls", null: false
+    t.integer "bananists", null: false
+    t.text "enroots"
+    t.datetime "probeables", precision: nil
+    t.datetime "xenogamous", precision: nil
+    t.string "contentfuls", default: "open"
+  end
+
+  create_table "subsulfides", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "priestesses", null: false
+    t.bigint "extracardials", null: false
+    t.datetime "hillockies", precision: nil, null: false
+    t.datetime "uranostaphyloplasties", precision: nil, null: false
+  end
+
+  create_table "subtacksmen", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "pronubas", null: false
+    t.datetime "oleraceous", precision: nil
+    t.datetime "rhamnites", precision: nil
+  end
+
+  create_table "sulliables", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "shaws", limit: 36, null: false
+    t.bigint "proceremonialisms"
+    t.boolean "warriorhoods", default: false, null: false
+    t.text "barwises"
+    t.string "scuffles"
+    t.string "ulnars", default: "", null: false
+    t.datetime "protragedies", precision: nil
+    t.datetime "upbrims", precision: nil
+  end
+
+  create_table "sulphates", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "unmeridionals"
+    t.string "laborousnesses"
+    t.string "solipedous"
+    t.string "untrainednesses"
+    t.string "arrantlies"
+    t.string "norths"
+    t.string "reweds"
+    t.string "brilliancies"
+    t.string "addressees"
+    t.string "sabutans"
+    t.string "dammishes"
+    t.datetime "inadvisables", precision: nil
+    t.datetime "kabels", precision: nil
+    t.text "copemates"
+    t.text "puppethoods"
+    t.text "transportatives"
+    t.string "aitkenites"
+    t.string "christendies"
+    t.string "explorators"
+    t.string "sporals"
+  end
+
+  create_table "sulphites", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "uncomfortings", limit: 36, null: false
+    t.string "unministerials", null: false
+    t.text "salivals"
+    t.text "silleries"
+    t.string "spinelikes"
+    t.string "chrismations", null: false
+    t.string "looties", null: false
+    t.string "mechanistics", null: false
+    t.boolean "ogaires", default: false, null: false
+    t.boolean "cornstalks", default: false, null: false
+    t.integer "spiriters"
+    t.integer "kelebes"
+    t.datetime "globularlies", precision: nil
+    t.datetime "monorchids", precision: nil
+    t.text "coseismics"
+    t.string "workablenesses"
+    t.integer "dowsets", default: 1
+  end
+
+  create_table "sulphoichthyolates", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "snakebites"
+    t.integer "sabuloses"
+    t.datetime "undoubteds", precision: nil
+    t.datetime "typholysins", precision: nil
+  end
+
+  create_table "sulphurousnesses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "remarkablenesses", null: false
+    t.string "counterexcommunications", null: false
+    t.datetime "antiloimics", precision: nil, null: false
+    t.datetime "bathmotropics", precision: nil, default: "3000-01-01 00:00:00", null: false
+    t.bigint "unconsulteds", null: false
+    t.bigint "compasses"
+  end
+
+  create_table "sundaynesses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.decimal "shoppers", precision: 16, scale: 2, default: "0.0"
+    t.string "prickwoods"
+    t.bigint "tonsurates", null: false
+    t.bigint "poundmen", null: false
+    t.datetime "unstatutables", precision: nil
+    t.string "overpaineds", null: false
+    t.datetime "phalangides", precision: nil
+    t.datetime "annoyments", precision: nil
+  end
+
+  create_table "superchargers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "outsonnets", limit: 36, null: false
+    t.text "nines", null: false
+    t.string "paleometallics"
+    t.bigint "presystematics", null: false
+    t.datetime "gastromyces", precision: nil, null: false
+    t.datetime "richnesses", precision: nil, null: false
+  end
+
+  create_table "superfulfills", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "hobbyisms"
+    t.decimal "elytrigerous", precision: 16, scale: 2, null: false
+    t.string "dynamomorphics", null: false
+    t.bigint "trachodonts", null: false
+    t.datetime "stadholderates", precision: nil
+    t.datetime "vermiculosities", precision: nil
+    t.string "reglets", limit: 36, null: false
+    t.datetime "overgoverns", precision: nil
+    t.boolean "letts", default: false, null: false
+    t.string "unperplexings"
+    t.string "cwiercs"
+    t.string "lissotriches"
+    t.integer "nonfatalistics"
+    t.datetime "boweleds", precision: nil
+    t.decimal "pasiteleans", precision: 16, scale: 2
+    t.datetime "phratria", precision: nil
+    t.string "voluntaryists"
+    t.string "processors"
+    t.string "bairnlinesses"
+  end
+
+  create_table "supermishaps", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.text "countergauges"
+    t.text "washerymen"
+    t.bigint "devilkins"
+    t.datetime "unabilities", precision: nil, null: false
+    t.datetime "boresomes", precision: nil, null: false
+    t.string "pommets", limit: 36, null: false
+  end
+
+  create_table "superoxalates", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "champers", limit: 36, null: false
+    t.string "rhodochrosites", limit: 200
+    t.string "dissuasories"
+    t.integer "execrations", null: false
+    t.datetime "semiuprights", precision: nil
+    t.datetime "alarminglies", precision: nil
+  end
+
+  create_table "superprintings", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "jinglings", null: false
+    t.integer "unexplicables"
+    t.datetime "subcontrarieties", precision: nil
+    t.datetime "proromances", precision: nil
+    t.datetime "vomitories", precision: nil
+    t.string "oversubtleties", limit: 36
+    t.string "kos"
+    t.string "scribbleisms"
+    t.boolean "contestables", default: false
+    t.boolean "suggestresses", default: true
+    t.text "malapertnesses"
+    t.text "inurements"
+  end
+
+  create_table "superwagers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "scobiforms", null: false
+    t.string "eurobins", null: false
+    t.string "triovulates", null: false
+    t.string "bibliopegistics", null: false
+    t.boolean "unwelcomelies", default: false, null: false
+    t.datetime "housemistresses", precision: nil
+    t.datetime "brochans", precision: nil
+    t.string "hurrieds", limit: 36, null: false
+    t.integer "begalls"
+  end
+
+  create_table "surfacelies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "bushhammers"
+    t.integer "bedstaves"
+    t.string "translades"
+    t.text "leucotomies", size: :medium
+    t.datetime "polioencephalomyelitis", precision: nil, null: false
+    t.datetime "vasospastics", precision: nil, null: false
+    t.datetime "masquers", precision: nil
+    t.datetime "pagans", precision: nil
+  end
+
+  create_table "surtaxes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "pargos", null: false
+    t.boolean "stimulators", default: false, null: false
+    t.string "diphtherians", null: false
+    t.string "chemakuans", null: false
+    t.string "urges", null: false
+    t.string "steatites", null: false
+    t.bigint "kryokonites"
+    t.string "trilisas", null: false
+    t.bigint "unjostleds", null: false
+    t.string "gilbertianisms", null: false
+    t.string "snappilies", null: false
+    t.decimal "oolitics", precision: 16, scale: 2, default: "0.0", null: false
+    t.datetime "snooses", precision: nil
+    t.datetime "nonparasitisms", precision: nil
+  end
+
+  create_table "swaddlebills", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "unworkmanlies", limit: 36, null: false, collation: "ascii_general_ci"
+    t.bigint "pentenes", null: false
+    t.bigint "postcolumellars"
+    t.string "lhota", null: false
+    t.string "isoldes", default: "processing", null: false
+    t.string "discursions", null: false
+    t.datetime "admedians", precision: nil, null: false
+    t.datetime "acts", precision: nil, null: false
+  end
+
+  create_table "synapses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "overstalleds", limit: 36, null: false
+    t.string "omnifariouslies"
+    t.boolean "eptatretidaes", default: false
+    t.string "eosins"
+    t.integer "hemelytrals"
+    t.datetime "pharyngitis", precision: nil
+    t.datetime "ungarrisoneds", precision: nil
+  end
+
+  create_table "synchromeshes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.datetime "xeranthemums", precision: nil, null: false
+    t.datetime "heptaces", precision: nil, null: false
+    t.string "semiexposeds", limit: 36, null: false
+    t.bigint "unseals"
+    t.bigint "beloveds", null: false
+    t.string "asteisms", null: false
+    t.string "loas"
+    t.string "murderings"
+  end
+
+  create_table "syodicons", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "heliotropes"
+    t.date "snerps"
+    t.decimal "ichthyophagians", precision: 16, scale: 2
+    t.decimal "unintersecteds", precision: 16, scale: 2
+    t.decimal "rollinia", precision: 16, scale: 2
+    t.decimal "nondichotomous", precision: 16, scale: 2
+    t.date "ursolics"
+    t.date "hezrons"
+    t.decimal "porules", precision: 16, scale: 2
+    t.string "couthilies"
+    t.boolean "acosmics"
+    t.date "chemis"
+    t.datetime "gangrels", precision: nil, null: false
+    t.datetime "failings", precision: nil, null: false
+    t.string "evocatrixes"
+    t.string "vermicules"
+    t.decimal "eparterials", precision: 16, scale: 2
+    t.string "breakoffs", default: "ACHCO", null: false
+  end
+
+  create_table "syres", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "superbnesses"
+    t.string "sobers"
+    t.string "robustious"
+    t.datetime "sacrococcygeus", precision: nil
+    t.datetime "rakits", precision: nil
+  end
+
+  create_table "syrtics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "rabbinicas"
+    t.bigint "polychromatics", null: false
+    t.decimal "rhexis", precision: 16, scale: 6, default: "0.0"
+    t.decimal "unimbibeds", precision: 16, scale: 2, default: "0.0"
+    t.datetime "autoprogressives", precision: nil, null: false
+    t.datetime "contrapositions", precision: nil, null: false
+    t.decimal "karakas", precision: 16, scale: 6, default: "0.0"
+    t.boolean "anticonstitutionals", default: false
+    t.bigint "arthroscleroses"
+    t.string "concoagulations"
+    t.bigint "jasiones"
+  end
+
+  create_table "tablelands", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "wonderlandishes", null: false
+    t.string "pratincolas", null: false
+    t.datetime "tractablenesses", precision: nil
+    t.datetime "tropostereoscopes", precision: nil
+    t.decimal "quos", precision: 16, scale: 2
+    t.date "incidences"
+    t.date "disrings"
+    t.bigint "eucosia"
+    t.decimal "brools", precision: 16, scale: 2
+    t.string "termins"
+    t.string "bebatters", limit: 36, null: false
+    t.bigint "slippinglies"
+  end
+
+  create_table "tabus", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "proteinochromogens", null: false
+    t.decimal "outrushes", precision: 16, scale: 15, default: "0.0"
+    t.decimal "tiliaceous", precision: 16, scale: 15, default: "0.0"
+    t.text "groomers"
+    t.datetime "camphanics", precision: nil, null: false
+    t.datetime "dairymen", precision: nil, null: false
+    t.text "staymakers"
+  end
+
+  create_table "tamables", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "udders"
+    t.bigint "accessarinesses"
+    t.string "isobathics"
+    t.string "hylegiacals"
+    t.integer "sunburnednesses"
+    t.string "consonantics"
+    t.integer "kecklings"
+    t.string "address_line_1"
+    t.integer "address_line_1_distance"
+    t.string "address_line_2"
+    t.integer "address_line_2_distance"
+    t.string "golees"
+    t.integer "holdups"
+    t.string "baggagemen"
+    t.integer "slatteds"
+    t.string "shufflewings"
+    t.integer "interpunctions"
+    t.string "stoodens"
+    t.integer "monarchists"
+    t.float "laparoenterotomies"
+    t.integer "millies"
+    t.datetime "securitans", precision: nil
+    t.datetime "photochromographies", precision: nil
+    t.boolean "nucleoplasmatics"
+    t.boolean "repermits"
+    t.boolean "address_line_1_success"
+    t.boolean "address_line_2_success"
+    t.boolean "laggins"
+    t.boolean "balsas"
+    t.boolean "geronomites"
+    t.boolean "altheas"
+    t.boolean "youngnesses"
+    t.boolean "damaginglies"
+    t.boolean "eleemosynaries"
+    t.boolean "indicators"
+    t.boolean "serapeas"
+    t.boolean "goniatites"
+    t.boolean "urbifies"
+    t.boolean "preaxiallies"
+    t.boolean "interresponsibilities"
+    t.boolean "sponsalia"
+    t.boolean "usuries"
+  end
+
+  create_table "tamaras", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "circumnavigables", null: false
+    t.string "imperspicuous", null: false
+    t.string "rists", null: false
+    t.string "hires", null: false
+    t.string "hebrewdoms"
+    t.string "clairaudiences", null: false
+    t.string "reciprocates", limit: 36, null: false, collation: "ascii_general_ci"
+    t.datetime "tripartitelies", precision: nil
+    t.datetime "printworks", precision: nil
+  end
+
+  create_table "tamers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "pterodactylians"
+    t.datetime "ascertains", precision: nil, null: false
+    t.datetime "pseudolunules", precision: nil, null: false
+    t.boolean "matriarches", default: false
+    t.boolean "dentirostrates", default: true, null: false
+    t.string "encephalomalaxis", default: "debit_date", null: false
+    t.string "intrapsychicals"
+  end
+
+  create_table "tammanies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "tellers", limit: 36, null: false
+    t.string "isuretines"
+    t.string "usselves"
+    t.decimal "fluentnesses", precision: 16, scale: 2
+    t.text "subclovers"
+    t.date "indefectiblies"
+    t.date "phonophorous"
+    t.date "sakis"
+    t.integer "hollowfaceds"
+    t.string "hemerobiids"
+    t.bigint "unfiles", null: false
+    t.string "policemanlikes", null: false
+    t.boolean "provokables", default: false
+    t.datetime "chondrogenies", precision: nil, null: false
+    t.datetime "interimistics", precision: nil, null: false
+    t.string "accepteds", null: false
+  end
+
+  create_table "tammies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "nandis"
+    t.date "chloriders"
+    t.datetime "sunsets", precision: nil
+    t.datetime "swissesses", precision: nil
+  end
+
+  create_table "tanistries", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "cueists"
+    t.string "brachioradials"
+    t.bigint "spreckles"
+    t.string "curdies"
+    t.datetime "silicules", precision: nil
+    t.datetime "discomycetes", precision: nil
+  end
+
+  create_table "targeteds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "factitudes", limit: 36, null: false
+    t.integer "nonspills", null: false
+    t.string "moistifies"
+    t.string "beglerbegships"
+    t.integer "camphorates"
+    t.datetime "wildcatters", precision: nil
+    t.datetime "desulphurizes", precision: nil
+    t.datetime "unflitcheds", precision: nil
+  end
+
+  create_table "tarradiddles", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "transitionists"
+    t.decimal "homoeographies", precision: 16, scale: 2, default: "0.0"
+    t.decimal "tremblinglies", precision: 16, scale: 2, default: "0.0"
+    t.datetime "diplopodas", precision: nil, null: false
+    t.datetime "regalnesses", precision: nil, null: false
+    t.text "electroopticals"
+    t.bigint "vindicatorilies"
+  end
+
+  create_table "tassels", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "bedplates", null: false
+    t.bigint "coutelles", null: false
+    t.string "laangs", null: false
+    t.datetime "iwas", precision: nil
+    t.datetime "gravesides", precision: nil
+  end
+
+  create_table "tastings", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "aquaticallies", null: false
+    t.integer "hallings", limit: 1
+    t.string "slopworkers", null: false
+    t.string "cholanics"
+    t.datetime "tangkas", precision: nil
+    t.datetime "vaginates", precision: nil
+    t.string "rogations", limit: 36
+    t.string "granules", null: false
+    t.text "chromidiosomes"
+  end
+
+  create_table "tataupas", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.text "manatines", null: false
+    t.text "stroboscopes", null: false
+    t.text "neurotomes"
+    t.bigint "clericalists"
+    t.string "undiffracteds"
+    t.string "overtimorous"
+    t.integer "nodulars"
+    t.datetime "unturns", precision: nil
+    t.bigint "devilishes", null: false
+    t.datetime "yokelishes", precision: nil
+    t.datetime "baculiticones", precision: nil
+  end
+
+  create_table "taums", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "bushis", limit: 36, null: false
+    t.string "strongbraineds", null: false
+    t.bigint "salays", null: false
+    t.string "cardiorespiratories", null: false
+    t.bigint "uralia", null: false
+    t.text "preconsciouslies", size: :medium
+    t.datetime "irresolvablenesses", precision: nil
+    t.datetime "jussories", precision: nil
+  end
+
+  create_table "taxaspideans", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "theophania", null: false
+    t.string "previsionals", null: false
+    t.decimal "tabarets", precision: 16, scale: 2, null: false
+    t.datetime "ahungries", precision: nil
+    t.datetime "malagasies", precision: nil, null: false
+    t.datetime "tristrams", precision: nil, null: false
+    t.datetime "religionlesses", precision: nil, null: false
+  end
+
+  create_table "taxeaters", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "fijians"
+    t.string "colchicaceaes"
+    t.decimal "meteorologicals", precision: 16, scale: 2, default: "0.0"
+    t.integer "interallies"
+    t.datetime "slickeries", precision: nil, null: false
+    t.datetime "liegers", precision: nil, null: false
+  end
+
+  create_table "taxibuses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.datetime "reconfesses", precision: nil, null: false
+    t.bigint "matchers", null: false
+    t.bigint "radiolitics", null: false
+    t.bigint "surprisables", null: false
+    t.datetime "pentastomoids", precision: nil
+    t.datetime "dialogistics", precision: nil
+    t.bigint "trichromatisms", default: 0, null: false
+    t.bigint "achlamydeous"
+  end
+
+  create_table "taxlesses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "inspirators"
+    t.string "labiomancies"
+    t.datetime "soteres", precision: nil, null: false
+    t.datetime "photomagnetisms", precision: nil, null: false
+    t.integer "tripmadams"
+    t.string "kankies", limit: 300, default: "--- []\n"
+    t.string "faultfinds"
+    t.boolean "isoperimetrics", default: false
+    t.boolean "rewardfuls", default: false
+    t.string "palaeotypicallies"
+    t.string "silverheads"
+    t.boolean "solaneines", default: false
+    t.datetime "rubelets", precision: nil
+    t.string "wattages"
+    t.string "bryanisms"
+    t.string "endoneurials"
+    t.string "calids"
+    t.boolean "overconsideratelies", default: false
+    t.string "polyplacophorous"
+    t.string "psychosurgeons"
+    t.string "reservables"
+    t.string "thermetrographs"
+    t.string "unallieds"
+    t.string "wharfings"
+    t.string "paradoxographers"
+    t.string "marrees"
+    t.string "papillateds"
+    t.string "triformities"
+    t.string "oxybutyrics"
+    t.string "pareiasaurians"
+    t.string "nepotics"
+    t.string "riks"
+    t.string "ungrappleds"
+    t.string "grins"
+    t.string "phobics"
+    t.string "dinotheria"
+    t.boolean "unexcellents"
+    t.string "choirwises"
+    t.string "fictitious"
+    t.boolean "matsuris", default: false
+    t.boolean "underschemes", default: false
+    t.boolean "glakies", default: false
+    t.boolean "plentifullies", default: false
+    t.boolean "respectablies", default: false
+    t.boolean "ajivikas", default: false
+    t.boolean "unforgivenesses", default: false
+    t.boolean "acromonogrammatics", default: false
+    t.boolean "gastrorrhaphies", default: false
+    t.boolean "nonperiodicals", default: false
+    t.boolean "proenzymes", default: false
+    t.boolean "fraternizes", default: false
+    t.boolean "mesentericallies", default: false
+    t.boolean "recohabitations", default: false
+    t.boolean "sayables", default: false
+    t.string "ostracodes"
+    t.string "fragilaria"
+    t.string "phenolsulphonephthaleins"
+    t.string "redistends", default: ""
+    t.bigint "epenthesizes"
+    t.text "obligatives"
+    t.string "kandelia"
+    t.string "candleshines"
+    t.string "generalia"
+    t.date "tympanuchus"
+    t.bigint "spoutings"
+    t.datetime "shutterwises", precision: nil
+    t.bigint "pouncets"
+    t.string "convectors"
+    t.string "bakongos", limit: 36, null: false
+    t.string "unfitties"
+  end
+
+  create_table "tealeafies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "uruguayans", null: false
+    t.date "chittamwoods", null: false
+    t.datetime "headsets", precision: nil, null: false
+    t.datetime "blickeys", precision: nil
+    t.datetime "overbrilliants", precision: nil, null: false
+    t.datetime "multifidous", precision: nil, null: false
+  end
+
+  create_table "telegraphones", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "teachablies", limit: 36, null: false
+    t.bigint "unreceiveds", null: false
+    t.string "penniferous"
+    t.string "catholes"
+    t.datetime "overswirlings", precision: nil
+    t.integer "pecopteris", null: false
+    t.datetime "nitrates", precision: nil
+    t.datetime "theodicies", precision: nil
+    t.string "unoutrageds"
+    t.bigint "penetrants", null: false
+    t.boolean "digitations", default: false, null: false
+  end
+
+  create_table "teleostomis", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "occasionaries"
+    t.string "gignates"
+    t.integer "beblotches"
+    t.string "woads"
+    t.string "laryngographies"
+    t.text "antivaccinists", size: :medium
+    t.string "unbestarreds"
+  end
+
+  create_table "telethermometers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "groggeries", null: false
+    t.string "magniloquentlies", null: false
+    t.boolean "outstrokes", null: false
+    t.datetime "lamellicorns", precision: nil
+    t.datetime "unlandeds", precision: nil
+    t.boolean "besprents", null: false
+  end
+
+  create_table "teleutos", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "waags"
+    t.bigint "garancines"
+    t.string "melodramatics"
+    t.string "sunts"
+    t.string "hydrophobies"
+    t.string "pretentatives"
+    t.string "salpingotomies"
+    t.bigint "demichamfrons"
+    t.datetime "mixeds", precision: nil
+    t.string "firespouts"
+    t.datetime "agogics", precision: nil, null: false
+    t.datetime "conceptisms", precision: nil, null: false
+  end
+
+  create_table "telotrochals", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "sugarlikes"
+    t.datetime "emydosaurians", precision: nil
+    t.datetime "beetraves", precision: nil
+    t.datetime "superaccomplisheds", precision: nil
+    t.string "topplers"
+    t.bigint "gunracks"
+    t.string "agelacrinites"
+    t.string "confederators", limit: 36
+  end
+
+  create_table "temblors", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "chromotropisms", null: false
+    t.string "ungainsayablies", null: false
+    t.string "ragsorters"
+    t.datetime "lewisites", precision: nil
+    t.datetime "polyphonisms", precision: nil
+  end
+
+  create_table "tenderlings", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "pizes", limit: 36, null: false
+    t.string "postiques", limit: 36, null: false
+    t.string "hierocraticals", limit: 4, null: false
+    t.string "unsugaries", limit: 36, null: false
+    t.datetime "bannermen", precision: nil
+    t.datetime "unplentifuls", precision: nil
+  end
+
+  create_table "tenggereses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "triodontophorus", limit: 36, null: false
+    t.date "irrisories", null: false
+    t.string "wigmakers", null: false
+    t.string "glyceroses", null: false
+    t.integer "cannibalities", null: false
+    t.datetime "whittrets", precision: nil
+    t.datetime "outwriggles", precision: nil
+  end
+
+  create_table "tenophonies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "unlawfullies"
+    t.bigint "quakerishes"
+    t.datetime "iodohydrins", precision: nil, null: false
+    t.datetime "astropectens", precision: nil, null: false
+    t.string "overgrievous"
+    t.date "misguidinglies"
+    t.boolean "unprobeds"
+    t.string "holometaboles"
+  end
+
+  create_table "tepetates", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "hippophiles", limit: 36, null: false, collation: "ascii_general_ci"
+    t.string "folkmotes", limit: 36, null: false, collation: "ascii_general_ci"
+    t.text "dactylomegalies"
+    t.boolean "percentiles", null: false
+    t.datetime "bandfishes", precision: nil, null: false
+    t.datetime "uncontentingnesses", precision: nil, null: false
+    t.datetime "dressmakings", precision: nil, null: false
+    t.text "pneumonokonioses"
+    t.text "piscatoriallies"
+    t.string "cacorhythmics", limit: 36, null: false
+    t.string "outprices", limit: 36, null: false
+  end
+
+  create_table "terebras", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "mooseys"
+    t.bigint "synechologicals"
+    t.string "selensilvers"
+    t.text "unroasteds"
+    t.bigint "parodontitis"
+    t.datetime "bisectionallies", precision: nil
+    t.datetime "thights", precision: nil
+  end
+
+  create_table "termagants", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "sinfulnesses", null: false
+    t.string "headwears", null: false
+    t.string "anthracitics", limit: 36, null: false
+    t.integer "fordables", null: false
+    t.bigint "felicifics", null: false
+    t.datetime "pseudovals", precision: nil, null: false
+    t.datetime "bullfights", precision: nil, null: false
+  end
+
+  create_table "terminativelies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "providorings"
+    t.decimal "colauxes", precision: 16, scale: 2, default: "0.0"
+    t.bigint "interpenetrants"
+    t.datetime "intercontorteds", precision: nil, null: false
+    t.datetime "scrapmongers", precision: nil, null: false
+    t.decimal "inclusivenesses", precision: 16, scale: 2, default: "0.0"
+    t.decimal "tetralogics", precision: 16, scale: 2, default: "0.0"
+    t.decimal "ortyginaes", precision: 16, scale: 2, default: "0.0"
+    t.decimal "saturnia", precision: 16, scale: 2, default: "0.0"
+    t.string "planlesslies"
+  end
+
+  create_table "terpinols", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "euphonies", limit: 36, null: false
+    t.string "gerontoxons", null: false
+    t.date "madagasses", null: false
+    t.datetime "colleters", precision: nil
+    t.datetime "attributers", precision: nil
+  end
+
+  create_table "terricoles", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "hispidulates", null: false
+    t.string "doxologicals", null: false
+    t.string "archspirits", null: false
+    t.string "anuries", null: false
+    t.datetime "nonignorants", precision: nil
+    t.datetime "sinistroculars", precision: nil
+  end
+
+  create_table "terrierlikes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "exudations"
+    t.boolean "perieleses", default: true
+    t.datetime "oversubscriptions", precision: nil, null: false
+    t.datetime "dawkins", precision: nil, null: false
+    t.string "misogynics", null: false
+    t.boolean "aluminas", default: true, null: false
+    t.boolean "taweries", default: false, null: false
+    t.string "woolers", default: "debit_date", null: false
+    t.string "unstrengthens"
+    t.datetime "intemperances", precision: nil
+    t.datetime "gestatories", precision: nil
+    t.string "hydrometries"
+    t.bigint "williamsoniaceaes"
+  end
+
+  create_table "terriers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "oncometrics", null: false
+    t.integer "teasellikes", null: false
+    t.datetime "solifugaes", precision: nil, null: false
+    t.datetime "pahs", precision: nil, null: false
+    t.datetime "oscillations", precision: nil, null: false
+    t.boolean "pococurantists", null: false
+    t.boolean "unbewitches", null: false
+    t.bigint "hospitations", null: false
+    t.boolean "hogans"
+    t.integer "syndicalists", limit: 1
+  end
+
+  create_table "teruyukis", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "piannets", null: false
+    t.string "ghibellinisms", limit: 36, null: false
+    t.text "boltonia", null: false
+    t.datetime "stomatoplastics", precision: nil, null: false
+    t.datetime "dextrorselies", precision: nil, null: false
+    t.bigint "undigs", null: false
+    t.bigint "winklehawks", null: false
+    t.string "apoops", null: false
+    t.string "befrounces", default: "NOT_PROCESSED", null: false
+  end
+
+  create_table "tesserants", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "sanguinaceous", null: false
+    t.string "hardens", null: false
+    t.boolean "aenigmatites", default: true, null: false
+    t.boolean "pantagruels", default: false, null: false
+    t.datetime "socrateans", precision: nil
+    t.datetime "sipings", precision: nil
+    t.string "approbators", limit: 36
+  end
+
+  create_table "testoons", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "prosopyles", limit: 36, null: false
+    t.bigint "installations", null: false
+    t.integer "subcontinents", null: false
+    t.string "temperas", null: false
+    t.string "reflexibles", null: false
+    t.string "hempstrings"
+    t.bigint "haphazardlies"
+    t.datetime "unagitateds", precision: nil, null: false
+    t.datetime "unmarchings", precision: nil, null: false
+  end
+
+  create_table "testudinaria", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "antlids", null: false
+    t.string "unregardedlies", null: false
+    t.string "onlookers", null: false
+    t.text "exagitates", null: false
+    t.datetime "scoundreldoms", precision: nil
+    t.datetime "cyprians", precision: nil
+  end
+
+  create_table "tetanus", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "tessellas", limit: 36, null: false, collation: "ascii_general_ci"
+    t.string "unweapons", limit: 36, null: false, collation: "ascii_general_ci"
+    t.string "ungnostics", null: false
+    t.string "attalehs", null: false
+    t.text "spicates"
+    t.datetime "quinquedentateds", precision: nil, null: false
+    t.datetime "aldanes", precision: nil, null: false
+    t.datetime "galactometries", precision: nil
+    t.datetime "breds", precision: nil, null: false
+    t.datetime "crepes", precision: nil
+    t.integer "declericalizes"
+    t.string "predominations", limit: 36, collation: "ascii_general_ci"
+  end
+
+  create_table "tetragonia", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "titerations"
+    t.string "parapathies"
+    t.string "friedrichsdors"
+    t.date "tachysterols"
+    t.datetime "heliozoics", precision: nil, null: false
+    t.datetime "falsens", precision: nil, null: false
+    t.boolean "vasotripsies", default: false, null: false
+  end
+
+  create_table "tetrahydrateds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.decimal "gobbledygooks", precision: 16, scale: 2, null: false
+    t.string "actinoblasts", limit: 36, null: false
+    t.bigint "quinaldinics", null: false
+    t.bigint "paradoxures", null: false
+    t.string "catonians", null: false
+    t.datetime "explainables", precision: nil
+    t.datetime "sarcocystis", precision: nil
+  end
+
+  create_table "tetralemmas", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "bitheisms"
+    t.string "implicants"
+    t.string "mounts"
+    t.string "fimbrillates"
+    t.date "characterisms"
+    t.string "unhippeds"
+    t.boolean "voicelessnesses", default: false
+    t.datetime "beakermen", precision: nil, null: false
+    t.datetime "inhales", precision: nil, null: false
+    t.integer "grandiloquences"
+    t.string "dishexecontahedroids"
+    t.string "manualiters"
+    t.boolean "provocants", default: false
+    t.boolean "enlodgements", default: true
+    t.integer "strigaes"
+    t.integer "consciencelesslies"
+    t.boolean "tunkets", default: true
+    t.bigint "linearlies"
+    t.bigint "uniridescents"
+    t.boolean "unidirecteds", default: false, null: false
+    t.string "carbocinchomeronics", limit: 36, null: false
+    t.string "orthopteroideas", null: false
+    t.bigint "alexipyretics", null: false
+    t.datetime "superseptals", precision: nil
+  end
+
+  create_table "thalamiflorous", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "nephroerysipelas", null: false
+    t.string "bumblers", null: false
+    t.text "outtells"
+    t.datetime "suffraganeous", precision: nil
+    t.datetime "dishwaters", precision: nil
+    t.bigint "explosibilities"
+    t.string "stipuleds"
+    t.boolean "herdboys", null: false
+    t.date "subbasaltics", null: false
+    t.boolean "faculas", default: false
+    t.string "toltecs", default: "draft", null: false
+    t.text "hesitatingnesses"
+    t.boolean "hepaticostomies"
+    t.boolean "credentlies", default: false
+    t.string "infragrants", limit: 36, null: false
+    t.string "uncredulous", default: "voluntary", null: false
+  end
+
+  create_table "thanatophidians", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.integer "surveyances"
+    t.bigint "cloakmakings"
+    t.datetime "tyrannouslies", precision: nil
+    t.datetime "integuments", precision: nil
+  end
+
+  create_table "thanatousia", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "orohydrographics", null: false
+    t.string "liftables"
+    t.datetime "unoffensivenesses", precision: nil
+    t.datetime "biographies", precision: nil
+  end
+
+  create_table "theatrophiles", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "quadruplets"
+    t.bigint "succinites", null: false
+    t.string "daubings"
+    t.string "singultous", null: false
+    t.datetime "grippies", precision: nil
+    t.datetime "propaedeutics", precision: nil
+    t.string "continuedlies", limit: 36, null: false
+  end
+
+  create_table "thelyplasties", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "escalades", limit: 36, null: false
+    t.bigint "nieves", null: false
+    t.datetime "briggs", precision: nil, null: false
+    t.datetime "macroprisms", precision: nil, null: false
+  end
+
+  create_table "theomythologies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "rarotongans"
+    t.string "flummeries", null: false
+    t.datetime "pentamerous", precision: nil, null: false
+    t.datetime "adobes", precision: nil, null: false
+    t.string "cancerous", limit: 36
+  end
+
+  create_table "theopaschites", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "altometers", limit: 36, null: false
+    t.bigint "subantichrists", null: false
+    t.string "spaecrafts", null: false
+    t.datetime "nextlies", precision: nil, null: false
+    t.datetime "ointments", precision: nil, null: false
+  end
+
+  create_table "theophorics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "gasmakers", null: false
+    t.string "loxotomies"
+    t.string "fiendishlies"
+    t.string "chorioretinitis"
+    t.date "transoceans"
+    t.datetime "rills", precision: nil, null: false
+    t.datetime "remembrances", precision: nil, null: false
+  end
+
+  create_table "thereanents", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "endodontics", limit: 36, null: false
+    t.date "icemen", null: false
+    t.date "nebulizers", null: false
+    t.string "septa", null: false
+    t.string "crystosphenes", null: false
+    t.datetime "nonspecificities", precision: nil
+    t.datetime "dissentiencies", precision: nil
+  end
+
+  create_table "thereouts", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "larrigans"
+    t.string "consults"
+    t.string "haughtnesses"
+    t.string "whitetails"
+    t.bigint "ladyfingers"
+    t.string "lighthouses"
+    t.datetime "misexpressions", precision: nil
+    t.datetime "quakerizes", precision: nil
+  end
+
+  create_table "thermoneuroses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "messings", limit: 36, null: false
+    t.bigint "cognizances", null: false
+    t.string "mesocoracoids", null: false
+    t.datetime "debts", precision: nil
+    t.datetime "snavels", precision: nil
+    t.datetime "milliares", precision: nil
+  end
+
+  create_table "thickens", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "matchmakers", limit: 36, null: false
+    t.bigint "pectinatodenticulates", null: false
+    t.string "fingerers", null: false
+    t.datetime "unbolds", precision: nil, null: false
+    t.datetime "antecommunions", precision: nil, null: false
+    t.boolean "arthrobranchia", default: false, null: false
+    t.boolean "afterthoughts", default: false, null: false
+  end
+
+  create_table "thicknessings", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "brams"
+    t.boolean "thaumaturgia", default: true, null: false
+    t.datetime "existibles", precision: nil, null: false
+    t.bigint "tirribis"
+    t.datetime "ammodytoids", precision: nil
+    t.datetime "reshines", precision: nil
+  end
+
+  create_table "thievelesses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "folials", null: false
+    t.boolean "counterweighs", default: false
+    t.datetime "unpillorieds", precision: nil
+    t.datetime "rosarubies", precision: nil
+    t.datetime "grieffuls", precision: nil
+    t.boolean "solates"
+  end
+
+  create_table "thimblelikes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "intumesces"
+    t.boolean "borts", default: false
+    t.boolean "corbiculas", default: false
+    t.integer "censorious", limit: 1
+    t.integer "mormyrids", limit: 1
+    t.datetime "hopperettes", precision: nil
+    t.datetime "kiestlesses", precision: nil
+    t.boolean "diplocephalies", default: false
+    t.boolean "pulverizers", default: false
+    t.string "trichinellas"
+    t.string "obligativenesses"
+    t.datetime "plankwises", precision: nil
+    t.string "matchablenesses"
+    t.datetime "contrahents", precision: nil
+  end
+
+  create_table "thons", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "lambhoods", limit: 36, null: false
+    t.bigint "reappraisements", null: false
+    t.bigint "isallobars", null: false
+    t.datetime "polissoirs", precision: nil, null: false
+    t.datetime "twofoldlies", precision: nil, null: false
+  end
+
+  create_table "thundersmites", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.integer "trioeciouslies", limit: 1, null: false
+    t.bigint "spiries", null: false
+    t.boolean "yagnobs", default: false, null: false
+    t.datetime "overgrieves", precision: nil
+    t.datetime "dexters", precision: nil
+    t.string "reinterventions"
+    t.bigint "unfrizzs"
+  end
+
+  create_table "thyesteans", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "revues", null: false
+    t.bigint "misrepresenters"
+    t.date "lennies", null: false
+    t.datetime "orchellas", precision: nil
+    t.datetime "unprofiteds", precision: nil
+    t.string "resentiences"
+  end
+
+  create_table "thymetics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "bookables", limit: 36, null: false
+    t.string "prolatenesses", limit: 100
+    t.text "pliskies"
+    t.datetime "cabbages", precision: nil
+    t.datetime "butanols", precision: nil
+  end
+
+  create_table "ticktacks", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "selectmen", limit: 36, null: false
+    t.bigint "fictioneers", null: false
+    t.datetime "paradichlorbenzenes", precision: nil
+    t.datetime "acarologies", precision: nil
+    t.string "phosphoriferous", default: "OTHER", null: false
+    t.integer "innervates", null: false
+  end
+
+  create_table "tillodontidaes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "molossidaes", limit: 36, null: false
+    t.bigint "paragraphs", null: false
+    t.string "nicols", limit: 36, null: false
+    t.decimal "narwhalians", precision: 16, scale: 2
+    t.decimal "spinetails", precision: 16, scale: 2
+    t.datetime "variolizations", precision: nil, null: false
+    t.datetime "sustainers", precision: nil, null: false
+    t.decimal "psychopannychistics", precision: 16, scale: 2
+    t.decimal "upstamps", precision: 16, scale: 2
+    t.decimal "boatwomen", precision: 16, scale: 2
+    t.decimal "substanches", precision: 16, scale: 2
+    t.date "prothetics"
+    t.string "jejunoduodenals", limit: 36
+    t.boolean "glassinesses", default: false
+  end
+
+  create_table "timberlands", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "electrodepositions", null: false
+    t.text "nairs", null: false
+    t.text "centrosymmetrics"
+    t.boolean "differencinglies", default: false
+    t.boolean "changefuls", default: false
+    t.boolean "undreggies", default: false
+    t.date "evenwises", null: false
+    t.string "arteriofibroses"
+    t.string "semidisks"
+    t.datetime "subartesians", precision: nil, null: false
+    t.datetime "philosophicohistoricals", precision: nil, null: false
+    t.boolean "ninetieths", default: false
+    t.date "dragonishes"
+    t.boolean "gelandelaufers", default: false
+    t.text "subreason1"
+    t.text "subreason2"
+    t.string "predetrimentals"
+    t.text "subreason2_if_other_chosen"
+  end
+
+  create_table "tinlets", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "markebs", limit: 36, null: false
+    t.string "takars", null: false
+    t.datetime "harperesses", precision: nil
+    t.datetime "jotties", precision: nil
+  end
+
+  create_table "tintlesses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "metamericallies", null: false
+    t.string "impletes"
+    t.text "mcintoshes"
+    t.datetime "niddicks", precision: nil
+    t.datetime "raphia", precision: nil
+    t.datetime "unreduciblenesses", precision: nil
+    t.bigint "teleia"
+    t.datetime "phrenocardia", precision: nil
+    t.datetime "lanugos", precision: nil
+    t.string "interrogatednesses"
+  end
+
+  create_table "tirerooms", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "theolatrous"
+    t.datetime "myiferous", precision: nil, null: false
+    t.datetime "subumbonals", precision: nil, null: false
+  end
+
+  create_table "tissuals", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "sanatoria", limit: 36, null: false
+    t.bigint "fils", null: false
+    t.bigint "prepubis", null: false
+    t.text "reciprocators"
+    t.datetime "chathamites", precision: nil, null: false
+    t.datetime "choletherapies", precision: nil, null: false
+  end
+
+  create_table "tizzies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "isoagglutinogens"
+    t.date "wittifieds", null: false
+    t.date "intrusions"
+    t.boolean "storaxes", default: false
+    t.boolean "lokmen", default: false
+    t.boolean "nonpartisans"
+    t.date "theriacs"
+    t.string "amaterialistics"
+    t.date "preposterouslies"
+    t.datetime "bubastids", precision: nil
+    t.datetime "reoffenses", precision: nil
+    t.date "emcees"
+    t.boolean "unstintinglies", default: false, null: false
+    t.string "tiemakers", limit: 36, null: false
+  end
+
+  create_table "tocororos", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "atelectases", null: false
+    t.boolean "folia", default: false, null: false
+    t.bigint "desilvers"
+    t.bigint "pondweeds"
+    t.datetime "oceanwises", precision: nil, null: false
+    t.datetime "ligules", precision: nil, default: "3000-01-01 00:00:00", null: false
+    t.bigint "caesalpiniaceaes", null: false
+    t.bigint "overthwartnesses"
+  end
+
+  create_table "tonelessnesses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "theatricables", null: false
+    t.bigint "sepals", null: false
+    t.string "semicantilevers", null: false
+    t.bigint "cosmopolitanizations", null: false
+    t.string "quadrenniallies", null: false
+    t.date "tetramorphous"
+    t.datetime "idiomusculars", precision: nil
+    t.datetime "tunablenesses", precision: nil
+  end
+
+  create_table "topazines", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "arthropodals", limit: 36, null: false
+    t.text "respondes", null: false
+    t.datetime "pyoxanthoses", precision: nil
+    t.datetime "farmyardies", precision: nil
+    t.string "pterocaryas", null: false
+  end
+
+  create_table "topotypicals", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "costraights", limit: 36, null: false
+    t.bigint "kryptons", null: false
+    t.string "deconcentrations", null: false
+    t.date "watermongers", null: false
+    t.bigint "factiouslies", null: false
+    t.bigint "hokans", null: false
+    t.datetime "collareds", precision: nil
+    t.datetime "zs", precision: nil
+  end
+
+  create_table "torbanites", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "belies"
+    t.bigint "whortles"
+    t.bigint "boodlers"
+    t.datetime "callosities", precision: nil, null: false
+    t.datetime "mothersomes", precision: nil, null: false
+    t.decimal "susanchites", precision: 16, scale: 2, default: "0.0", null: false
+  end
+
+  create_table "torchmen", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "peculiarnesses", null: false
+    t.bigint "munia"
+    t.bigint "indigenouslies"
+    t.bigint "quinquefoliateds", null: false
+    t.decimal "histonals", precision: 16, scale: 2
+    t.string "crooknecks"
+    t.datetime "paleobiogeographies", precision: nil
+    t.datetime "stereotelemeters", precision: nil
+  end
+
+  create_table "tororokombus", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "bettings", null: false
+    t.bigint "fulgorids", null: false
+    t.datetime "chaetopodous", precision: nil, null: false
+    t.datetime "rockweeds", precision: nil, null: false
+  end
+
+  create_table "tortulaceous", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "palaeics", limit: 36, null: false
+    t.integer "shatans", null: false
+    t.string "misdescribes", null: false
+    t.boolean "synchronisticals", null: false
+    t.datetime "quaestorials", precision: nil
+    t.datetime "trenchantnesses", precision: nil
+  end
+
+  create_table "totalizators", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "chilognaths"
+    t.boolean "copperizes", default: true, null: false
+    t.bigint "mozarabics"
+    t.datetime "nationalistics", precision: nil
+    t.datetime "mantispidaes", precision: nil
+  end
+
+  create_table "touristdoms", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "dockers", null: false
+    t.integer "mithridatics", null: false
+    t.date "unneighborlies", null: false
+    t.decimal "pieceworks", precision: 16, scale: 6
+    t.decimal "bradycinesia", precision: 16, scale: 6
+    t.text "lightproofs"
+    t.datetime "duodecimfids", precision: nil
+    t.datetime "unthirstings", precision: nil
+  end
+
+  create_table "trachomas", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "hazardlesses"
+    t.string "nectarials", null: false
+    t.text "blusterous"
+    t.bigint "cerebrins"
+    t.string "minimalisms"
+    t.string "nyctitropics", null: false
+    t.string "talabons", null: false
+    t.integer "shepstares", default: 0, null: false
+    t.datetime "neuropsychiatrics", precision: nil
+    t.datetime "wiretails", precision: nil
+    t.bigint "colletes"
+    t.string "thermosettings"
+    t.string "atticomastoids"
+  end
+
+  create_table "tradesmanships", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.integer "disseizors", null: false
+    t.string "inflicters", null: false
+    t.datetime "hemoscopies", precision: nil, null: false
+    t.datetime "countersuggestions", precision: nil, null: false
+  end
+
+  create_table "trammelinglies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "reiterateds", limit: 36, null: false
+    t.bigint "shortsighteds", null: false
+    t.string "yurujures", limit: 36, null: false
+    t.bigint "cancans", null: false
+    t.string "germantowns", limit: 36, null: false
+    t.bigint "ungibbets", null: false
+    t.string "unreligioneds", limit: 36, null: false
+    t.date "udalers"
+    t.string "sheepishnesses", null: false
+    t.decimal "transorbitals", precision: 16, scale: 2, null: false
+    t.decimal "ingests", precision: 16, scale: 2, null: false
+    t.decimal "arsines", precision: 16, scale: 2, null: false
+    t.decimal "acutangulars", precision: 16, scale: 2, null: false
+    t.decimal "termitaries", precision: 16, scale: 2, null: false
+    t.decimal "puthers", precision: 16, scale: 2, null: false
+    t.decimal "pyknics", precision: 16, scale: 2, null: false
+    t.decimal "saunas", precision: 16, scale: 2, null: false
+    t.decimal "lokets", precision: 16, scale: 2, null: false
+    t.decimal "unmindfullies", precision: 16, scale: 2, null: false
+    t.decimal "grandfatherships", precision: 16, scale: 2, null: false
+    t.decimal "unidealistics", precision: 16, scale: 2, null: false
+    t.decimal "repursues", precision: 16, scale: 2, null: false
+    t.decimal "smiris", precision: 16, scale: 2, null: false
+    t.datetime "jargons", precision: nil, null: false
+    t.datetime "pneumatotherapeutics", precision: nil, null: false
+  end
+
+  create_table "transferribilities", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "tridecylenes", null: false
+    t.datetime "tricephals", precision: nil
+    t.datetime "effluents", precision: nil
+    t.bigint "mores", null: false
+    t.date "stellaria", null: false
+    t.date "spinulosogranulates", null: false
+  end
+
+  create_table "translatresses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "gratia", limit: 36, null: false
+    t.bigint "anteorbitals", null: false
+    t.decimal "intensivelies", precision: 16, scale: 15
+    t.decimal "phanerozonia", precision: 16, scale: 15
+    t.string "leiophyllums"
+    t.text "tokenlesses"
+    t.datetime "orthognathics", precision: nil, null: false
+    t.datetime "ebrious", precision: nil, null: false
+  end
+
+  create_table "transparencies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "polybranchia", null: false
+    t.bigint "dianilides", null: false
+    t.bigint "spiritlands"
+    t.datetime "hexodes", precision: nil
+    t.datetime "rhinolophines", precision: nil
+  end
+
+  create_table "transpleurals", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "maegbotes", limit: 36, null: false
+    t.bigint "profeminisms", null: false
+    t.bigint "oxaluramides", null: false
+    t.bigint "sargus", null: false
+    t.date "snatchilies", null: false
+    t.datetime "redemptives", precision: nil
+    t.datetime "sinians", precision: nil
+  end
+
+  create_table "transubstantials", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "snotties", limit: 36, null: false
+    t.string "unlastings"
+    t.bigint "grudgefuls"
+    t.string "unleds", null: false
+    t.string "hieraticisms", null: false
+    t.datetime "morals", precision: nil, null: false
+    t.datetime "preformationists", precision: nil, null: false
+  end
+
+  create_table "transversospinals", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "weftages", limit: 36, null: false
+    t.bigint "antirumors", null: false
+    t.integer "catchcries", limit: 2
+    t.integer "interpretorials", limit: 1
+    t.integer "doublegangers", limit: 1
+    t.integer "ridgeds", limit: 1
+    t.integer "inulases", limit: 1
+    t.integer "recharters", limit: 1
+    t.integer "swordplays", limit: 1
+    t.string "reason_code_1"
+    t.string "reason_code_2"
+    t.string "reason_code_3"
+    t.string "reason_code_4"
+    t.string "reason_code_5"
+    t.string "reason_code_6"
+    t.datetime "scandinavia", precision: nil
+    t.datetime "overnarrows", precision: nil
+    t.bigint "pugnacities"
+  end
+
+  create_table "trappoids", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.decimal "biplanals", precision: 10
+    t.decimal "unscorings", precision: 10, null: false
+    t.string "vulnerablenesses", null: false
+    t.string "myrrhols", null: false
+    t.string "enrapts", limit: 36, null: false
+    t.bigint "theologizes", null: false
+    t.datetime "psychorealists", precision: nil, null: false
+    t.datetime "feces", precision: nil, null: false
+    t.datetime "exculpates", precision: nil
+  end
+
+  create_table "tregergs", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "provables", limit: 36, null: false
+    t.string "quakinesses", limit: 36, null: false
+    t.string "zonitids", limit: 36, null: false
+    t.decimal "northeasterns", precision: 16, scale: 2, null: false
+    t.datetime "hates", precision: nil, null: false
+    t.datetime "gauds", precision: nil, null: false
+    t.boolean "undisparities", default: false, null: false
+    t.datetime "featherers", precision: nil
+    t.string "poleburns", limit: 36
+  end
+
+  create_table "tremas", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "sulides", limit: 36, null: false
+    t.bigint "refavors", null: false
+    t.bigint "nonacknowledgments", null: false
+    t.datetime "directors", precision: nil, null: false
+    t.bigint "anodals"
+    t.bigint "pioneers"
+    t.bigint "polygoneutisms"
+    t.bigint "pinguiculaceous"
+    t.bigint "rhabdos"
+    t.bigint "unforgivinglies"
+    t.bigint "prothrombins"
+    t.bigint "sarsas"
+    t.bigint "resistivenesses"
+    t.bigint "observatorials"
+    t.bigint "cypseloids"
+    t.bigint "unshuffles"
+    t.bigint "swaggeringlies"
+    t.bigint "philocynies"
+    t.bigint "innocentlies"
+    t.bigint "vitiators"
+    t.bigint "nonlimitations"
+    t.bigint "borotungstates"
+    t.bigint "groins"
+    t.bigint "peevedlies"
+    t.bigint "cainguas"
+    t.boolean "hushedlies"
+    t.string "arribas"
+    t.decimal "laryngendoscopes", precision: 16, scale: 15
+    t.decimal "kinetomers", precision: 16, scale: 15
+    t.string "corporealizations"
+    t.decimal "odophones", precision: 16, scale: 2
+    t.string "ortives"
+    t.bigint "inquilinaes"
+    t.bigint "presternals"
+    t.string "persulphurics"
+    t.bigint "unstorieds"
+    t.decimal "dendroceratines", precision: 16, scale: 6
+    t.bigint "improficiencies"
+    t.decimal "cardinals", precision: 16, scale: 15
+    t.bigint "overprovenders"
+    t.decimal "bulbous", precision: 16, scale: 6
+    t.decimal "aquilaria", precision: 16, scale: 6
+    t.decimal "kappas", precision: 16, scale: 6
+    t.bigint "autosymbolics"
+    t.bigint "actinotherapeutics"
+    t.datetime "thiamines", precision: nil, null: false
+    t.datetime "wiseacres", precision: nil, null: false
+  end
+
+  create_table "tremetols", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "proroguers"
+    t.bigint "incloses"
+    t.string "silicles"
+    t.string "lizards"
+    t.text "transpicuouslies"
+    t.string "bicipitous"
+    t.string "denominationalists"
+    t.datetime "chinchillas", precision: nil
+    t.datetime "teleutoforms", precision: nil, null: false
+    t.datetime "ruckseys", precision: nil, null: false
+    t.text "xanthites"
+  end
+
+  create_table "triakistetrahedrals", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "surfles", null: false
+    t.bigint "mihrabs", null: false
+    t.bigint "maladventures"
+    t.bigint "oniscoideans"
+    t.date "staidnesses"
+    t.string "accentlesses"
+    t.string "missishnesses"
+    t.date "news"
+    t.string "venerativelies"
+    t.string "antiphagocytics"
+    t.boolean "trappeds"
+    t.date "succedaneas"
+    t.datetime "ciconioids", precision: nil, null: false
+    t.datetime "baselies", precision: nil, null: false
+    t.bigint "exercitorians"
+    t.string "araminas"
+    t.integer "buyides"
+    t.bigint "turricals"
+    t.boolean "vashegyites", default: false, null: false
+    t.bigint "epituberculous"
+  end
+
+  create_table "trianders", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "intrastromals", limit: 36, null: false
+    t.string "miliolas", limit: 36
+    t.string "absinthics"
+    t.text "gnostologies"
+    t.string "subtractions"
+    t.text "copis"
+    t.string "prolificies", limit: 36
+    t.datetime "desmopathologists", precision: nil
+    t.datetime "ophionines", precision: nil
+    t.integer "leaseholds", default: 1
+    t.integer "subjectionals", null: false
+  end
+
+  create_table "trichodontidaes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "kaisers", limit: 36, null: false, collation: "ascii_general_ci"
+    t.string "homoeogenics", limit: 36, null: false, collation: "ascii_general_ci"
+    t.boolean "obreptions", null: false
+    t.datetime "antihypochondriacs", precision: nil
+    t.datetime "orichalcums", precision: nil
+  end
+
+  create_table "trichopterygidaes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "collapsibles", null: false
+    t.string "embossings", null: false
+    t.string "meerschaums"
+    t.datetime "resinols", precision: nil
+    t.datetime "tuffs", precision: nil
+    t.datetime "imperviousnesses", precision: nil
+    t.string "apanteses"
+  end
+
+  create_table "tridimensioneds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "nattereds", null: false
+    t.string "beneficiaryships"
+    t.bigint "congratulatories"
+    t.string "ambivalences", null: false
+    t.bigint "geats", null: false
+    t.string "gaffkyas", null: false
+    t.string "cynthiidaes", null: false
+    t.decimal "microdonts", precision: 16, scale: 2, default: "0.0", null: false
+    t.string "gaynesses"
+    t.string "lymphectasia"
+    t.text "mangonisms"
+    t.datetime "anxious", precision: nil
+    t.datetime "waltzers", precision: nil
+    t.boolean "joyces", default: false
+  end
+
+  create_table "trigonellas", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "ballers", limit: 36, null: false
+    t.bigint "misrealizes", null: false
+    t.text "spillovers"
+    t.text "onomatopoeians"
+    t.text "gandermooners"
+    t.text "bradyspermatisms"
+    t.text "jethros"
+    t.text "gonimia"
+    t.text "redubbers"
+    t.text "outpops"
+    t.text "fishhouses"
+    t.datetime "undersingings", precision: nil
+    t.datetime "wasps", precision: nil
+  end
+
+  create_table "trigrammatisms", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "numerants", null: false
+    t.boolean "vomitings", default: false
+    t.datetime "langueds", precision: nil, null: false
+    t.datetime "vinlands", precision: nil, null: false
+  end
+
+  create_table "trillis", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "spaves", null: false
+    t.string "ametropia", null: false
+    t.datetime "multiporteds", precision: nil, null: false
+    t.datetime "borofluohydrics", precision: nil, null: false
+  end
+
+  create_table "trips", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "garrupas", limit: 36, null: false
+    t.string "delicenses", limit: 36
+    t.integer "electromotives", default: 0, null: false
+    t.text "nutationals", size: :medium
+    t.string "ungrows", limit: 36, null: false
+    t.string "attractionallies", limit: 36, null: false
+    t.datetime "decomposes", precision: nil
+    t.datetime "salukis", precision: nil
+    t.date "rhymists"
+    t.date "convertings"
+    t.text "unpassablenesses", size: :medium
+  end
+
+  create_table "trisulphides", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "lunoids", null: false
+    t.bigint "anoxics", null: false
+    t.date "hawserwises", null: false
+    t.date "decodons", null: false
+    t.datetime "bayoneteds", precision: nil
+    t.datetime "causabilities", precision: nil
+  end
+
+  create_table "triterpenes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.decimal "thingsteads", precision: 16, scale: 6, null: false
+    t.boolean "wemlesses", null: false
+    t.decimal "concocts", precision: 16, scale: 2, null: false
+    t.decimal "krausens", precision: 16, scale: 2, null: false
+    t.decimal "uncincts", precision: 16, scale: 2, null: false
+    t.bigint "manumotives", null: false
+    t.bigint "aminoformics", null: false
+    t.datetime "thoughtens", precision: nil
+    t.datetime "topazies", precision: nil
+  end
+
+  create_table "tritocerebrals", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "meretriciouslies", null: false
+    t.string "pereiras", null: false
+    t.string "diazoics"
+    t.string "obtusilobous"
+    t.string "kelpers"
+    t.string "synthermals"
+    t.boolean "hydroperitoneums"
+    t.string "pseudophenanthrenes"
+    t.boolean "unparcelings"
+    t.datetime "unhasties", precision: nil
+    t.bigint "arsenicisms", null: false
+    t.datetime "paralepses", precision: nil, null: false
+    t.datetime "elizabethanisms", precision: nil, null: false
+    t.string "reflexologicals"
+    t.string "latookas"
+    t.bigint "gainings"
+    t.string "edriophthalmians"
+    t.string "adolescences"
+    t.string "leiotropics", limit: 36, null: false
+  end
+
+  create_table "trochis", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.integer "towhees"
+    t.datetime "dermoidectomies", precision: nil, null: false
+    t.datetime "plutarchians", precision: nil, null: false
+    t.string "binaurals", null: false
+    t.string "phascolarctinaes", null: false
+    t.string "outwings"
+    t.string "crookbills"
+  end
+
+  create_table "trocos", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.integer "thirteenths", default: 0, null: false
+    t.date "rutiles", null: false
+    t.integer "leucocytotics", null: false
+    t.integer "rebarbarizes", null: false
+    t.bigint "obstreperous", null: false
+    t.datetime "acrostichums", precision: nil
+    t.datetime "farraginous", precision: nil
+    t.boolean "autotrophics", default: false, null: false
+  end
+
+  create_table "trondhjemites", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "outwords"
+    t.bigint "telars"
+    t.string "purpurescents", default: "unfunded", null: false
+    t.datetime "toothdrawers", precision: nil, null: false
+    t.datetime "benzalhydrazines", precision: nil, null: false
+    t.bigint "zarathustrians", null: false
+    t.bigint "preoffensives"
+    t.string "rhagiocrins"
+    t.string "mulks"
+    t.decimal "envapors", precision: 16, scale: 2
+    t.string "ebriosities"
+  end
+
+  create_table "tubercleds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "twisels"
+    t.string "canaanitishes"
+    t.string "styliferous"
+    t.string "queenfishes"
+    t.string "tulostomas"
+    t.date "youthheids"
+    t.datetime "morphographicals", precision: nil
+    t.datetime "frivolities", precision: nil
+    t.bigint "arithmomania"
+    t.string "cryptoinflationists"
+    t.string "enwidens", limit: 36
+  end
+
+  create_table "tuboovarians", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "gypsous", null: false
+    t.string "ocreataes", null: false
+    t.string "semioccasionallies", null: false
+    t.datetime "ascribables", precision: nil
+    t.datetime "leonists", precision: nil
+    t.string "stockers"
+  end
+
+  create_table "tudels", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "pediculicidals", limit: 36, null: false
+    t.bigint "episodials", null: false
+    t.string "blechnoids"
+    t.text "chapterals"
+    t.text "roilies"
+    t.string "euskeras"
+    t.datetime "festinatelies", precision: nil, null: false
+    t.datetime "stepfathers", precision: nil, null: false
+  end
+
+  create_table "tuftaffeta", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "vocabularieds"
+    t.string "chasmeds"
+    t.string "privilies"
+    t.datetime "edgies", precision: nil
+    t.datetime "counterpleases", precision: nil
+    t.string "mannerizes", limit: 36
+  end
+
+  create_table "tumefacients", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.date "aristotelics"
+    t.datetime "prongbucks", precision: nil, null: false
+    t.datetime "biloculates", precision: nil, null: false
+    t.boolean "wahabiisms"
+    t.text "barms", size: :medium
+    t.string "suppressals"
+  end
+
+  create_table "tumorlikes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "cylindrelloids", limit: 36, null: false
+    t.bigint "tongans", null: false
+    t.string "whences", null: false
+    t.datetime "synclinoria", precision: nil, null: false
+    t.datetime "labiduridaes", precision: nil, null: false
+  end
+
+  create_table "tungstites", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "impactionizes", null: false
+    t.string "preflorations"
+    t.date "prigmen", null: false
+    t.date "allodelphites", null: false
+    t.datetime "teems", precision: nil, null: false
+    t.datetime "intolerations", precision: nil, null: false
+    t.string "myxogastres", default: "", null: false
+    t.string "rudistans"
+  end
+
+  create_table "tunicins", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "untactfullies"
+    t.bigint "monitories"
+    t.decimal "turbos", precision: 16, scale: 2
+    t.text "preterhumen", size: :medium
+    t.datetime "archfoes", precision: nil, null: false
+    t.datetime "cableds", precision: nil, null: false
+  end
+
+  create_table "tushers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "sowbellies", null: false
+    t.decimal "resistivelies", precision: 16, scale: 6
+    t.string "planetaria"
+    t.decimal "charitablenesses", precision: 16, scale: 2
+    t.string "heezies"
+    t.string "turpantineweeds"
+    t.boolean "bullfoots"
+    t.string "retardments"
+    t.datetime "orthians", precision: nil, null: false
+    t.datetime "jackknives", precision: nil, null: false
+  end
+
+  create_table "tutorizations", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "unexemplifiables", limit: 36, null: false
+    t.string "infraoculars", null: false
+    t.string "unnettleds", null: false
+    t.string "invulnerablenesses"
+    t.string "uncookables"
+    t.date "fleabites", null: false
+    t.datetime "demagogisms", precision: nil
+    t.datetime "pismires", precision: nil
+  end
+
+  create_table "tututnis", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "scutigeridaes", null: false
+    t.bigint "compellablies", null: false
+    t.decimal "suggestionables", precision: 16, scale: 2, default: "0.0", null: false
+    t.datetime "periphrases", precision: nil
+    t.datetime "cutiterebras", precision: nil
+  end
+
+  create_table "twaddies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "bioticals"
+    t.decimal "prorecalls", precision: 16, scale: 2
+    t.date "semibreves"
+    t.date "silicoarsenides"
+    t.string "tannates"
+    t.string "xenosaurids"
+    t.datetime "caracolis", precision: nil
+    t.datetime "stultiloquences", precision: nil
+  end
+
+  create_table "tympanichords", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "collarbones", limit: 36, null: false
+    t.bigint "sordariaceaes", null: false
+    t.bigint "intussusceptions", null: false
+    t.datetime "sishes", precision: nil, null: false
+    t.datetime "diploids", precision: nil, null: false
+  end
+
+  create_table "tyrannicides", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "subjugations", limit: 36, null: false
+    t.bigint "noninstructions", null: false
+    t.string "onychophorous", null: false
+    t.string "malloseismics", null: false
+    t.datetime "tetraphosphates", precision: nil, null: false
+    t.datetime "mummichogs", precision: nil, null: false
+    t.text "barytophyllites"
+    t.string "patterns"
+  end
+
+  create_table "tyrantships", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "carvings", limit: 36, null: false
+    t.string "uncondemneds", limit: 36, null: false
+    t.boolean "irresilients", default: false, null: false
+    t.datetime "dudishnesses", precision: nil
+    t.datetime "demibaths", precision: nil
+  end
+
+  create_table "uirinas", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "regainments", limit: 36, null: false
+    t.string "hobbisms", null: false
+    t.bigint "guggles", null: false
+    t.string "biochemicallies", null: false
+    t.datetime "unobtrusivenesses", precision: nil, null: false
+    t.datetime "misprisals", precision: nil, null: false
+  end
+
+  create_table "ultimobranchials", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "sheep"
+    t.bigint "fulvidnesses"
+    t.integer "verticallies"
+    t.datetime "focallies", precision: nil, null: false
+    t.datetime "pseudepisematics", precision: nil, null: false
+    t.text "palaestras"
+  end
+
+  create_table "ultragoods", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "overcompetitives", null: false
+    t.bigint "tetrazyls", null: false
+    t.bigint "interrogatorilies", null: false
+    t.datetime "physicalnesses", precision: nil, null: false
+    t.datetime "upmounts", precision: nil, null: false
+    t.string "diplopics", limit: 36, null: false
+  end
+
+  create_table "ultraviri", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "pentanitrates", null: false
+    t.bigint "disentanglers", null: false
+    t.bigint "frisesomorums", null: false
+    t.date "panphenomenalisms", null: false
+    t.date "circumincessions", null: false
+    t.date "anthobiologies", null: false
+    t.datetime "salinelles", precision: nil, null: false
+    t.datetime "broomsticks", precision: nil, null: false
+    t.bigint "cowleds", null: false
+  end
+
+  create_table "ultrawealthies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "palaeoplains", null: false
+    t.bigint "hydrofluoborics", null: false
+    t.string "pharos", null: false
+    t.text "overfamiliars", null: false
+    t.string "bes", null: false
+    t.datetime "denumerants", precision: nil
+    t.datetime "autarchics", precision: nil
+  end
+
+  create_table "unadulterouslies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "nidis", null: false
+    t.bigint "misexpresses", null: false
+    t.string "snubs", limit: 36, null: false
+    t.datetime "snarks", precision: nil, null: false
+    t.datetime "parkins", precision: nil, null: false
+    t.bigint "reworkeds", null: false
+  end
+
+  create_table "unanticipateds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "arbusta", null: false
+    t.string "unclassablenesses", limit: 36, null: false
+    t.bigint "synchondroses"
+    t.integer "barbarians", null: false
+    t.datetime "verisimilitudes", precision: nil
+    t.datetime "preterchristians", precision: nil
+    t.bigint "orignals"
+  end
+
+  create_table "unappreciablenesses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "recoupments", null: false
+    t.string "extraserous"
+    t.date "hemitriglyphs"
+    t.datetime "overcoynesses", precision: nil
+    t.datetime "catholicos", precision: nil
+  end
+
+  create_table "unassassinateds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "inalimentals", null: false
+    t.bigint "vulcanizates", null: false
+    t.bigint "euomphalids", null: false
+    t.string "pyrotechnicals"
+    t.datetime "bombycidaes", precision: nil
+    t.string "ornoites"
+  end
+
+  create_table "unaugmentables", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "chondrectomies", limit: 36, null: false
+    t.bigint "ricininics", null: false
+    t.string "oppidans", default: "--- []\n"
+    t.string "diplosomes"
+    t.string "underexposes"
+    t.string "monads"
+    t.integer "bedriddens"
+    t.datetime "postaspirates", precision: nil
+    t.string "ragtags"
+    t.string "geodes"
+    t.date "whipships"
+    t.datetime "rowdyishnesses", precision: nil
+    t.datetime "largemouths", precision: nil
+    t.datetime "hydrofluorics", precision: nil
+  end
+
+  create_table "unbeloveds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "palsgravines", null: false
+    t.string "hexogens"
+    t.string "unpuzzles"
+    t.boolean "carpologies"
+    t.integer "prehensilities"
+    t.integer "muscovitics"
+    t.string "nasutes"
+    t.string "ivybells"
+    t.boolean "curlicues"
+    t.string "befrizs"
+    t.string "dentoids"
+    t.datetime "gracelikes", precision: nil
+    t.datetime "hollipers", precision: nil
+    t.string "setiparous"
+    t.string "dhanvantaris"
+    t.bigint "unmovablies"
+    t.string "napecrests"
+  end
+
+  create_table "unbendables", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "untogglers"
+    t.string "steplesses"
+    t.string "sumpits"
+    t.string "ethylamides"
+    t.string "pilocystics"
+    t.string "loggerheads"
+    t.string "counterformulas"
+    t.datetime "unprosecutables", precision: nil
+    t.datetime "attends", precision: nil
+    t.boolean "wearisomelies", default: false, null: false
+  end
+
+  create_table "unblushings", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "humoralisms"
+    t.string "sphinxians"
+    t.string "unexplodeds"
+    t.datetime "undiscourageds", precision: nil, null: false
+    t.datetime "phrenomesmerisms", precision: nil
+    t.datetime "seaquakes", precision: nil, null: false
+    t.datetime "coarbitrators", precision: nil, null: false
+  end
+
+  create_table "unbrowneds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "agrobiologists", null: false
+    t.string "venedotians", null: false
+    t.string "purries"
+    t.string "punctations"
+    t.string "antismokings"
+    t.string "omoplatoscopies"
+    t.string "nasillates"
+    t.string "pyocyanases"
+    t.datetime "bibliographicals", precision: nil, null: false
+    t.datetime "bertrums", precision: nil
+    t.integer "encrinoideas", default: 0, null: false
+    t.datetime "merops", precision: nil
+    t.datetime "sultanisms", precision: nil
+    t.string "etiolins"
+    t.string "petitionees"
+    t.string "anywises", limit: 36, null: false
+    t.string "hemipterans"
+    t.string "stintedlies", limit: 36
+    t.string "blees", default: "BusinessCenter::Recommendation", null: false
+    t.string "autoinoculations"
+    t.boolean "waygangs"
+  end
+
+  create_table "uncarnivorous", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "tunnelists", limit: 36, null: false, collation: "ascii_general_ci"
+    t.bigint "tallets", null: false
+    t.bigint "unornamentallies", null: false
+    t.string "arthels"
+    t.boolean "myotomics", default: false
+    t.datetime "hospices", precision: nil
+    t.datetime "mahris", precision: nil
+  end
+
+  create_table "uncarpeteds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "whidders", limit: 36, null: false
+    t.string "hypersecretions", limit: 36, null: false
+    t.boolean "stichometrics"
+    t.datetime "incontrollables", precision: nil, null: false
+    t.datetime "scaledrakes", precision: nil, default: "3000-01-01 00:00:00", null: false
+    t.bigint "hawkies", null: false
+    t.bigint "hyperacutenesses"
+  end
+
+  create_table "uncharacteristics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "outleaps", null: false
+    t.bigint "balletics", null: false
+    t.text "engagednesses"
+    t.datetime "subsistences", precision: nil
+    t.datetime "hyperites", precision: nil
+  end
+
+  create_table "uncheateds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "yashiros", limit: 36, null: false
+    t.date "acephalinas", null: false
+    t.datetime "missishes", precision: nil, null: false
+    t.datetime "arthrozoas", precision: nil, null: false
+    t.decimal "worthiests", precision: 16, scale: 2, default: "0.0", null: false
+    t.decimal "perradius", precision: 16, scale: 2, default: "0.0", null: false
+    t.decimal "necrologicals", precision: 16, scale: 2, default: "0.0", null: false
+    t.decimal "blennoemeses", precision: 16, scale: 2, default: "0.0", null: false
+    t.decimal "untempleds", precision: 16, scale: 2, default: "0.0", null: false
+    t.string "factorials", limit: 36, null: false
+  end
+
+  create_table "unclassifiables", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "chaologies"
+    t.string "systemwises"
+    t.string "indisciplinables"
+    t.string "quoddities"
+    t.bigint "dodos"
+    t.datetime "psilomelanes", precision: nil
+    t.datetime "purgatories", precision: nil
+    t.bigint "anoplocephalics"
+    t.string "credibilities", limit: 36
+    t.string "plagiographs"
+    t.string "outrogues"
+    t.string "unpossiblies"
+  end
+
+  create_table "unclothedlies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "radiobroadcasters", limit: 36, null: false, collation: "ascii_general_ci"
+    t.string "rewidens", limit: 36, null: false, collation: "ascii_general_ci"
+    t.datetime "polygynia", precision: nil, null: false
+    t.datetime "salmiacs", precision: nil
+    t.datetime "fluelesses", precision: nil
+    t.datetime "nonvassals", precision: nil
+  end
+
+  create_table "uncolorables", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "officiaries"
+    t.string "tremulousnesses"
+    t.string "relocators"
+    t.string "swoonies"
+    t.string "settings"
+    t.string "commemoratives"
+    t.string "drudges"
+    t.decimal "anacamptometers", precision: 16, scale: 2, default: "0.0"
+    t.bigint "willowies"
+    t.datetime "pneumonocarcinomas", precision: nil, null: false
+    t.datetime "afebriles", precision: nil, null: false
+    t.string "pluckers"
+    t.string "stymphalians"
+    t.boolean "file_1099", default: true
+    t.integer "rexes"
+    t.string "academists"
+    t.boolean "aggrieveds", default: false
+    t.string "antiblastics", default: "Contractor"
+    t.integer "cohabits", default: 0
+    t.bigint "anticoagulatings"
+    t.date "gulosities"
+    t.string "postvaricellars", limit: 36, null: false
+    t.string "seemlesses"
+    t.bigint "unlimes", null: false
+  end
+
+  create_table "uncommodiousnesses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "diketos", null: false
+    t.string "tuparas", null: false
+    t.bigint "babylonishes"
+    t.decimal "caniculars", precision: 16, scale: 6
+    t.bigint "tangiblies"
+    t.bigint "flats"
+    t.datetime "shadchans", precision: nil
+    t.datetime "metroptosia", precision: nil
+  end
+
+  create_table "unconsecutives", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "walkways"
+    t.datetime "hyperdiatessarons", precision: nil
+    t.datetime "superstimulates", precision: nil
+    t.datetime "irrisions", precision: nil
+    t.datetime "palatables", precision: nil
+    t.integer "renunculus"
+    t.string "unravellers", default: "idle", null: false
+    t.integer "nonfermentations", default: 0, null: false
+  end
+
+  create_table "uncounterfeits", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "vandalroots", null: false
+    t.datetime "hydroxyacetics", precision: nil
+    t.string "concinnous"
+    t.string "edentates"
+    t.string "nonobservances"
+    t.string "longsomenesses"
+    t.string "autocopists"
+    t.datetime "uncountervaileds", precision: nil
+    t.datetime "spermolytics", precision: nil
+    t.datetime "holoparasitics", precision: nil
+    t.string "smethes"
+    t.datetime "metaxylenes", precision: nil
+    t.datetime "adaptionals", precision: nil
+    t.string "penitents"
+  end
+
+  create_table "uncourteds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "aplobasalts", limit: 36, null: false, collation: "ascii_general_ci"
+    t.bigint "wordies", null: false
+    t.bigint "unbridegroomlikes", null: false
+    t.text "misaffections"
+    t.string "predeterminations", null: false
+    t.string "dilations", null: false
+    t.string "anus"
+    t.boolean "ureterovesicals", default: false, null: false
+    t.decimal "noselikes", precision: 16, scale: 2, null: false
+    t.decimal "prutahs", precision: 16, scale: 2
+    t.decimal "plurifoliates", precision: 16, scale: 2
+    t.datetime "esteemables", precision: nil, null: false
+    t.datetime "tapelikes", precision: nil, null: false
+  end
+
+  create_table "uncriticiseds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "nepidaes", null: false
+    t.bigint "unescapables", null: false
+    t.datetime "terrences", precision: nil
+    t.datetime "researches", precision: nil
+    t.datetime "creoles", precision: nil
+  end
+
+  create_table "undazzles", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "squames", limit: 36, null: false
+    t.string "actinolites", null: false
+    t.string "curvilinearities", null: false
+    t.string "claudia"
+    t.string "anhemolytics"
+    t.boolean "comamies"
+    t.string "chondrosepta"
+    t.text "unimmortals"
+    t.datetime "untwitcheds", precision: nil, null: false
+    t.datetime "receiverships", precision: nil, null: false
+  end
+
+  create_table "undenoteds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "igniferousnesses", limit: 36, null: false
+    t.string "passionates", limit: 36, null: false
+    t.string "calchaquis", limit: 36, null: false
+    t.datetime "cronstedtites", precision: nil, null: false
+    t.datetime "sancyites", precision: nil
+    t.bigint "cheiropodists", null: false
+    t.bigint "aquicultures"
+    t.string "matfelons"
+    t.datetime "macraucheniids", precision: nil, null: false
+    t.datetime "unseareds", precision: nil, null: false
+  end
+
+  create_table "underboys", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "ramroddies", null: false
+    t.integer "myeloics", default: 0, null: false
+    t.datetime "threelings", precision: nil
+    t.datetime "graphics", precision: nil
+  end
+
+  create_table "undernurses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "boils", null: false
+    t.string "hoplonemertines", limit: 36, null: false
+    t.bigint "cebells", null: false
+    t.date "nonrepressions", null: false
+    t.decimal "interconvertibilities", precision: 16, scale: 2, null: false
+    t.decimal "enders", precision: 16, scale: 2, null: false
+    t.string "rondeaus", null: false
+    t.datetime "carbanilides", precision: nil, null: false
+    t.datetime "mucusins", precision: nil, null: false
+  end
+
+  create_table "underregions", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "jeremianics", null: false
+    t.boolean "spindleshanks", default: true, null: false
+    t.datetime "phylogenics", precision: nil
+    t.datetime "aerolitics", precision: nil
+    t.string "liegefuls"
+    t.string "rhipipterous"
+    t.integer "tarnallies"
+    t.datetime "gingivals", precision: nil
+  end
+
+  create_table "undertwigs", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "stenotics", null: false
+    t.boolean "interfretteds", default: false, null: false
+    t.boolean "elateds", default: false, null: false
+    t.decimal "unshrunkens", precision: 16, scale: 2
+    t.text "ilmenorutiles"
+    t.date "pipefuls"
+    t.datetime "quaequaes", precision: nil
+    t.datetime "throblesses", precision: nil
+    t.bigint "claiths"
+    t.string "primarinesses", limit: 36, null: false
+  end
+
+  create_table "undervoltages", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "nepheshes", limit: 36, null: false
+    t.bigint "transeptallies", null: false
+    t.string "logodaedalies", limit: 36, null: false
+    t.datetime "distillables", precision: nil
+    t.datetime "traversions", precision: nil
+  end
+
+  create_table "undevouts", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "virilities", limit: 36, null: false
+    t.bigint "unretirings", null: false
+    t.bigint "outborns", null: false
+    t.string "oleographics", null: false
+    t.datetime "postsystolics", precision: nil, null: false
+    t.datetime "laminations", precision: nil, null: false
+  end
+
+  create_table "undistinguisheds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "sequelants", limit: 36, null: false, collation: "ascii_general_ci"
+    t.string "operalogues", limit: 36, null: false, collation: "ascii_general_ci"
+    t.string "pathogenicities", limit: 36, null: false, collation: "ascii_general_ci"
+    t.boolean "subcirculars", default: true, null: false
+    t.boolean "nonfrictions", default: false, null: false
+    t.datetime "pliablenesses", precision: nil
+    t.datetime "yourselves", precision: nil
+  end
+
+  create_table "undrippings", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "tetracolics", limit: 36, null: false
+    t.decimal "palemen", precision: 16, scale: 2
+    t.string "owlishlies", null: false
+    t.decimal "copperers", precision: 16, scale: 2
+    t.string "carabidoids", null: false
+    t.decimal "subcontinuals", precision: 16, scale: 2
+    t.string "outswifts", null: false
+    t.string "elaphures", null: false
+    t.text "barids"
+    t.text "firefangeds"
+    t.date "brines", null: false
+    t.string "aurigas", null: false
+    t.string "epigonations", null: false
+    t.date "mingles"
+    t.datetime "inswells", precision: nil
+    t.datetime "murderinglies", precision: nil
+    t.bigint "donatiaceaes", null: false
+  end
+
+  create_table "uneatings", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "putures", limit: 36, null: false
+    t.bigint "retrosternals", null: false
+    t.string "chronometries"
+    t.date "kermanshahs", null: false
+    t.string "bloodlines"
+    t.datetime "cavitates", precision: nil
+    t.datetime "razormakings", precision: nil
+  end
+
+  create_table "uneloquents", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.datetime "ophiologicals", precision: nil, null: false
+    t.datetime "outshouts", precision: nil
+    t.string "chenopodiaceaes", null: false
+    t.datetime "hugoesques", precision: nil
+  end
+
+  create_table "uneuphonious", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "superterrenes"
+    t.decimal "tubuliferous", precision: 16, scale: 2
+    t.datetime "exhibitives", precision: nil, null: false
+    t.datetime "fruitlessnesses", precision: nil, null: false
+    t.bigint "galeproofs"
+    t.bigint "gamins"
+  end
+
+  create_table "unexclusives", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "grinds", null: false
+    t.date "malics"
+    t.string "forgettinglies"
+    t.datetime "inguinocutaneous", precision: nil
+    t.datetime "bubalines", precision: nil
+    t.string "blesses"
+    t.string "rechisels"
+    t.integer "inappealables"
+    t.datetime "gelatins", precision: nil
+    t.string "slackings", limit: 36, null: false
+  end
+
+  create_table "unexecutables", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "shoutinglies", null: false
+    t.bigint "ellipsonics", null: false
+    t.datetime "priestisms", precision: nil
+    t.datetime "unkindlednesses", precision: nil
+  end
+
+  create_table "unfacadeds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "replods", limit: 36, null: false
+    t.string "lenders", limit: 36, null: false
+    t.string "tumidnesses", null: false
+    t.string "objectivists"
+    t.datetime "contractibles", precision: nil
+    t.string "unpedagogicals"
+    t.datetime "nebaliidaes", precision: nil
+    t.datetime "elecampanes", precision: nil, null: false
+    t.datetime "uncharacters", precision: nil, null: false
+  end
+
+  create_table "unfistulous", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "merelies", limit: 36, null: false
+    t.string "orthocarpous", null: false
+    t.string "meanlies", null: false
+    t.string "antiskiddings", null: false
+    t.bigint "habilimentations", null: false
+    t.string "disquisitivelies", null: false
+    t.bigint "eyelets"
+    t.datetime "ophthalmodiastimeters", precision: nil
+    t.datetime "monosteles", precision: nil
+  end
+
+  create_table "unfleetings", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "wetnesses"
+    t.bigint "equiglacials"
+    t.date "cheerios"
+    t.string "blackfellows"
+    t.string "hydrometridaes"
+    t.bigint "pathoradiographies"
+    t.datetime "kinglies", precision: nil, null: false
+    t.datetime "debarbarizes", precision: nil, null: false
+    t.string "outdistricts"
+    t.string "defaces"
+    t.integer "forefaces"
+    t.datetime "skewerers", precision: nil
+    t.text "phlegmas"
+    t.string "anthemideaes"
+    t.integer "absinthols", default: 0
+    t.text "frankpledges"
+    t.bigint "speakablies"
+    t.bigint "sabulums"
+    t.datetime "mohammedists", precision: nil
+    t.string "everlastinglies"
+    t.boolean "terminalizations", default: true, null: false
+    t.boolean "brayeras", default: false, null: false
+    t.string "prosupports"
+    t.text "unwinsomes", size: :medium
+    t.integer "stethophonometers"
+    t.integer "gerips"
+    t.boolean "murgas", default: false
+    t.bigint "volapukisms"
+    t.string "filipinianas"
+    t.boolean "denaries", default: false
+    t.bigint "hoffmannites"
+    t.string "splanchnographicals"
+    t.bigint "afterglides"
+    t.string "postaxiads"
+    t.string "rachioplegia", limit: 36, null: false
+  end
+
+  create_table "unfoisteds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "nazaritishes"
+    t.datetime "uncouthsomes", precision: nil
+    t.datetime "woolwashers", precision: nil
+    t.datetime "plenishments", precision: nil
+    t.datetime "insecures", precision: nil
+    t.bigint "frankings"
+    t.string "redeliberations", limit: 36
+  end
+
+  create_table "unforecasteds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "interplights", null: false
+    t.string "podostemonaceaes", null: false
+  end
+
+  create_table "unfraughts", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "lovebirds"
+    t.bigint "precystics"
+    t.string "linins", default: "pending", null: false
+    t.datetime "pediculophobia", precision: nil
+    t.string "unenviouslies", null: false
+    t.bigint "repatriations"
+    t.string "foulers"
+    t.text "transformisms"
+    t.datetime "nondisqualifyings", precision: nil
+    t.datetime "encases", precision: nil
+    t.boolean "villagehoods", default: false
+    t.boolean "dipsomaniacals", default: false
+  end
+
+  create_table "unfunnies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "street_1"
+    t.string "street_2"
+    t.string "dikereeves"
+    t.string "accidentals"
+    t.string "columbins"
+    t.string "cuspules"
+    t.datetime "synoptics", precision: nil, null: false
+    t.datetime "stalkies", precision: nil, null: false
+    t.string "plateries"
+    t.bigint "bulbocapnins"
+    t.string "tangies"
+    t.string "nicotinamides"
+    t.string "edelweisses"
+    t.string "rhipidistians"
+    t.string "progressionists"
+    t.string "endothermous"
+    t.string "nonornamentals"
+    t.string "sponsorials"
+    t.string "blockpates"
+    t.string "insteams"
+    t.string "superaccurates"
+    t.string "nauts"
+    t.string "jonathans"
+    t.string "spanings"
+    t.boolean "tullibees", default: false
+    t.string "tercines", limit: 36, null: false
+    t.string "manomins"
+  end
+
+  create_table "unfurnishednesses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "magnelectrics", null: false
+    t.string "cryptozonates", null: false
+    t.datetime "palingenesies", precision: nil
+    t.datetime "dewdamps", precision: nil
+    t.bigint "brachygnathia", null: false
+  end
+
+  create_table "ungenerics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "coccygomorphs", null: false
+    t.string "pennateds"
+    t.boolean "putrilages"
+    t.string "anarcestes"
+    t.decimal "lamellibranchia", precision: 16, scale: 2
+    t.string "heterographics"
+    t.string "ciconians"
+    t.string "carapaceds"
+    t.string "phosphorisms"
+    t.string "umbellates"
+    t.string "fraudlessnesses"
+    t.string "foresets"
+    t.string "pontocaspians"
+    t.string "carolines"
+    t.string "suliotes"
+    t.string "parabolizers"
+    t.string "blamers"
+    t.string "coryphaenas"
+    t.string "battels"
+    t.string "mavis"
+    t.string "nonadhesions"
+    t.string "looks"
+    t.string "renitencies"
+    t.string "nymphics"
+    t.string "slumps"
+    t.string "bilimbings"
+    t.string "prepotentlies"
+    t.string "temerous"
+    t.string "bedmates"
+    t.string "luminaries"
+    t.string "stercoranists"
+    t.string "semicastrates"
+    t.string "alcippes"
+    t.integer "quintilis"
+    t.string "autopilots"
+    t.string "semionotidaes"
+    t.string "agrostographicals"
+    t.datetime "distrustfullies", precision: nil, null: false
+    t.datetime "manifoldnesses", precision: nil, null: false
+    t.string "rev2020_filing_status"
+    t.decimal "rev2020_extra_withholding", precision: 10
+    t.boolean "rev2020_two_jobs"
+    t.decimal "rev2020_dependents_amount", precision: 10
+    t.decimal "rev2020_other_income", precision: 10
+    t.decimal "rev2020_deductions", precision: 10
+    t.string "or_w4_exemption_code"
+    t.string "mo_w4_exemption_reason"
+    t.decimal "galaxes", precision: 16, scale: 2
+    t.decimal "zoneds", precision: 16, scale: 2
+    t.string "unblotteds"
+    t.decimal "eucharitidaes", precision: 10
+    t.string "ureters"
+    t.decimal "fungins", precision: 10
+    t.decimal "oillikes", precision: 16, scale: 2
+  end
+
+  create_table "ungloves", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "palmers"
+    t.bigint "pinenes"
+    t.datetime "griddlers", precision: nil, null: false
+    t.datetime "headways", precision: nil, null: false
+  end
+
+  create_table "unhopinglies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "strands"
+    t.bigint "massilies"
+  end
+
+  create_table "unhusks", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "oliversmiths", limit: 36, null: false
+    t.string "shortages", limit: 36, null: false
+    t.datetime "untransparents", precision: nil
+    t.datetime "convokers", precision: nil
+  end
+
+  create_table "uniambicallies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "corkwings"
+    t.bigint "semasiologies", null: false
+    t.datetime "awrecks", precision: nil
+    t.datetime "developments", precision: nil
+  end
+
+  create_table "unifiables", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "monitions", null: false
+    t.string "plaguefuls", null: false
+    t.date "raffishnesses", null: false
+    t.string "pastednesses", null: false
+    t.datetime "calcics", precision: nil
+    t.datetime "trinitroglycerins", precision: nil
+  end
+
+  create_table "unignitables", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "scrubgrasses", null: false
+    t.datetime "moringuoids", precision: nil
+    t.datetime "holytides", precision: nil
+  end
+
+  create_table "unilinears", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "heraldesses", null: false
+    t.string "amyclaeans", null: false
+    t.string "vulneroses"
+    t.string "polyamyloses", limit: 1024
+    t.string "kobongs", limit: 36, null: false
+    t.datetime "adynamia", precision: nil
+    t.datetime "azoxybenzoics", precision: nil
+  end
+
+  create_table "uniparous", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "comals", limit: 36, null: false
+    t.string "cedents", null: false
+    t.string "tubbals", null: false
+    t.string "sinkages", null: false
+    t.string "grummeters"
+    t.string "latonians", null: false
+    t.string "groomishes", null: false
+    t.string "syphilous", null: false
+    t.date "wisers", null: false
+    t.string "icterogenetics", null: false
+    t.string "helminthisms"
+    t.string "panoptics"
+    t.string "dikages"
+    t.float "iscariotisms", null: false
+    t.string "trichomonas", null: false
+    t.string "skedgewiths", null: false
+    t.float "detaxes", null: false
+    t.float "soothingnesses"
+    t.float "pilars"
+    t.float "perilabyrinthitis"
+    t.float "asbestos"
+    t.float "awbers"
+    t.float "shelvers"
+    t.float "nonimperials"
+    t.float "dianas"
+    t.float "demipremisses"
+    t.float "isoimmunizes"
+    t.float "symposia"
+    t.float "theogonists"
+    t.float "oppugnances"
+    t.float "paraphrasters", null: false
+    t.bigint "volutins"
+    t.bigint "schules", null: false
+    t.bigint "postpharyngeals", null: false
+    t.float "quavers", null: false
+    t.float "hazards", null: false
+    t.datetime "snurs", precision: nil
+    t.datetime "idolothytes", precision: nil
+    t.float "cardiomyoliposes", null: false
+  end
+
+  create_table "unjealous", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "stomachlessnesses", limit: 36, null: false
+    t.bigint "paganalia", null: false
+    t.string "playhouses", null: false
+    t.datetime "spideries", precision: nil
+    t.datetime "taimyrites", precision: nil
+    t.date "repressories"
+  end
+
+  create_table "unkins", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.decimal "superiors", precision: 16, scale: 2, null: false
+    t.string "vulgarizes", limit: 36, null: false
+    t.bigint "symphilics", null: false
+    t.bigint "ocelliforms", null: false
+    t.string "careens", null: false
+    t.datetime "gists", precision: nil
+    t.datetime "hypodermatomies", precision: nil
+  end
+
+  create_table "unmercerizeds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "hiramites", null: false
+    t.text "rutinoses"
+    t.string "kingpieces"
+    t.bigint "sapheadeds"
+    t.datetime "clausures", precision: nil
+    t.datetime "phlegmonics", precision: nil
+    t.string "endothelia"
+    t.boolean "sowlikes", default: false
+    t.bigint "umbilicus"
+    t.bigint "sardinewises"
+    t.string "lepisosteidaes", limit: 36
+    t.string "gabes"
+  end
+
+  create_table "unmeritoriouslies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "vilipenditories", limit: 36, null: false
+    t.bigint "postmillennialisms", null: false
+    t.bigint "ewes", null: false
+    t.decimal "meristematicallies", precision: 16, scale: 2
+    t.string "inhumorouslies", null: false
+    t.datetime "unbeings", precision: nil, null: false
+    t.datetime "torulaforms", precision: nil, null: false
+  end
+
+  create_table "unminimizeds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "nonpermissibles"
+    t.bigint "hematherms"
+    t.bigint "panococos", null: false
+    t.decimal "pervicaciouslies", precision: 16, scale: 2
+    t.boolean "unfordeds"
+    t.decimal "genyantrums", precision: 16, scale: 2
+    t.decimal "defecates", precision: 16, scale: 2
+    t.decimal "palombinos", precision: 16, scale: 2
+    t.boolean "coccos"
+    t.decimal "viviperfuses", precision: 16, scale: 2
+    t.decimal "chromatographics", precision: 16, scale: 2
+    t.datetime "mullers", precision: nil
+    t.datetime "tapas", precision: nil
+    t.bigint "pussycats"
+    t.bigint "reversals"
+    t.boolean "biographizes"
+    t.string "acephalists"
+    t.string "quinoidations"
+  end
+
+  create_table "unmodifiables", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "miscooks", limit: 36, null: false
+    t.bigint "unbehelds"
+    t.datetime "sworns", precision: nil, null: false
+    t.string "peromelous", default: "draft", null: false
+    t.datetime "ependymomas", precision: nil, null: false
+    t.datetime "bulleteds", precision: nil, null: false
+    t.string "stereographies"
+    t.text "bescrapes"
+    t.bigint "accustomeds"
+    t.string "negatednesses"
+    t.datetime "subgeometrics", precision: nil
+    t.datetime "pretastes", precision: nil
+  end
+
+  create_table "unmooteds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "unbleedings", null: false
+    t.bigint "reviviscencies", null: false
+    t.datetime "strontics", precision: nil
+    t.datetime "ungranteds", precision: nil
+    t.datetime "utopistics", precision: nil
+    t.datetime "organistics", precision: nil
+    t.string "dicyemidaes"
+    t.boolean "uniconstants", default: false
+    t.boolean "abnormalists", default: false, null: false
+    t.boolean "kassus", default: false, null: false
+    t.string "potentiallies", limit: 36, null: false
+  end
+
+  create_table "unmoralists", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "septonasals"
+    t.string "universities"
+    t.bigint "lindas"
+    t.string "treckschuyts"
+    t.string "clitellines"
+    t.bigint "hortatives"
+    t.bigint "leskeaceaes"
+    t.datetime "arsinoitheria", precision: nil
+    t.datetime "quinquagesimals", precision: nil
+  end
+
+  create_table "unmotivatedlies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "parsonizes", limit: 36, null: false
+    t.string "flustras", null: false
+    t.string "foliiforms", limit: 36
+    t.datetime "rabbits", precision: nil
+    t.datetime "varlets", precision: nil
+    t.datetime "whiggarchies", precision: nil
+  end
+
+  create_table "unnestles", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "denturals", limit: 36, null: false
+    t.bigint "khasas"
+    t.integer "guimpes", default: 0, null: false
+    t.datetime "phenacyls", precision: nil
+    t.datetime "suppuratives", precision: nil
+    t.integer "repicks", default: 0, null: false
+  end
+
+  create_table "unnoiseds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "concavers", null: false
+    t.integer "doubloons", null: false
+    t.text "microcombustions", null: false
+    t.bigint "gadoideas"
+    t.integer "mauveines"
+    t.text "outlays"
+    t.bigint "ussingites"
+    t.datetime "suberifications", precision: nil
+    t.datetime "thynnids", precision: nil, null: false
+    t.datetime "borizes", precision: nil, null: false
+  end
+
+  create_table "unoffendinglies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "exiles"
+    t.bigint "prosies"
+    t.datetime "asiphonogamas", precision: nil, null: false
+    t.datetime "forenoons", precision: nil, null: false
+    t.bigint "cynomoria"
+  end
+
+  create_table "unpainstakings", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "nonmorals", null: false
+    t.bigint "kamichis", null: false
+    t.decimal "panichthyophagous", precision: 16, scale: 2
+    t.decimal "recompetitors", precision: 16, scale: 2
+    t.datetime "squadrons", precision: nil, null: false
+    t.datetime "suspendeds", precision: nil, null: false
+    t.string "unconcernedlies", default: "created", null: false
+  end
+
+  create_table "unphilosophicalnesses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "mesioversions", null: false
+    t.bigint "landmongers"
+    t.decimal "azuries", precision: 16, scale: 2
+    t.datetime "hauteurs", precision: nil
+    t.datetime "poneras", precision: nil
+  end
+
+  create_table "unpiteous", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "notalgics", null: false
+    t.bigint "geburs", null: false
+    t.string "cotoniers"
+    t.datetime "urachus", precision: nil, null: false
+    t.datetime "pyrgologists", precision: nil, null: false
+    t.string "woodpennies"
+    t.string "profligations"
+    t.datetime "solomonitics", precision: nil
+    t.datetime "inexhaustiblies", precision: nil
+    t.integer "logria"
+  end
+
+  create_table "unpoliticallies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "emplaces"
+    t.string "benzylics"
+    t.string "treatisers"
+    t.datetime "humblenesses", precision: nil, null: false
+    t.datetime "stairbuilders", precision: nil, null: false
+    t.datetime "blithemeats", precision: nil
+    t.datetime "montanisticals", precision: nil
+  end
+
+  create_table "unpracticallies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "gneissics"
+    t.string "engjateigurs"
+    t.integer "usefulnesses", limit: 1, null: false
+    t.decimal "replenishes", precision: 16, scale: 2, null: false
+    t.datetime "capsizes", precision: nil
+    t.bigint "petreas"
+    t.string "splayfooteds"
+    t.integer "paraphrasticallies", limit: 1, default: 0
+    t.datetime "hephaestians", precision: nil
+    t.datetime "seaminesses", precision: nil
+    t.boolean "patrins", default: false
+    t.bigint "sellings"
+    t.string "idiogastras"
+    t.boolean "periorals", default: false, null: false
+    t.bigint "predestructions"
+  end
+
+  create_table "unprismatics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.date "bloodripenesses"
+    t.string "tripletails"
+    t.bigint "hoarilies"
+    t.string "keratomas"
+    t.string "pageanteers"
+    t.string "asymbolia"
+    t.string "upbelches"
+    t.datetime "penthemimerals", precision: nil
+    t.datetime "scarificators", precision: nil
+    t.decimal "illusivelies", precision: 16, scale: 2
+    t.text "petitioners"
+    t.string "glaiks"
+    t.string "pancreaticogastrostomies"
+    t.bigint "frescos"
+    t.string "erythrozincites"
+  end
+
+  create_table "unprocrastinateds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "outchides", null: false
+    t.bigint "potassics", null: false
+    t.date "androcracies", null: false
+    t.date "ammonitesses", null: false
+    t.text "satyagrahis"
+    t.datetime "earthshocks", precision: nil
+    t.datetime "rainies", precision: nil
+    t.date "taurobolia"
+  end
+
+  create_table "unquartereds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "propertylesses", limit: 36, null: false
+    t.decimal "trowels", precision: 16, scale: 2
+    t.decimal "antizymotics", precision: 16, scale: 2
+    t.datetime "pelargonins", precision: nil
+    t.string "starklies"
+    t.string "decrials"
+    t.string "indelicates"
+    t.string "bardships"
+    t.string "ungreaseds"
+    t.decimal "floatations", precision: 16, scale: 2
+    t.date "lavations"
+    t.date "rushings"
+    t.string "oristics"
+    t.string "atavus"
+    t.decimal "interosculations", precision: 16, scale: 2
+    t.string "mamelonations"
+    t.string "slams"
+    t.datetime "mousekins", precision: nil, null: false
+    t.datetime "philistinelies", precision: nil, null: false
+    t.string "unpolisheds"
+    t.string "overgifteds"
+    t.string "dixiecrats"
+  end
+
+  create_table "unquestionates", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "youthhoods", null: false
+    t.bigint "solvolyzes"
+    t.datetime "artocarpaceaes", precision: nil
+    t.string "cerebroganglions"
+    t.datetime "laparosalpingotomies", precision: nil
+    t.datetime "weldings", precision: nil
+    t.bigint "sovereignties"
+  end
+
+  create_table "unravishings", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.decimal "nonsufferances", precision: 16, scale: 2
+    t.decimal "rhodanics", precision: 16, scale: 2
+    t.bigint "sulvanites"
+    t.bigint "cespitoses"
+    t.bigint "gobioideas"
+    t.string "unsacramentarians"
+    t.datetime "clerodendrons", precision: nil
+    t.datetime "nonparous", precision: nil
+    t.string "auncels"
+    t.string "overspeculations"
+    t.integer "oversystematics"
+    t.datetime "gyves", precision: nil
+  end
+
+  create_table "unrecoineds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "sniveleds", limit: 36, null: false
+    t.string "ragamuffinisms", null: false
+    t.string "vindemiatrixes"
+    t.string "unbetterables"
+    t.integer "chronometers"
+    t.datetime "intuitivelies", precision: nil
+    t.datetime "climatures", precision: nil, null: false
+    t.datetime "woodchucks", precision: nil, null: false
+    t.string "anerotics"
+    t.string "nymphets"
+    t.integer "plasmotomies"
+    t.datetime "stinges", precision: nil
+  end
+
+  create_table "unregaleds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "afterworkings", null: false
+    t.bigint "bevatrons"
+    t.string "leatherns"
+    t.string "begorries"
+    t.boolean "malandereds", default: false
+    t.datetime "gunations", precision: nil
+    t.datetime "superzealous", precision: nil
+    t.decimal "maravedis", precision: 16, scale: 2
+    t.string "nonretrenchments"
+    t.string "diatomicities"
+    t.string "metrometers"
+    t.string "comportments"
+    t.boolean "lynns"
+    t.string "unsinkabilities"
+    t.bigint "threatenings"
+    t.string "sapindaships"
+    t.datetime "versines", precision: nil
+    t.datetime "nightshines", precision: nil
+    t.string "sabathikos"
+    t.string "lithoglyptics"
+    t.string "lanternflowers"
+    t.string "undemures"
+    t.string "potecaries"
+    t.integer "pretangibles"
+    t.integer "nonelectrics"
+    t.integer "galvanizes"
+    t.string "aeroembolisms"
+    t.string "incommunicatives"
+    t.string "erythrozymes"
+    t.string "acrobatholithics"
+    t.string "inorganizeds"
+    t.string "atmiatries"
+    t.string "quinacrines"
+    t.string "koilanaglyphics"
+    t.string "taxwaxes"
+    t.integer "outreasons"
+    t.string "cropweeds"
+    t.string "singleheartednesses"
+    t.datetime "sprucifications", precision: nil
+    t.datetime "muddlebraineds", precision: nil
+    t.text "ophthalmotonometers"
+    t.string "autographometers"
+    t.string "retrospectivenesses"
+    t.string "telesign_contact_address_1"
+    t.string "telesign_contact_address_2"
+    t.string "unprudents"
+    t.string "skuas", limit: 2
+    t.string "undreamings", limit: 5
+    t.string "helios", limit: 2
+    t.string "gudefathers"
+    t.string "nonnarcotics"
+  end
+
+  create_table "unreplenisheds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "slapdashes", limit: 36, null: false
+    t.bigint "hydropneumothoraxes", null: false
+    t.string "overdescants", null: false
+    t.string "unofficialdoms", null: false
+    t.text "unfletcheds"
+    t.datetime "nonchurcheds", precision: nil
+    t.datetime "uninebriateds", precision: nil
+  end
+
+  create_table "unreproachings", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.integer "quernals", null: false
+    t.string "grinderies", null: false
+    t.string "gymnastics"
+    t.string "mudstones"
+    t.integer "graphomaniacs"
+    t.datetime "frolickies", precision: nil
+    t.integer "tarocs", default: 0, null: false
+    t.datetime "pulmobranchia", precision: nil, null: false
+    t.datetime "heptaspermous", precision: nil, null: false
+    t.datetime "incrests", precision: nil
+    t.datetime "soleidaes", precision: nil
+  end
+
+  create_table "unscarifieds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "crystallizers", limit: 36, null: false
+    t.decimal "bathetics", precision: 36, scale: 2, null: false
+    t.bigint "disinvaginations", null: false
+    t.string "unstraddleds", limit: 8, null: false
+    t.string "outlookers", limit: 280, null: false
+    t.string "unpleaseds", null: false
+    t.datetime "homodromous", precision: nil
+    t.datetime "neutrophilics", precision: nil
+    t.date "unattainings", null: false
+    t.datetime "asides", precision: nil
+    t.datetime "coenobiars", precision: nil
+    t.datetime "cuttlebones", precision: nil
+    t.string "thoroughspeds", null: false
+    t.bigint "excandescents", null: false
+  end
+
+  create_table "unscornfuls", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "sandwoods"
+    t.string "unprecises"
+    t.string "unpromoteds", null: false
+    t.text "regardings"
+    t.string "garces"
+    t.string "epaulets"
+    t.bigint "dourlies"
+    t.bigint "brabants"
+    t.bigint "calelectricals", null: false
+    t.text "rudentures"
+    t.datetime "theodidacts", precision: nil
+    t.datetime "bareheads", precision: nil
+    t.text "diversionaries"
+    t.datetime "unascendables", precision: nil
+    t.boolean "uninfluenceables", default: false
+    t.string "shredcocks", limit: 36
+  end
+
+  create_table "unscrimpeds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "roundmoutheds"
+    t.string "troths"
+    t.string "prosopites"
+    t.text "traves"
+    t.datetime "toluidinos", precision: nil, null: false
+    t.datetime "expenditures", precision: nil, null: false
+    t.datetime "invincibles", precision: nil
+    t.bigint "beardeds"
+  end
+
+  create_table "unsees", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "uncommonlies", limit: 36, null: false
+    t.string "pleurocentrums"
+    t.string "daroos"
+    t.bigint "eudaemonistics", null: false
+    t.string "niobous", limit: 36, null: false
+    t.integer "borosalicylics"
+    t.datetime "horopteries", precision: nil
+    t.datetime "wienerwursts", precision: nil
+    t.datetime "brimlesses", precision: nil
+    t.datetime "homophyllous", precision: nil
+    t.datetime "divorceables", precision: nil
+    t.datetime "nektons", precision: nil
+    t.string "edifies"
+  end
+
+  create_table "unshapenlies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "aerogenes", limit: 36, null: false
+    t.bigint "sextuplexes", null: false
+    t.bigint "counterindentations", null: false
+    t.datetime "inbounds", precision: nil, null: false
+    t.datetime "psychophysiologists", precision: nil, null: false
+    t.datetime "fingertips", precision: nil, null: false
+  end
+
+  create_table "unstartings", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "kinetoscopics", null: false
+    t.string "nepheloids", null: false
+    t.string "beslimes", null: false
+    t.datetime "huses", precision: nil
+    t.datetime "phosphorizes", precision: nil
+  end
+
+  create_table "unstintedlies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "onyms", null: false
+    t.bigint "enters"
+    t.date "unrememberings", null: false
+    t.string "counterfires"
+    t.datetime "diallyls", precision: nil, null: false
+    t.datetime "owns", precision: nil, null: false
+    t.text "misuras"
+    t.bigint "rebudgets"
+    t.date "ancestrians"
+    t.date "alcoholisms"
+    t.date "oilproofs"
+    t.datetime "rizzoms", precision: nil
+    t.boolean "heliciforms", default: false, null: false
+    t.string "preaches", limit: 36, null: false
+    t.boolean "unexclusivelies", default: false, null: false
+  end
+
+  create_table "unstupefieds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "bulters", limit: 36, null: false
+    t.boolean "carnallites", default: false, null: false
+    t.date "unparagonizeds", null: false
+    t.decimal "prosubscriptions", precision: 16, scale: 2, null: false
+    t.string "antislips", null: false
+    t.string "wearifuls", null: false
+    t.date "ladronisms", null: false
+    t.string "keellesses", null: false
+    t.string "judications"
+    t.bigint "describables"
+    t.text "votings"
+    t.string "whirlgigs", null: false
+    t.string "rallies"
+    t.boolean "precondenses", default: false, null: false
+    t.decimal "longshanks", precision: 16, scale: 2, null: false
+    t.decimal "walings", precision: 16, scale: 2, null: false
+    t.string "photoresistances", null: false
+    t.bigint "offhandeds", null: false
+    t.datetime "hereticalnesses", precision: nil
+    t.datetime "excitosecretories", precision: nil
+    t.bigint "spidgers"
+    t.string "chalcographists"
+    t.string "lops"
+    t.date "siderologies"
+    t.date "pumplesses"
+    t.date "corndodgers"
+  end
+
+  create_table "unsubmissivelies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "transcolorations"
+    t.bigint "postmyxedematous"
+    t.string "feculences", null: false
+    t.string "smelteries", null: false
+    t.string "electrometrics", null: false
+    t.string "outspeeches", null: false
+    t.string "evangelicans", null: false
+    t.string "sofronia", null: false
+    t.string "stercorariidaes", null: false
+    t.string "vangs", null: false
+    t.string "bailies", null: false
+    t.string "glycogenolyses", null: false
+    t.string "neurectases", null: false
+    t.string "bottekins", null: false
+    t.datetime "tractarianizes", precision: nil
+    t.datetime "gentisins", precision: nil
+  end
+
+  create_table "unsubscribings", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "enlightens", limit: 36, null: false, collation: "ascii_general_ci"
+    t.bigint "postdiluvials", null: false
+    t.string "enrolls", null: false
+    t.string "dreggishes", null: false
+    t.string "monumentalizations"
+    t.string "antilacrosses", null: false
+    t.date "aeolharmonicas"
+    t.date "commelinaceaes"
+    t.boolean "ripsacks", default: true, null: false
+    t.datetime "isogenous", precision: nil, null: false
+    t.datetime "remorsefullies", precision: nil, null: false
+    t.date "arimasps"
+    t.integer "navigabilities"
+    t.integer "hirundinous"
+    t.date "ommatidia"
+  end
+
+  create_table "unsubsidizeds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "stuprations", null: false
+    t.bigint "hyaloliparites", null: false
+    t.datetime "reconciliators", precision: nil, null: false
+    t.datetime "unscrupulosities", precision: nil, null: false
+    t.string "visas", default: "Pufferfish::Blob", null: false
+  end
+
+  create_table "unsuppliables", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "hyenas", null: false
+    t.decimal "pensums", precision: 16, scale: 2
+    t.integer "rebegs"
+    t.string "collegataries"
+    t.string "connaches"
+    t.datetime "genioplasties", precision: nil, null: false
+    t.datetime "trikirs", precision: nil, null: false
+    t.decimal "headcloths", precision: 16, scale: 2
+    t.date "hyperprosexia"
+    t.boolean "antipathics", default: false
+    t.decimal "britannicallies", precision: 16, scale: 2
+    t.text "decretories"
+    t.integer "nourishers"
+    t.bigint "bearables"
+  end
+
+  create_table "unurgings", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "kiacks", limit: 36, null: false
+    t.bigint "untimbereds", null: false
+    t.string "ceilidhs", null: false
+    t.string "octavinas", null: false
+    t.string "quiscos"
+    t.datetime "mistrysts", precision: nil
+    t.datetime "amentaceous", precision: nil
+    t.datetime "unembaseds", precision: nil
+    t.datetime "prelithics", precision: nil
+    t.datetime "turnduns", precision: nil
+    t.bigint "gruneritizations"
+    t.boolean "succubas", default: false, null: false
+    t.boolean "turkeries", default: false, null: false
+  end
+
+  create_table "unverbalizeds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "tetanoids", null: false
+    t.integer "slumproofs", null: false
+    t.integer "nincompooperies"
+    t.datetime "speedinesses", precision: nil
+    t.datetime "remonstrants", precision: nil
+    t.decimal "enteropneustans", precision: 16, scale: 2
+    t.string "arpeggiandos"
+    t.boolean "hemeras", default: false
+    t.boolean "venenousnesses", default: true, null: false
+    t.bigint "counterimaginations"
+  end
+
+  create_table "unwaxeds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "ethanedials", null: false
+    t.string "pierinaes", null: false
+    t.datetime "pimplas", precision: nil, null: false
+    t.datetime "ediblenesses", precision: nil
+    t.datetime "nonveterans", precision: nil
+    t.datetime "acataposes", precision: nil
+    t.string "amarths"
+  end
+
+  create_table "unwhiteneds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "disasinates", null: false
+    t.boolean "email_2fa_confirmation_enabled", default: false
+    t.datetime "odontoclasts", precision: nil
+    t.datetime "sublobulars", precision: nil
+    t.boolean "all_2fa_whitelisted", default: false
+  end
+
+  create_table "unworns", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "spitefuls", null: false
+    t.bigint "asexualities", null: false
+    t.decimal "gamelions", precision: 16, scale: 2, null: false
+    t.string "spatlings", null: false
+    t.datetime "resilials", precision: nil, null: false
+    t.datetime "scrooges", precision: nil, null: false
+    t.datetime "unsparingnesses", precision: nil
+    t.datetime "spiritfuls", precision: nil
+  end
+
+  create_table "urases", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "clavials", null: false
+    t.date "projicientlies", null: false
+    t.string "monogonies"
+    t.datetime "hetaerics", precision: nil, null: false
+    t.datetime "rumbustious", precision: nil, null: false
+    t.bigint "limpilies"
+  end
+
+  create_table "uredinales", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "spectrophonics", null: false
+    t.bigint "escambrons", null: false
+    t.bigint "faucalizes", null: false
+    t.datetime "rhynchophores", precision: nil
+    t.datetime "convictors", precision: nil
+  end
+
+  create_table "urethrorrhagia", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "interwoves", limit: 36, null: false
+    t.date "murderouslies"
+    t.date "ineffectives"
+    t.string "neurofibrillars"
+    t.string "dwangs"
+    t.integer "stilters"
+    t.datetime "submaxillas", precision: nil, null: false
+    t.datetime "rejoices", precision: nil, null: false
+    t.bigint "squeakproofs"
+    t.date "platitudinarians"
+  end
+
+  create_table "urginglies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "renvoys", limit: 36, null: false
+    t.text "petals", null: false
+    t.integer "diallagoids", null: false
+    t.text "unadaptives", size: :medium, null: false
+    t.text "mootings", size: :medium
+    t.boolean "bandagists", null: false
+    t.datetime "predays", precision: nil
+    t.datetime "prisonables", precision: nil
+  end
+
+  create_table "urinometers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "unfelonious", limit: 36, null: false
+    t.bigint "rutherfordines", null: false
+    t.string "spangles"
+    t.string "antiracings"
+    t.bigint "synodicallies", null: false
+    t.string "widespreadlies", null: false
+    t.string "culmen", null: false
+    t.string "lyons", null: false
+    t.datetime "experimentarians", precision: nil
+    t.datetime "valoniaceous", precision: nil
+    t.datetime "yttrofluorites", precision: nil
+    t.string "hypothecations"
+    t.string "ceramicites"
+    t.string "workbrittles"
+    t.bigint "unidealizeds"
+  end
+
+  create_table "urinometrics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "erythrocytics", limit: 36, null: false, collation: "ascii_general_ci"
+    t.string "fluxiles", limit: 36, null: false, collation: "ascii_general_ci"
+    t.boolean "debauchments", default: false, null: false
+    t.text "fitchees", null: false
+    t.text "unwitnesseds", null: false
+    t.string "mazamas", null: false
+    t.datetime "pughs", precision: nil, null: false
+    t.datetime "premonitories", precision: nil, null: false
+  end
+
+  create_table "uropodals", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "pageantics", null: false
+    t.string "citronellics", null: false
+    t.boolean "superabductions"
+    t.integer "ghosties", limit: 1, null: false
+    t.datetime "unvaryinglies", precision: nil, null: false
+    t.datetime "ramphastidaes", precision: nil, null: false
+    t.string "heftilies"
+    t.string "magistrallies"
+  end
+
+  create_table "uropoetics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "wolffia", null: false
+    t.string "sheepstealers", null: false
+    t.datetime "footstones", precision: nil
+    t.datetime "lations", precision: nil
+    t.datetime "hectoringlies", precision: nil
+  end
+
+  create_table "ursoids", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "indeterminablenesses", limit: 36, null: false
+    t.bigint "allowers", null: false
+    t.string "bullworts"
+    t.datetime "hateables", precision: nil
+    t.datetime "physiques", precision: nil
+    t.bigint "pycnodontis", null: false
+    t.boolean "bulimies", default: true, null: false
+  end
+
+  create_table "us", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "honeypots", limit: 36, null: false
+    t.bigint "scabrous", null: false
+    t.bigint "capitalists", null: false
+    t.datetime "clytemnestras", precision: nil
+    t.datetime "iridescences", precision: nil
+  end
+
+  create_table "usucaptions", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "chilicotes", null: false
+    t.bigint "unconfronteds", null: false
+    t.datetime "whichways", precision: nil, null: false
+    t.datetime "unconceivings", precision: nil, null: false
+  end
+
+  create_table "utinams", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.datetime "boundlesses", precision: nil
+    t.string "autopoints", null: false
+    t.integer "beelols", limit: 1
+    t.integer "sortilegers"
+    t.integer "prejuniors", limit: 1
+    t.integer "dozies", limit: 1
+    t.bigint "rhatania", null: false
+    t.string "ruthenates", limit: 36, null: false
+    t.string "inextincts"
+    t.datetime "daughterlings", precision: nil, null: false
+    t.datetime "shrovetides", precision: nil, null: false
+  end
+
+  create_table "vaccinationists", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.decimal "tricolumnars", precision: 16, scale: 2, null: false
+    t.bigint "naggingnesses", null: false
+    t.string "postcalcaneals", null: false
+    t.string "pyrrolines", limit: 36, null: false
+    t.datetime "adorers", precision: nil
+    t.datetime "psychologicallies", precision: nil
+    t.integer "trippets"
+    t.text "lancelies"
+    t.string "posttarsals", null: false
+  end
+
+  create_table "vacciniolas", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "delusories", null: false
+    t.bigint "panidiomorphics"
+    t.bigint "malonyls"
+    t.datetime "governorates", precision: nil, null: false
+    t.datetime "trochalopodas", precision: nil, null: false
+  end
+
+  create_table "vaginoperitoneals", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "preconversions", null: false
+    t.string "exceptionablenesses"
+    t.decimal "monodontals", precision: 16, scale: 2, default: "0.0"
+    t.boolean "caryophyllaceous"
+    t.bigint "anglaises", null: false
+    t.bigint "w2_questionnaire_id"
+    t.datetime "perturbatories", precision: nil, null: false
+    t.datetime "undebateds", precision: nil, null: false
+  end
+
+  create_table "variforms", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "unwomen", null: false
+    t.boolean "ballistics", default: false, null: false
+    t.datetime "broughams", precision: nil, null: false
+    t.datetime "unligatureds", precision: nil, default: "3000-01-01 00:00:00", null: false
+    t.bigint "hightops", null: false
+    t.bigint "unatonings"
+  end
+
+  create_table "vatics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "wellcurbs", null: false
+    t.bigint "architypographers", null: false
+    t.string "unmaidenlies", null: false
+    t.bigint "auspicates", null: false
+    t.text "confiders", size: :long, null: false
+    t.text "alpines", size: :long
+    t.boolean "notacanthids", default: false, null: false
+    t.datetime "octastylos", precision: nil
+    t.string "laelia", limit: 36, null: false
+    t.datetime "pimperies", precision: nil
+    t.datetime "sclerodermites", precision: nil
+    t.text "preactives", size: :long
+  end
+
+  create_table "vellalas", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "rompies", null: false
+    t.string "counterrestorations", null: false
+    t.text "tecnoctonia"
+    t.datetime "fissirostrals", precision: nil
+    t.datetime "abhenries", precision: nil
+    t.datetime "limbats", precision: nil, null: false
+    t.bigint "polystomidaes"
+    t.bigint "witchwomen"
+    t.string "palaverists"
+    t.string "unfarceds", limit: 36
+  end
+
+  create_table "ventrofixations", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "theologists", limit: 36, null: false
+    t.bigint "phlogisticals", null: false
+    t.string "marriageables", null: false
+    t.bigint "heracliteans", null: false
+  end
+
+  create_table "ventromesials", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "fallacious"
+    t.string "tormentors"
+    t.text "sapheadednesses"
+    t.bigint "scarlatinals", null: false
+    t.bigint "snifflies"
+    t.string "ovals"
+    t.datetime "alisphenoidals", precision: nil, null: false
+    t.datetime "dynamitics", precision: nil, null: false
+    t.string "moralities"
+  end
+
+  create_table "veratrylidenes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "renovatories", null: false
+    t.datetime "excitables", precision: nil, null: false
+    t.datetime "cossas", precision: nil, null: false
+    t.bigint "bdellotomies", null: false
+  end
+
+  create_table "vereks", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "dactyliothecas", limit: 36, null: false
+    t.bigint "criticisms", null: false
+    t.bigint "lipeurus", null: false
+    t.bigint "hyphomycetes", null: false
+    t.boolean "greetings", default: false
+    t.datetime "lipodystrophies", precision: nil
+    t.datetime "sandies", precision: nil
+  end
+
+  create_table "vesiculata", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "almeriites", limit: 36, null: false
+    t.bigint "procomedies", null: false
+    t.bigint "osteitis", null: false
+    t.string "serodermatoses", null: false
+    t.string "dindymenes", null: false
+    t.decimal "dephlogisticates", precision: 16, scale: 2, null: false
+    t.decimal "pseudohemals", precision: 16, scale: 2, null: false
+    t.text "vanelikes", null: false
+    t.datetime "rectangulates", precision: nil, null: false
+    t.datetime "unhastes", precision: nil, null: false
+    t.string "unleafeds", limit: 64
+    t.text "hemocoeles"
+    t.string "medicophysicals"
+    t.bigint "hydrosulphates"
+    t.datetime "euconjugataes", precision: nil
+  end
+
+  create_table "vestments", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "slubberinglies", limit: 36, null: false
+    t.integer "whatsomevers", null: false
+    t.integer "imprescriptiblies", null: false
+    t.bigint "eudeves", null: false
+    t.bigint "leucocytes"
+    t.boolean "protervities", default: true, null: false
+    t.boolean "unswatheds", default: true, null: false
+    t.text "praiselesses"
+    t.datetime "cocashweeds", precision: nil
+    t.datetime "educives", precision: nil
+    t.string "flageolets"
+    t.bigint "unacclimations"
+    t.string "roughdrafts", default: "check_date", null: false
+    t.boolean "arvicolas", default: false, null: false
+    t.boolean "imperscriptibles", default: false, null: false
+  end
+
+  create_table "vetivers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "didascalars", limit: 36, null: false
+    t.bigint "andronitis", null: false
+    t.bigint "pantarchies", null: false
+    t.string "dandyizes", null: false
+    t.date "nontypographicals", null: false
+    t.decimal "conciliables", precision: 16, scale: 2, null: false
+    t.string "thermogens"
+    t.datetime "flameds", precision: nil
+    t.datetime "nephrolepis", precision: nil
+    t.string "proctoptomas", null: false
+    t.boolean "adventials"
+    t.boolean "gratemen"
+  end
+
+  create_table "vibroscopics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "trachomatous", limit: 36, null: false
+    t.bigint "precoagulations", null: false
+    t.bigint "unconglomerateds", null: false
+    t.string "samogonkas"
+    t.string "loomeries", null: false
+    t.string "branglers"
+    t.datetime "evades", precision: nil
+    t.datetime "condescendings", precision: nil
+    t.datetime "vaingloriousnesses", precision: nil
+    t.bigint "arousers"
+    t.bigint "laparonephrectomies"
+    t.bigint "electropisms"
+    t.datetime "achromous", precision: nil
+    t.datetime "blackbands", precision: nil
+    t.date "cuneates"
+  end
+
+  create_table "vicariates", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "vonsenites", limit: 36, null: false, collation: "ascii_general_ci"
+    t.string "chickenhearteds", limit: 36, null: false, collation: "ascii_general_ci"
+    t.string "caramels", null: false
+    t.datetime "hangables", precision: nil
+    t.datetime "torneses", precision: nil
+    t.datetime "contours", precision: nil
+    t.datetime "tuberales", precision: nil
+  end
+
+  create_table "vignerons", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "hebraisms"
+    t.string "craniata"
+    t.datetime "dyspepticallies", precision: nil
+    t.datetime "defenses", precision: nil
+    t.string "inassimilations"
+    t.string "samanthas"
+  end
+
+  create_table "viharas", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "mowns"
+    t.integer "discriminatories"
+    t.datetime "unoffendings", precision: nil, null: false
+    t.datetime "candleholders", precision: nil, null: false
+    t.string "nasologists"
+  end
+
+  create_table "viniferas", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "tyrannosaurs", limit: 36, null: false
+    t.string "thionurates", null: false
+    t.string "ermanriches", null: false
+    t.string "sprylies", null: false
+    t.datetime "revelabilities", precision: nil
+    t.datetime "taipans", precision: nil
+  end
+
+  create_table "virials", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "wins", null: false
+    t.boolean "midshipmen", default: false
+    t.datetime "diplopodics", precision: nil, null: false
+    t.datetime "lautarites", precision: nil, null: false
+  end
+
+  create_table "virtuosities", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "unlearneds", null: false
+    t.string "proreservationists", limit: 36, null: false
+    t.datetime "pilikais", precision: nil
+    t.datetime "stickweeds", precision: nil
+    t.bigint "oscars", null: false
+  end
+
+  create_table "viscachas", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.integer "uncrisps", null: false
+    t.integer "barbacous", null: false
+    t.datetime "sphenomaxillaries", precision: nil
+    t.datetime "isopiestics", precision: nil
+  end
+
+  create_table "viscerotropics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "concursus", null: false
+    t.bigint "slipperinesses", null: false
+    t.datetime "invocatives", precision: nil
+    t.datetime "biloxis", precision: nil
+  end
+
+  create_table "vitalisticallies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "golgis", null: false
+    t.bigint "seneschalships", null: false
+    t.datetime "unemendeds", precision: nil, null: false
+    t.datetime "pharologies", precision: nil
+    t.datetime "graminiferous", precision: nil, null: false
+    t.datetime "prioresses", precision: nil, null: false
+    t.bigint "watts"
+    t.string "torpedos"
+  end
+
+  create_table "vivisectionists", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "tiltables", null: false
+    t.string "periphrastics", null: false
+    t.string "infanticides", null: false
+    t.string "algoses", limit: 36, null: false
+    t.datetime "miscommunicates", precision: nil
+    t.datetime "subpentagonals", precision: nil
+  end
+
+  create_table "vocationalisms", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "craniodidymus", limit: 36, null: false, collation: "ascii_general_ci"
+    t.string "taproots", limit: 36, null: false, collation: "ascii_general_ci"
+    t.string "lariats", limit: 36
+    t.text "degreasers"
+    t.text "pterygotus"
+    t.datetime "gratinates", precision: nil, null: false
+    t.datetime "feliforms", precision: nil, null: false
+    t.string "stonewalls", limit: 36, null: false, collation: "ascii_general_ci"
+  end
+
+  create_table "volatilizables", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "rufescences", limit: 36, null: false
+    t.bigint "hyperkineses", null: false
+    t.datetime "jibis", precision: nil
+    t.datetime "hunnics", precision: nil
+  end
+
+  create_table "volationals", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "venturesomelies", null: false
+    t.string "obstreperousnesses"
+    t.datetime "geranomorphics", precision: nil, null: false
+    t.datetime "cantics", precision: nil, null: false
+    t.string "motherlinesses"
+    t.text "pressures"
+    t.string "harminics", limit: 36
+    t.string "sneezies"
+    t.string "geographizes"
+    t.string "amatories"
+    t.integer "uninjurednesses"
+    t.datetime "undercapitalizations", precision: nil
+    t.string "laminarians"
+    t.string "pervertedlies"
+    t.boolean "idoteas", default: false
+    t.bigint "rascaldoms"
+  end
+
+  create_table "volcanics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "albopannins", null: false
+    t.bigint "northeasternmosts", null: false
+    t.datetime "kalmucks", precision: nil, null: false
+    t.datetime "mallowworts", precision: nil, null: false
+  end
+
+  create_table "wagerers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "myriapods", limit: 36, null: false
+    t.string "oenanthyls", limit: 36, null: false
+    t.boolean "lithemics", default: false, null: false
+    t.date "clegs", null: false
+    t.datetime "misbills", precision: nil, null: false
+    t.datetime "teels", precision: nil, null: false
+  end
+
+  create_table "waiata", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "dickeys", null: false
+    t.bigint "octoates", null: false
+    t.text "ras", null: false
+    t.datetime "wagandas", precision: nil
+    t.datetime "ascribes", precision: nil
+  end
+
+  create_table "waiklies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "appendicalgia", limit: 36, null: false
+    t.string "peroxies", limit: 36, null: false
+    t.string "protothecas", limit: 36, null: false
+    t.datetime "gobiesoxes", precision: nil, null: false
+    t.bigint "pharyngotherapies", null: false
+    t.string "guauaenoks", limit: 50
+    t.string "flockers", limit: 50
+    t.datetime "hagiographals", precision: nil
+    t.datetime "sweetishes", precision: nil
+    t.datetime "himyarites", precision: nil
+  end
+
+  create_table "waistcoatings", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "tetrabranchia", limit: 36, null: false
+    t.string "simultaneouslies", null: false
+    t.text "lusitania"
+    t.text "rituallies"
+    t.decimal "thalassiophytes", precision: 6, scale: 2
+    t.datetime "sulphantimonides", precision: nil
+    t.datetime "belights", precision: nil
+  end
+
+  create_table "waiters", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "radiatenesses", null: false
+    t.bigint "lucklesses", null: false
+    t.datetime "prepunishes", precision: nil
+    t.datetime "petroliferous", precision: nil
+  end
+
+  create_table "warlikenesses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "roys", limit: 36, null: false
+    t.string "eleonorites", null: false
+    t.datetime "lymphocytes", precision: nil, null: false
+    t.datetime "terebellums", precision: nil, null: false
+  end
+
+  create_table "warrantises", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "ambrosia", null: false
+    t.datetime "overraces", precision: nil, null: false
+    t.datetime "conglobulates", precision: nil, null: false
+    t.integer "acromiosternals", limit: 1, default: 0, null: false
+    t.bigint "parasyphilitics"
+    t.text "guyandots"
+  end
+
+  create_table "washtroughs", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "hemachates", limit: 36, null: false
+    t.bigint "posticums", null: false
+    t.boolean "brogans", null: false
+    t.datetime "battlegrounds", precision: nil
+    t.datetime "uninconvenienceds", precision: nil
+  end
+
+  create_table "watchmanships", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "tenderables"
+    t.string "yellows"
+    t.bigint "virucidals"
+    t.string "zibeta"
+    t.bigint "phoenixes"
+    t.decimal "twinklinglies", precision: 16, scale: 2
+    t.bigint "jolters"
+    t.datetime "tracheolinguals", precision: nil
+    t.datetime "xanthorrhoeas", precision: nil
+  end
+
+  create_table "waters", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "scrattlings"
+    t.bigint "nonballotings"
+    t.integer "kerflaps", default: 0, null: false
+    t.datetime "eldresses", precision: nil
+    t.datetime "haptics", precision: nil
+    t.bigint "oviparous"
+    t.bigint "measleds"
+  end
+
+  create_table "waythorns", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "podittis"
+    t.string "isochronous", limit: 36, null: false
+    t.string "honeywoods"
+    t.string "shrievals"
+    t.string "arenicolites"
+    t.string "firebotes"
+    t.string "mucidnesses"
+    t.string "ramisticals"
+    t.text "tarquinishes"
+    t.string "behaviors"
+    t.string "imperializes"
+    t.datetime "oxycamphors", precision: nil
+  end
+
+  create_table "weepereds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "diaetetaes", limit: 36, null: false
+    t.bigint "schoolmasterishnesses", null: false
+    t.string "psychotechnicals", null: false
+    t.datetime "schizophrenes", precision: nil
+    t.datetime "drynaria", precision: nil
+  end
+
+  create_table "wheellesses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "lemures", null: false
+    t.string "onocentaurs", null: false
+    t.string "hypophyllous", null: false
+    t.string "unprogresseds", null: false
+    t.string "podolians", null: false
+    t.datetime "themata", precision: nil
+    t.datetime "geognosts", precision: nil
+    t.boolean "lucidas", default: false
+  end
+
+  create_table "whithers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.datetime "unpityingnesses", precision: nil, null: false
+    t.datetime "bearbanes", precision: nil, null: false
+    t.string "hydrous", limit: 36, null: false
+    t.bigint "unhystericals", null: false
+    t.string "upcomes", limit: 36, null: false
+    t.string "phytotopographicals"
+    t.string "wunnas", limit: 2
+    t.string "morallesses"
+    t.string "dendrochronologies", null: false
+    t.string "unpledgeds", limit: 2, null: false
+    t.string "fiercelies", null: false
+  end
+
+  create_table "whosomevers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "overchecks", null: false
+    t.string "turkeyberries", null: false
+    t.text "pretrains"
+    t.text "toxicotraumatics", null: false
+    t.integer "phoenicaceous"
+    t.string "destines", limit: 36, null: false
+    t.datetime "putridlies", precision: nil
+    t.datetime "boeotics", precision: nil, null: false
+    t.datetime "unpaireds", precision: nil, null: false
+    t.string "intransmissibles", null: false
+    t.string "hypericaceaes", null: false
+    t.string "incompatibles", null: false
+    t.string "unbendingnesses", null: false
+    t.boolean "perifolliculitis", default: false
+    t.string "paraperiodics"
+    t.string "ptenoglossas"
+  end
+
+  create_table "windages", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.integer "irrefrangibilities", limit: 1, default: 0
+    t.bigint "bantams"
+    t.datetime "testosterones", precision: nil
+    t.integer "glathsheimrs", limit: 1, default: 0, null: false
+  end
+
+  create_table "windflaws", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "aloewoods"
+    t.string "sheavelesses"
+    t.datetime "allogeneous", precision: nil
+    t.datetime "gynecratics", precision: nil
+    t.datetime "athenees", precision: nil
+  end
+
+  create_table "windrowers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "birefringents", null: false
+    t.datetime "interlocates", precision: nil, null: false
+    t.bigint "amongsts", null: false
+    t.datetime "trophophores", precision: nil
+    t.datetime "stercoranisms", precision: nil
+    t.bigint "orlops", default: 0, null: false
+  end
+
+  create_table "wiseheimers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "guisians", limit: 36, null: false
+    t.bigint "triumvirships", null: false
+    t.string "bismuthates", null: false
+    t.string "reperplexes"
+    t.datetime "semipros", precision: nil
+    t.datetime "bastardisms", precision: nil
+  end
+
+  create_table "witloofs", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.datetime "videttes", precision: nil
+    t.decimal "unpots", precision: 16, scale: 2, default: "0.0", null: false
+    t.bigint "lamellates"
+    t.bigint "unforgettings"
+    t.integer "pseudodiagnoses"
+    t.datetime "geneticallies", precision: nil
+    t.datetime "fraternallies", precision: nil
+    t.integer "manubriateds", limit: 1, default: 1, null: false
+    t.string "thermometrics"
+    t.integer "censurables"
+  end
+
+  create_table "wolfishlies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "forthbrings", limit: 36, null: false, collation: "ascii_general_ci"
+    t.string "quadrivalences", limit: 36, null: false
+    t.string "portmanteauxes", limit: 36, null: false
+    t.string "jodelrs", null: false
+    t.string "crums"
+    t.datetime "unplats", precision: nil, null: false
+    t.datetime "acotyledonous", precision: nil
+    t.datetime "thioantimonites", precision: nil
+  end
+
+  create_table "wormweeds", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "beachmasters"
+    t.decimal "jinniyehs", precision: 16, scale: 2, default: "0.0", null: false
+    t.date "batatillas"
+    t.text "moonfaceds"
+    t.datetime "potterers", precision: nil
+    t.datetime "leaders", precision: nil
+    t.date "ungestings"
+    t.string "viremics"
+    t.bigint "quicksilveries"
+    t.bigint "miolithics"
+    t.string "intermundanes"
+    t.boolean "mentorisms", default: false
+    t.string "counterfesseds"
+    t.string "unaccessionals"
+    t.bigint "unpalisadoeds"
+    t.string "spoorers"
+    t.bigint "burettes"
+    t.string "prebiddings", default: "pending", null: false
+  end
+
+  create_table "worrilesses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "contretemps", limit: 36, null: false
+    t.bigint "columbaes", null: false
+    t.string "digressories", null: false
+    t.bigint "brandons", null: false
+    t.datetime "polyhydroxies", precision: nil
+    t.datetime "uta", precision: nil
+    t.datetime "drests", precision: nil, null: false
+  end
+
+  create_table "wrappings", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "nondirections", null: false
+    t.datetime "comparabilities", precision: nil
+    t.datetime "floriculturallies", precision: nil, null: false
+    t.datetime "clerklesses", precision: nil, null: false
+    t.bigint "enteradenologicals"
+    t.string "nemoricoles"
+  end
+
+  create_table "writhednesses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "mayhappens"
+    t.string "familists"
+    t.decimal "somatous", precision: 16, scale: 2
+    t.datetime "unprofanes", precision: nil, null: false
+    t.datetime "snowinesses", precision: nil, null: false
+    t.string "dehkans", limit: 36, null: false
+  end
+
+  create_table "xenomaniacs", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "zeallesses", null: false
+    t.datetime "umbellets", precision: nil, null: false
+    t.datetime "unenterprisinglies", precision: nil, null: false
+  end
+
+  create_table "xenophobians", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "convulsedlies", limit: 36, null: false
+    t.string "unglossies", null: false
+    t.text "opsonizations", null: false
+    t.string "singeds", limit: 36, null: false
+    t.datetime "youwards", precision: nil
+    t.datetime "chaptalizes", precision: nil
+  end
+
+  create_table "yashmaks", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "scuffs", null: false
+    t.string "sabbathisms", null: false
+    t.boolean "contextuals", default: false, null: false
+    t.text "awkwardishes"
+    t.text "outtongues"
+    t.datetime "unvenereals", precision: nil, null: false
+    t.datetime "glaniostomis", precision: nil, null: false
+    t.bigint "panegyrizers"
+    t.boolean "astronauts", default: false, null: false
+    t.string "skirrs", limit: 36, null: false
+    t.text "aceships"
+    t.string "fricatives", default: "full_time", null: false
+    t.string "breastplates"
+    t.decimal "flatboats", precision: 16, scale: 2
+    t.decimal "chondropterygiis", precision: 16, scale: 2
+    t.string "colliers"
+    t.text "amphorics"
+    t.string "sphaerophoraceaes", default: "yes"
+    t.datetime "tantafflins", precision: nil
+    t.bigint "unpatteds"
+  end
+
+  create_table "yawninglies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "unviolables", null: false
+    t.string "stercorariinaes"
+    t.string "undescendables"
+    t.datetime "chaldaeis", precision: nil
+    t.datetime "deslimes", precision: nil
+  end
+
+  create_table "yokes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "scaberulous", null: false
+    t.string "unscanneds", null: false
+    t.string "vamooses", null: false
+    t.string "unratifieds", null: false
+    t.boolean "griffs", default: true, null: false
+    t.integer "antennulars", default: 2, null: false
+    t.string "hypostomides", limit: 36, null: false
+    t.datetime "fabricatresses", precision: nil, null: false
+    t.datetime "lendees", precision: nil, null: false
+  end
+
+  create_table "ypsiloids", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "phantomists", limit: 36, null: false
+    t.datetime "evocativelies", precision: nil, null: false
+    t.datetime "katastates", precision: nil, null: false
+    t.bigint "summits", null: false
+    t.string "foraminiferas", null: false
+    t.string "captiousnesses", null: false
+    t.string "unpicks"
+    t.string "stades", null: false
+  end
+
+  create_table "yutus", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "imputatives", null: false
+    t.integer "goeducks", null: false
+    t.string "untroublesomes", null: false
+    t.integer "insagacities", null: false
+    t.text "methadones"
+    t.datetime "tagtails", precision: nil
+    t.datetime "insecteds", precision: nil
+    t.bigint "detests", null: false
+  end
+
+  create_table "zarathustrisms", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "guiltilies", null: false
+    t.string "disquiparancies"
+    t.datetime "ovenfuls", precision: nil, null: false
+    t.datetime "suffragitis", precision: nil, null: false
+    t.string "indivinables"
+  end
+
+  create_table "zealouslies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "phulwaras", limit: 36, null: false
+    t.bigint "subwealthies", null: false
+    t.string "corporas", null: false
+    t.decimal "sportfulnesses", precision: 16, scale: 2, null: false
+    t.string "octavaria", null: false
+    t.string "imitativelies"
+    t.string "gastromelus"
+    t.date "passewas", null: false
+    t.string "chiromants"
+    t.string "unauthorizednesses"
+    t.integer "dilutednesses"
+    t.datetime "gregos", precision: nil
+    t.datetime "arboricals", precision: nil
+    t.datetime "synarthrodia", precision: nil
+  end
+
+  create_table "zemimdaris", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "wonderers", null: false
+    t.date "unfanaticals", null: false
+    t.datetime "forewisdoms", precision: nil
+    t.datetime "lightfaces", precision: nil
+    t.integer "otocranes", limit: 1
+    t.bigint "translucentlies"
+    t.decimal "arrenotokies", precision: 16, scale: 2, default: "0.0"
+    t.decimal "welshries", precision: 16, scale: 2, default: "0.0"
+    t.date "pipers"
+  end
+
+  create_table "zeugobranchia", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "vinies"
+    t.bigint "recommands", null: false
+    t.string "yills", null: false
+    t.datetime "pectinids", precision: nil
+    t.datetime "libaments", precision: nil
+    t.string "tightlies", null: false
+    t.datetime "sulfindylics", precision: nil
+    t.integer "floccus"
+    t.bigint "submittals"
+  end
+
+  create_table "zippers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "chatterations", limit: 36, null: false
+    t.string "scorpionis", limit: 36, null: false
+    t.date "zoophytes", null: false
+    t.date "coventries", null: false
+  end
+
+  create_table "zoantharians", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "petreities"
+    t.string "macropinacoidals", null: false
+    t.string "nonclassifications"
+    t.string "hegaris"
+    t.integer "abhorsons"
+    t.datetime "univalves", precision: nil
+    t.datetime "sabbathaians", precision: nil
+    t.datetime "selamins", precision: nil
+  end
+
+  create_table "zolaesques", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "flaxtails", null: false
+    t.string "muggilies", null: false
+    t.bigint "pyromania"
+    t.string "apoquinines"
+    t.text "chummers"
+    t.datetime "anthropomorphologies", precision: nil, null: false
+    t.datetime "agues", precision: nil, null: false
+    t.string "protoactinia"
+    t.bigint "cannoneers"
+    t.boolean "boolyas", default: false
+  end
+
+  create_table "zoogeologies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "subjectednesses", null: false
+    t.string "coheritors", null: false
+    t.string "cabosheds", null: false
+    t.string "ticketings"
+    t.string "kroons"
+    t.string "uniphases"
+    t.string "hussites", null: false
+    t.date "quinopyrins"
+    t.string "chapelgoers"
+    t.string "kallimas"
+    t.datetime "dusknesses", precision: nil, null: false
+    t.datetime "dioceses", precision: nil, null: false
+    t.string "sootherers"
+  end
+
+  create_table "zoophorus", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "anta"
+    t.string "fightables"
+    t.string "riotinglies"
+    t.datetime "precontaineds", precision: nil
+    t.decimal "debilitateds", precision: 16, scale: 2
+    t.string "reambitious"
+    t.string "quadriloculars"
+    t.string "acephalocysts"
+    t.date "spookologicals"
+    t.datetime "parnellites", precision: nil, null: false
+    t.datetime "osirifications", precision: nil, null: false
+    t.string "hippeds"
+  end
+
+  create_table "zootaxies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "maclureas", limit: 36, null: false
+    t.string "propagators", null: false
+    t.string "feminologies", null: false
+    t.string "dasturis", null: false
+    t.bigint "unquarrieds"
+    t.datetime "boondocks", precision: nil
+    t.datetime "hystricisms", precision: nil
   end
 
   add_foreign_key "comments", "posts"


### PR DESCRIPTION
I'm trying to suss out why the `rails db:migrate` is our fairly large Rails monolith. There's some 1500 tables, which I think can account for most of it.

I made this migration based on our schema, but with table and column names replaced.